### PR TITLE
styles: standardize border-radius across menus, dropdowns, and modals

### DIFF
--- a/app/components/Aside/aside.module.css
+++ b/app/components/Aside/aside.module.css
@@ -229,7 +229,7 @@
 	bottom: calc(100% + 0.25rem);
 	background: var(--bg-color-dark);
 	border: 1px solid var(--border-color);
-	border-radius: 0.75rem;
+	border-radius: var(--border-radius-lg);
 	padding: 0.375rem;
 	z-index: 20;
 	box-shadow:
@@ -287,7 +287,7 @@
 	color: var(--foreground-color);
 	font-family: inherit;
 	text-align: left;
-	border-radius: 0.5rem;
+	border-radius: var(--border-radius-md);
 	transition: background 0.1s ease;
 }
 

--- a/app/components/CodeEditor/AiDropdown/aiDropdown.module.css
+++ b/app/components/CodeEditor/AiDropdown/aiDropdown.module.css
@@ -4,7 +4,7 @@
 	right: 0;
 	background: var(--bg-color-dark);
 	border: 1px solid var(--border-color);
-	border-radius: 0.75rem;
+	border-radius: var(--border-radius-lg);
 	box-shadow: 0 4px 12px rgb(0 0 0 / 30%);
 	z-index: 100;
 	min-width: 200px;

--- a/app/components/CodeEditor/AiDropdown/aiDropdown.module.css
+++ b/app/components/CodeEditor/AiDropdown/aiDropdown.module.css
@@ -4,7 +4,7 @@
 	right: 0;
 	background: var(--bg-color-dark);
 	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
+	border-radius: 0.75rem;
 	box-shadow: 0 4px 12px rgb(0 0 0 / 30%);
 	z-index: 100;
 	min-width: 200px;

--- a/app/components/CodeEditor/codeEditor.module.css
+++ b/app/components/CodeEditor/codeEditor.module.css
@@ -212,7 +212,7 @@
 	width: 22rem;
 	background: var(--bg-color-dark);
 	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
+	border-radius: 0.75rem;
 	box-shadow: 0 8px 24px rgb(0 0 0 / 30%);
 	z-index: 10;
 	animation: details-fade-in 0.15s ease-out;

--- a/app/components/CodeEditor/codeEditor.module.css
+++ b/app/components/CodeEditor/codeEditor.module.css
@@ -212,7 +212,7 @@
 	width: 22rem;
 	background: var(--bg-color-dark);
 	border: 1px solid var(--border-color);
-	border-radius: 0.75rem;
+	border-radius: var(--border-radius-lg);
 	box-shadow: 0 8px 24px rgb(0 0 0 / 30%);
 	z-index: 10;
 	animation: details-fade-in 0.15s ease-out;

--- a/app/components/History/history.module.css
+++ b/app/components/History/history.module.css
@@ -13,7 +13,7 @@
 	max-height: calc(100vh - 8rem);
 	background: var(--bg-color-dark);
 	border: 1px solid var(--border-color);
-	border-radius: 0.75rem;
+	border-radius: var(--border-radius-lg);
 	box-shadow: 0 8px 24px rgb(0 0 0 / 30%);
 	z-index: 10;
 	display: flex;
@@ -121,7 +121,7 @@
 	padding: 0.75rem;
 	background: var(--bg-color);
 	border: 1px solid var(--border-color);
-	border-radius: 0.5rem;
+	border-radius: var(--border-radius-md);
 	cursor: pointer;
 }
 

--- a/app/components/History/history.module.css
+++ b/app/components/History/history.module.css
@@ -13,7 +13,7 @@
 	max-height: calc(100vh - 8rem);
 	background: var(--bg-color-dark);
 	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
+	border-radius: 0.75rem;
 	box-shadow: 0 8px 24px rgb(0 0 0 / 30%);
 	z-index: 10;
 	display: flex;
@@ -121,7 +121,7 @@
 	padding: 0.75rem;
 	background: var(--bg-color);
 	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
