### PR TITLE
feat: show selected AI model name in chat modal header

### DIFF
--- a/app/components/CodeEditor/AiChatModal/AiChatModal.tsx
+++ b/app/components/CodeEditor/AiChatModal/AiChatModal.tsx
@@ -55,6 +55,7 @@ const AiChatModal = ({
 	const [errorMessage, setErrorMessage] = useState<string>("");
 	const [lastAction, setLastAction] = useState<AiAction | null>(null);
 	const [inputValue, setInputValue] = useState<string>("");
+	const [selectedModel, setSelectedModel] = useState<string>("");
 	const abortRef = useRef<AbortController | null>(null);
 	const streamTimerRef = useRef<number | null>(null);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -127,7 +128,15 @@ const AiChatModal = ({
 	useEffect(() => {
 		if (!isOpen) {
 			resetConversation();
+
+			return;
 		}
+
+		getUserDataFromSession().then((session) => {
+			const model = session?.user?.user_metadata?.ollama_model;
+
+			setSelectedModel(model ?? "");
+		});
 	}, [isOpen]);
 
 	const autosizeTextarea = (): void => {
@@ -363,7 +372,7 @@ const AiChatModal = ({
 									<span className={styles.assistantHeaderIcon}>
 										<Sparkle width={14} height={14} />
 									</span>
-									<span>AI</span>
+									<span>{selectedModel || "AI"}</span>
 								</div>
 
 								{showThinking && (


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `AI` label in the assistant message header with the user's configured Ollama model name (e.g. `llama3.2`)
- Falls back to `AI` when no model is configured
- Fetches the model from user session metadata when the modal opens

## Test plan
- [ ] Open AI chat modal — header should show the model name from Account Settings > AI > Model field
- [ ] If no model is configured, header should fall back to `AI`
- [ ] Changing the model in Account Settings and reopening the modal should reflect the new name