### PR TITLE
feat: add Public snippets navigation link

### DIFF
--- a/app/components/Aside/Aside.tsx
+++ b/app/components/Aside/Aside.tsx
@@ -36,6 +36,7 @@ import Loading from "@/components/ui/icons/Loading";
 import List from "@/components/ui/icons/List";
 import Rows from "@/components/ui/icons/Rows";
 import CaretDown from "@/components/ui/icons/CaretDown";
+import Globe from "@/components/ui/icons/Globe";
 
 /* Styles */
 import styles from "./aside.module.css";
@@ -44,8 +45,10 @@ type AsideProps = {
 	isLoading: boolean;
 	codeEditorStates: SnippetEditorStates;
 	tags: TagItem[];
+	publicCount: number;
 	onGetAll: () => void;
 	onGetUncategorized: () => void;
+	onGetPublic: () => void;
 	onGetFavorites: () => void;
 	onGetTrash: () => void;
 	onTagClick: (tag: string) => void;
@@ -56,9 +59,11 @@ const Aside = ({
 	isLoading,
 	codeEditorStates,
 	tags,
+	publicCount,
 	onGetFavorites,
 	onGetAll,
 	onGetUncategorized,
+	onGetPublic,
 	onGetTrash,
 	onTagClick,
 	onAccountClick,
@@ -120,6 +125,10 @@ const Aside = ({
 
 			case MenuItems.Uncategorized:
 				onGetUncategorized();
+				break;
+
+			case MenuItems.Public:
+				onGetPublic();
 				break;
 
 			case MenuItems.Favorites:
@@ -246,6 +255,21 @@ const Aside = ({
 						<Tray className={styles.icon} width={18} height={18} />
 						Uncategorized
 					</a>
+
+					{publicCount > 0 && (
+						<a
+							className={`${styles.linkItem} blue-color ${menuType === MenuItems.Public && styles.linkItemActive}`}
+							onClick={(event: MouseEvent<HTMLAnchorElement>) =>
+								clickMenuHandler(event, "public")
+							}
+						>
+							<Globe className={styles.icon} width={18} height={18} />
+							Public
+							<span className={styles.numberOfItems}>
+								({publicCount})
+							</span>
+						</a>
+					)}
 
 					<a
 						className={`${styles.linkItem} yellow-color ${menuType === MenuItems.Favorites && styles.linkItemActive}`}

--- a/app/components/Aside/aside.module.css
+++ b/app/components/Aside/aside.module.css
@@ -76,6 +76,11 @@
 	color: var(--foreground-color);
 }
 
+.numberOfItems {
+	font-size: var(--small-font-size);
+	margin-left: 0.313rem;
+}
+
 .settingsItems {
 	color: var(--gray-color);
 	cursor: pointer;

--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -43,6 +43,7 @@ type CodeEditorProps = {
 		fromButton: boolean | "favorite"
 	) => void;
 	onStarred: (currentSnippet: CurrentSnippet) => void;
+	onPublicToggle: (currentSnippet: CurrentSnippet) => void;
 	onTouched: (touched: boolean) => void;
 };
 
@@ -53,6 +54,7 @@ const CodeEditor = ({
 	defaultLanguage = SupportedLanguages.Markdown,
 	onSave,
 	onStarred,
+	onPublicToggle,
 	onTouched,
 }: CodeEditorProps): ReactElement => {
 	const isMobile = useViewPortStore((state) => state.isMobile);
@@ -218,12 +220,14 @@ const CodeEditor = ({
 			currentSnippet.public_slug
 		);
 
-		setCurrentSnippet({
+		const updatedSnippet = {
 			...currentSnippet,
 			is_public: newIsPublic,
 			public_slug: slug,
-		});
+		};
 
+		setCurrentSnippet(updatedSnippet);
+		onPublicToggle(updatedSnippet);
 		onTouched(false);
 
 		if (newIsPublic && slug) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -338,6 +338,10 @@ body {
 	color: var(--orange-color);
 }
 
+.blue-color {
+	color: var(--blue-color);
+}
+
 .gradient-background {
 	color: var(--foreground-color);
 	background-image: linear-gradient(

--- a/app/lib/constants/core.ts
+++ b/app/lib/constants/core.ts
@@ -1,6 +1,7 @@
 export enum MenuItems {
 	All = "all",
 	Uncategorized = "uncategorized",
+	Public = "public",
 	Favorites = "favorites",
 	Trash = "trash",
 	None = "none",

--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -39,6 +39,7 @@ export default function Page(): ReactElement {
 	const [tags, setTags] = useState<TagItem[]>([]);
 	const [codeEditorStates, setCodedEditorStates] =
 		useState<SnippetEditorStates>(defaultCodeEditorStates);
+	const [publicCount, setPublicCount] = useState<number>(0);
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 	const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
 	const { addToast } = useToastStore();
@@ -106,6 +107,7 @@ export default function Page(): ReactElement {
 
 		if (isActive) {
 			getTags(data);
+			setPublicCount(data.filter((s: Snippet) => s.is_public).length);
 		}
 
 		setCodedEditorStates(defaultCodeEditorStates);
@@ -167,6 +169,9 @@ export default function Page(): ReactElement {
 			: allSnippets;
 
 		getTags(updatedSnippetList);
+		setPublicCount(
+			updatedSnippetList.filter((s: Snippet) => s.is_public).length
+		);
 	};
 
 	const saveSnippetHandler = async (
@@ -249,6 +254,38 @@ export default function Page(): ReactElement {
 		setActiveSnippetIndex(currentIndex > 0 ? currentIndex - 1 : 0);
 	};
 
+	const onPublicToggleHandler = (currentSnippet: CurrentSnippet): void => {
+		const newCount = currentSnippet.is_public
+			? publicCount + 1
+			: publicCount - 1;
+
+		setPublicCount(newCount);
+
+		if (
+			!currentSnippet.is_public &&
+			codeEditorStates.menuType === MenuItems.Public
+		) {
+			if (newCount <= 0) {
+				getSnippets();
+
+				return;
+			}
+
+			const currentIndex = findIndexForCurrentSnippet(currentSnippet);
+
+			if (currentIndex === -1) {
+				return;
+			}
+
+			const cloneSnippets = [...snippets];
+
+			cloneSnippets.splice(currentIndex, 1);
+			setSnippets(cloneSnippets);
+
+			setActiveSnippetIndex(currentIndex > 0 ? currentIndex - 1 : 0);
+		}
+	};
+
 	const newSnippetHandler = (newSnippet: Snippet): void => {
 		if (newSnippet) {
 			setSnippets([newSnippet, ...snippets]);
@@ -290,6 +327,22 @@ export default function Page(): ReactElement {
 			setCodedEditorStates({
 				...defaultCodeEditorStates,
 				menuType: MenuItems.Uncategorized,
+			});
+		}
+	};
+
+	const getPublicHandler = async (): Promise<void> => {
+		if (codeEditorStates.menuType !== MenuItems.Public) {
+			const allSnippets = await getAllSnippets();
+			const publicSnippets = allSnippets.filter(
+				(snippet: Snippet) => snippet.is_public
+			);
+
+			setSnippets(publicSnippets);
+
+			setCodedEditorStates({
+				...defaultCodeEditorStates,
+				menuType: MenuItems.Public,
 			});
 		}
 	};
@@ -384,8 +437,10 @@ export default function Page(): ReactElement {
 						isLoading={isLoading}
 						codeEditorStates={codeEditorStates}
 						tags={tags}
+						publicCount={publicCount}
 						onGetAll={getSnippetsHandler}
 						onGetUncategorized={getUncategorizedHandler}
+						onGetPublic={getPublicHandler}
 						onGetFavorites={getFavoritesHandler}
 						onGetTrash={getTrashHandler}
 						onTagClick={getSnippetsByTagHandler}
@@ -415,6 +470,7 @@ export default function Page(): ReactElement {
 						codeEditorStates={codeEditorStates}
 						onSave={saveSnippetHandler}
 						onStarred={onStarredHandler}
+						onPublicToggle={onPublicToggleHandler}
 						onTouched={touchedHandler}
 					/>
 				}


### PR DESCRIPTION
## Summary
- Adds a conditional **Public** menu link in the sidebar between Uncategorized and Favorites, showing only when public snippets exist
- Displays a real-time count badge `(N)` that updates instantly when toggling snippet visibility
- When un-publishing the last public snippet while viewing the Public filter, auto-navigates back to All Snippets

## Changes
| File | Change |
|------|--------|
| `app/lib/constants/core.ts` | Add `Public` to `MenuItems` enum |
| `app/globals.css` | Add `.blue-color` utility class |
| `app/components/Aside/aside.module.css` | Add `.numberOfItems` count badge style |
| `app/components/Aside/Aside.tsx` | Add Globe icon, `publicCount`/`onGetPublic` props, conditional Public link |
| `app/components/CodeEditor/CodeEditor.tsx` | Add `onPublicToggle` callback on public/private toggle |
| `app/snippets/page.tsx` | Add `publicCount` state, `getPublicHandler`, `onPublicToggleHandler` with auto-fallback |

## Test plan
- [ ] Make a snippet public → Public link appears in sidebar with count `(1)`
- [ ] Make another snippet public → count updates to `(2)`
- [ ] Click Public link → only public snippets shown
- [ ] While viewing Public, toggle a snippet to private → it's removed from the list, count decrements
- [ ] Remove all public snippets → Public link disappears, view switches to All Snippets
- [ ] No public snippets → Public link is absent from sidebar (not just hidden)