### PR TITLE
fix: extend AI route timeout to prevent 504 gateway errors

### DIFF
--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { aiActions, aiSystemPrompts } from "@/lib/constants/ai";
 
+export const maxDuration = 60;
+
 const validActions: AiAction[] = [
 	aiActions.explain,
 	aiActions.comments,
@@ -25,7 +27,7 @@ const anthropicVersion = process.env.ANTHROPIC_VERSION || "2023-06-01";
 const anthropicModel =
 	process.env.ANTHROPIC_MODEL || "claude-sonnet-4-20250514";
 
-const ollamaTimeout = 60000;
+const ollamaTimeout = 55000;
 
 const requestOllama = async (
 	prompt: string,


### PR DESCRIPTION
## Summary

- Add `export const maxDuration = 60` to `/api/ai/route.ts` so Vercel allows the serverless function up to 60s instead of the default 10s
- Reduce internal `ollamaTimeout` from 60s to 55s so the error handler can respond cleanly before Vercel's hard cutoff fires

## Why

Ollama model inference (especially on cold starts) takes longer than Vercel's default 10s serverless function limit. Cloudflare was returning a 504 Gateway Timeout because Vercel wasn't responding in time.

## Test plan

- [ ] Trigger an AI action from the modal against an Ollama endpoint
- [ ] Confirm no 504 errors appear for requests that complete under 60s