### PR TITLE
Fix button and input field colours per theme

### DIFF
--- a/app/components/ui/Button/button.module.css
+++ b/app/components/ui/Button/button.module.css
@@ -9,17 +9,17 @@
 }
 
 .primary {
-	background: transparent;
+	background: var(--button-bg);
 	color: var(--foreground-color);
 }
 
 .secondary {
-	background: var(--current-line);
+	background: var(--button-bg);
 	color: var(--gray-color);
 }
 
 .tertiary {
-	background-color: var(--bg-color-dark);
+	background-color: var(--button-bg);
 	color: var(--foreground-color);
 }
 

--- a/app/components/ui/Input/input.module.css
+++ b/app/components/ui/Input/input.module.css
@@ -41,12 +41,12 @@
 	outline: none;
 	width: 100%;
 	height: 1.875rem;
-	font-size: var(--normal-font-size);
+	font-size: var(--small-font-size);
 	touch-action: manipulation;
 }
 
 .inputDark {
-	background-color: transparent;
+	background-color: var(--input-bg);
 	color: var(--foreground-color);
 }
 
@@ -58,5 +58,11 @@
 .input::placeholder {
 	color: var(--gray-color);
 	opacity: 1; /* Firefox */
+	font-size: var(--tiny-font-size);
+}
+
+.inputLight::placeholder {
+	color: var(--current-line);
+	opacity: 1;
 	font-size: var(--tiny-font-size);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -174,6 +174,10 @@ table {
 
 	/* Spacing */
 	--border-radius: 0.313rem;
+
+	/* Component-specific */
+	--button-bg: var(--current-line);
+	--input-bg: transparent;
 }
 
 [data-theme="shades-of-purple"] {
@@ -186,7 +190,7 @@ table {
 	--blue-color: #6943d8;
 	--green-color: #a5ff90;
 	--dark-green-color: #2e5a1e;
-	--gray-color: #7e7e9a;
+	--gray-color: #9a95b8;
 	--purple-color: #a599e9;
 	--yellow-color: #fad000;
 	--orange-color: #ff9d00;
@@ -199,6 +203,8 @@ table {
 	--warning-color: #fef4e6;
 	--info-color: #e8f6fd;
 	--skeleton-shimmer: #4b3a8a;
+	--button-bg: #1e1e3f;
+	--input-bg: #1e1e3f;
 }
 
 [data-theme="catppuccin-latte"] {
@@ -223,6 +229,7 @@ table {
 	--error-color: #f5d5d8;
 	--warning-color: #f5ead0;
 	--info-color: #d0e8f5;
+	--input-bg: #fff;
 }
 
 [data-theme="ayu-light"] {
@@ -247,6 +254,7 @@ table {
 	--error-color: #f5dede;
 	--warning-color: #f5ede0;
 	--info-color: #deeaf5;
+	--input-bg: #fff;
 }
 
 [data-theme="github-dark"] {
@@ -295,6 +303,7 @@ table {
 	--error-color: #ffebe9;
 	--warning-color: #fff8c5;
 	--info-color: #ddf4ff;
+	--input-bg: #fff;
 }
 
 html,


### PR DESCRIPTION
#### GitHub Issue

N/A — follow-up fix to theme system

#### Why are you creating this PR? What value is added?

Fixes visual issues with button and input components across themes:

- **Buttons**: All variants (primary, secondary, tertiary) now use `--button-bg` CSS variable. On Shades of Purple, buttons get a dark purple background (`#1e1e3f`) instead of transparent/default. Default falls back to `var(--current-line)` matching Dracula behaviour.
- **Input fields (dark themes)**: Shades of Purple inputs now have a dark navy background (`#1e1e3f`) instead of transparent, making text legible.
- **Input fields (light themes)**: Catppuccin Latte, Ayu Light, and GitHub Light inputs get a white background (`#fff`) so fields are visible on light pages.
- **Input placeholder (light variant)**: Uses `--current-line` to match the text colour for consistency.
- **Input font size**: Reduced from `--normal-font-size` to `--small-font-size`.
- **Gray colour (Shades of Purple)**: Lightened to `#9a95b8` for better placeholder visibility.

#### Include screenshots below (if appropriate)