+	border-radius: 0.5rem;
 	cursor: pointer;
 }
 

--- a/app/components/ui/Modal/modal.module.css
+++ b/app/components/ui/Modal/modal.module.css
@@ -11,7 +11,7 @@
 
 .modal {
 	background: var(--bg-color-dark);
-	border-radius: 0.75rem;
+	border-radius: var(--border-radius-lg);
 	box-shadow: 0 10px 25px rgb(0 0 0 / 50%);
 	max-width: var(--modal-max-width, 90vw);
 	max-height: var(--modal-max-height, 90vh);
@@ -54,7 +54,7 @@
 	border: none;
 	cursor: pointer;
 	padding: 0.5rem;
-	border-radius: 0.5rem;
+	border-radius: var(--border-radius-md);
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/app/components/ui/Modal/modal.module.css
+++ b/app/components/ui/Modal/modal.module.css
@@ -11,7 +11,7 @@
 
 .modal {
 	background: var(--bg-color-dark);
-	border-radius: 8px;
+	border-radius: 0.75rem;
 	box-shadow: 0 10px 25px rgb(0 0 0 / 50%);
 	max-width: var(--modal-max-width, 90vw);
 	max-height: var(--modal-max-height, 90vh);
@@ -54,7 +54,7 @@
 	border: none;
 	cursor: pointer;
 	padding: 0.5rem;
-	border-radius: 4px;
+	border-radius: 0.5rem;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/app/components/ui/Select/select.module.css
+++ b/app/components/ui/Select/select.module.css
@@ -31,7 +31,7 @@
 	position: absolute;
 	top: calc(100% + 0.25rem);
 	background: var(--current-line);
-	border-radius: 0.75rem;
+	border-radius: var(--border-radius-lg);
 	z-index: 3;
 	width: 100%;
 	padding: 0.25rem 0.625rem;

--- a/app/components/ui/Select/select.module.css
+++ b/app/components/ui/Select/select.module.css
@@ -31,7 +31,7 @@
 	position: absolute;
 	top: calc(100% + 0.25rem);
 	background: var(--current-line);
-	border-radius: 0.3125rem;
+	border-radius: 0.75rem;
 	z-index: 3;
 	width: 100%;
 	padding: 0.25rem 0.625rem;

--- a/app/globals.css
+++ b/app/globals.css
@@ -174,6 +174,8 @@ table {
 
 	/* Spacing */
 	--border-radius: 0.313rem;
+	--border-radius-md: 0.5rem;
+	--border-radius-lg: 0.75rem;
 
 	/* Component-specific */
 	--button-bg: var(--current-line);


### PR DESCRIPTION
## Summary

- Aligns all popup container border-radius to `0.75rem` (matching the Aside settings menu)
- Aligns interactive items inside popups to `0.5rem` (matching `.userMenuItem`)
- Affected components: `AiDropdown`, `History` panel + list items, `detailsPanel` (snippet details), `Modal` container + close button, `Select` dropdown

## Changes

| Component | Selector | Before | After |
|---|---|---|---|
| `AiDropdown` | `.dropdown` | `var(--border-radius)` (0.313rem) | `0.75rem` |
| `History` | `.panel` | `var(--border-radius)` | `0.75rem` |
| `History` | `.listItem` | `var(--border-radius)` | `0.5rem` |
| `codeEditor` | `.detailsPanel` | `var(--border-radius)` | `0.75rem` |
| `Modal` | `.modal` | `8px` | `0.75rem` |
| `Modal` | `.closeButton` | `4px` | `0.5rem` |
| `Select` | `.selectWindow` | `0.3125rem` | `0.75rem` |

## Test plan

- [ ] Open the AI dropdown in the code editor and verify rounded corners
- [ ] Open the History panel and check panel corners + list item corners
- [ ] Open the Snippet Details panel and verify rounded corners
- [ ] Open any modal (Account, Screenshot) and verify rounded corners + close button
- [ ] Open the language Select dropdown and verify rounded corners
- [ ] Compare all of the above against the Aside settings menu as the visual reference