### PR TITLE
feat: convert AI chat modal to side drawer with multi-turn history

### DIFF
--- a/app/components/CodeEditor/AiChatModal/AiChatModal.tsx
+++ b/app/components/CodeEditor/AiChatModal/AiChatModal.tsx
@@ -11,7 +11,6 @@ import {
 import { createPortal } from "react-dom";
 
 /* Components */
-import CloseSquare from "@/components/ui/icons/CloseSquare";
 import Sparkle from "@/components/ui/icons/Sparkle";
 
 /* Lib */
@@ -35,6 +34,11 @@ import { requestAiAction } from "@/utils/ai.utils";
 /* Styles */
 import styles from "./aiChatModal.module.css";
 
+type ChatEntry = {
+	role: "user" | "assistant";
+	content: string;
+};
+
 type AiChatModalProps = {
 	isOpen: boolean;
 	currentSnippet: CurrentSnippet;
@@ -50,15 +54,17 @@ const AiChatModal = ({
 }: AiChatModalProps): ReactElement | null => {
 	const { addToast } = useToastStore();
 	const [status, setStatus] = useState<ChatStatus>(ChatStatus.Empty);
-	const [userMessage, setUserMessage] = useState<string>("");
+	const [currentUserMessage, setCurrentUserMessage] = useState<string>("");
 	const [revealedAnswer, setRevealedAnswer] = useState<string>("");
 	const [errorMessage, setErrorMessage] = useState<string>("");
 	const [lastAction, setLastAction] = useState<AiAction | null>(null);
 	const [inputValue, setInputValue] = useState<string>("");
 	const [selectedModel, setSelectedModel] = useState<string>("");
+	const [history, setHistory] = useState<ChatEntry[]>([]);
 	const abortRef = useRef<AbortController | null>(null);
 	const streamTimerRef = useRef<number | null>(null);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const chatRef = useRef<HTMLDivElement>(null);
 
 	const isProcessing = status === ChatStatus.Processing;
 	const showApplyButton =
@@ -83,11 +89,12 @@ const AiChatModal = ({
 		}
 
 		setStatus(ChatStatus.Empty);
-		setUserMessage("");
+		setCurrentUserMessage("");
 		setRevealedAnswer("");
 		setErrorMessage("");
 		setLastAction(null);
 		setInputValue("");
+		setHistory([]);
 	};
 
 	useEffect(() => {
@@ -109,11 +116,9 @@ const AiChatModal = ({
 		};
 
 		document.addEventListener("keydown", handleEscape);
-		document.body.style.overflow = "hidden";
 
 		return () => {
 			document.removeEventListener("keydown", handleEscape);
-			document.body.style.overflow = "unset";
 		};
 	}, [isOpen, onClose]);
 
@@ -138,6 +143,12 @@ const AiChatModal = ({
 			setSelectedModel(model ?? "");
 		});
 	}, [isOpen]);
+
+	useEffect(() => {
+		if (chatRef.current) {
+			chatRef.current.scrollTop = chatRef.current.scrollHeight;
+		}
+	}, [history, revealedAnswer]);
 
 	const autosizeTextarea = (): void => {
 		const textarea = textareaRef.current;
@@ -196,11 +207,23 @@ const AiChatModal = ({
 			abortRef.current.abort();
 		}
 
+		if (
+			currentUserMessage &&
+			revealedAnswer &&
+			status === ChatStatus.Answered
+		) {
+			setHistory((prev) => [
+				...prev,
+				{ role: "user", content: currentUserMessage },
+				{ role: "assistant", content: revealedAnswer },
+			]);
+		}
+
 		const controller = new AbortController();
 
 		abortRef.current = controller;
 
-		setUserMessage(displayMessage);
+		setCurrentUserMessage(displayMessage);
 		setRevealedAnswer("");
 		setErrorMessage("");
 		setLastAction(action);
@@ -289,193 +312,230 @@ const AiChatModal = ({
 		onClose();
 	};
 
-	const handleOverlayClick = (
-		event: React.MouseEvent<HTMLDivElement>
-	): void => {
-		if (event.target === event.currentTarget) {
-			onClose();
-		}
-	};
-
 	if (!isOpen || typeof document === "undefined") {
 		return null;
 	}
 
-	const showEmptyState = status === ChatStatus.Empty;
+	const showEmptyState = status === ChatStatus.Empty && history.length === 0;
 	const isStreaming = isProcessing && revealedAnswer.length > 0;
 	const showThinking = isProcessing && revealedAnswer.length === 0;
 	const sendDisabled = inputValue.trim().length === 0 || isProcessing;
 	const snippetDisplayName = currentSnippet?.name?.trim() || "Untitled snippet";
+	const hasCurrentTurn =
+		status !== ChatStatus.Empty || currentUserMessage !== "";
+	const inputPlaceholder =
+		history.length > 0 || currentUserMessage
+			? "Ask a follow-up…"
+			: "Ask something…";
 
-	const modalContent = (
-		<div className={styles.overlay} onClick={handleOverlayClick}>
-			<div
-				className={styles.modal}
-				role="dialog"
-				aria-modal="true"
-				aria-label="Ask AI"
-				onClick={(event) => event.stopPropagation()}
-			>
-				<div className={styles.header}>
-					<h2 className={styles.title}>
-						<span className={styles.titleIcon}>
-							<Sparkle width={18} height={18} />
-						</span>
-						<span>Ask AI</span>
-						<span className={styles.subtitle}>· {snippetDisplayName}</span>
-					</h2>
-					<div className={styles.headerActions}>
-						<span className={styles.kbdHint}>Esc</span>
-						<button
-							type="button"
-							className={styles.closeButton}
-							onClick={onClose}
-							aria-label="Close"
-						>
-							<CloseSquare width={18} height={18} />
-						</button>
-					</div>
+	const drawerContent = (
+		<aside className={styles.drawer} role="complementary" aria-label="Ask AI">
+			<div className={styles.header}>
+				<h2 className={styles.title}>
+					<span className={styles.titleIcon}>
+						<Sparkle width={16} height={16} />
+					</span>
+					<span>Ask AI</span>
+					<span className={styles.subtitle}>· {snippetDisplayName}</span>
+				</h2>
+
+				<div className={styles.headerActions}>
+					<button
+						type="button"
+						className={styles.iconButton}
+						onClick={resetConversation}
+						title="New chat"
+						aria-label="New chat"
+					>
+						<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+							<path
+								d="M9 2 L12 5 L7.5 9.5 L4.5 9.5 L4.5 6.5 Z"
+								stroke="currentColor"
+								strokeWidth="1.3"
+								strokeLinejoin="round"
+								fill="none"
+							/>
+						</svg>
+					</button>
+
+					<span className={styles.kbdHint}>Esc</span>
+
+					<button
+						type="button"
+						className={styles.iconButton}
+						onClick={onClose}
+						aria-label="Close"
+					>
+						<svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+							<path
+								d="M3 3 L11 11 M11 3 L3 11"
+								stroke="currentColor"
+								strokeWidth="1.5"
+								strokeLinecap="round"
+							/>
+						</svg>
+					</button>
 				</div>
+			</div>
 
-				<div className={styles.chat}>
-					{showEmptyState ? (
-						<div className={styles.empty}>
-							<span className={styles.emptyIcon}>
-								<Sparkle width={36} height={36} />
-							</span>
-							<h3 className={styles.emptyHeading}>What can I help you with?</h3>
-							<p className={styles.emptySubtext}>
-								Ask about the snippet on screen — explain it, refactor it, add
-								comments, or anything else.
-							</p>
-							<div className={styles.chips}>
-								{chipActions.map((action) => (
-									<button
-										key={action}
-										type="button"
-										className={styles.chip}
-										onClick={() => handleChipClick(action)}
-									>
-										{aiActionLabels[action]}
-									</button>
-								))}
-							</div>
+			<div className={styles.chat} ref={chatRef}>
+				{showEmptyState && (
+					<div className={styles.empty}>
+						<span className={styles.emptyIcon}>
+							<Sparkle width={36} height={36} />
+						</span>
+						<h3 className={styles.emptyHeading}>What can I help you with?</h3>
+						<p className={styles.emptySubtext}>
+							Ask about the snippet on screen — explain it, refactor it, add
+							comments, or anything else.
+						</p>
+						<div className={styles.chips}>
+							{chipActions.map((action) => (
+								<button
+									key={action}
+									type="button"
+									className={styles.chip}
+									onClick={() => handleChipClick(action)}
+								>
+									{aiActionLabels[action]}
+								</button>
+							))}
+						</div>
+					</div>
+				)}
+
+				{history.map((entry, index) =>
+					entry.role === "user" ? (
+						<div key={index} className={styles.userTurn}>
+							{entry.content}
 						</div>
 					) : (
-						<>
-							{userMessage && (
-								<div className={styles.userTurn}>{userMessage}</div>
-							)}
-
-							<div className={styles.assistantTurn}>
-								<div className={styles.assistantHeader}>
-									<span className={styles.assistantHeaderIcon}>
-										<Sparkle width={14} height={14} />
-									</span>
-									<span>{selectedModel || "AI"}</span>
-								</div>
-
-								{showThinking && (
-									<div className={styles.loader}>
-										<span className={styles.loaderSparkle}>
-											<Sparkle width={16} height={16} />
-										</span>
-										<span className={styles.shimmerText}>Thinking…</span>
-									</div>
-								)}
-
-								{(isStreaming ||
-									status === ChatStatus.Answered ||
-									status === ChatStatus.Stopped) &&
-									revealedAnswer.length > 0 && (
-										<div className={styles.assistantBody}>
-											{revealedAnswer}
-											{isStreaming && <span className={styles.caret} />}
-										</div>
-									)}
-
-								{status === ChatStatus.Stopped && (
-									<div className={styles.stoppedNote}>
-										<span className={styles.stoppedDot} />
-										<span>Stopped</span>
-									</div>
-								)}
-
-								{status === ChatStatus.Error && errorMessage && (
-									<p className={styles.errorMessage}>{errorMessage}</p>
-								)}
-
-								{showApplyButton && (
-									<button
-										type="button"
-										className={styles.applyButton}
-										onClick={handleApply}
-									>
-										Apply to editor
-									</button>
-								)}
+						<div key={index} className={styles.assistantTurn}>
+							<div className={styles.assistantHeader}>
+								<span className={styles.assistantHeaderIcon}>
+									<Sparkle width={14} height={14} />
+								</span>
+								<span>{selectedModel || "AI"}</span>
 							</div>
-						</>
-					)}
-				</div>
+							<div className={styles.assistantBody}>{entry.content}</div>
+						</div>
+					)
+				)}
 
-				<div className={styles.dock}>
-					<div className={styles.inputWrap}>
-						<div className={styles.inputRow}>
-							<textarea
-								ref={textareaRef}
-								className={styles.prompt}
-								placeholder="Ask something else..."
-								rows={1}
-								value={inputValue}
-								disabled={isProcessing}
-								onChange={handleInputChange}
-								onKeyDown={handleKeyDown}
-							/>
-							{isProcessing ? (
+				{hasCurrentTurn && (
+					<>
+						{currentUserMessage && (
+							<div className={styles.userTurn}>{currentUserMessage}</div>
+						)}
+
+						<div className={styles.assistantTurn}>
+							<div className={styles.assistantHeader}>
+								<span className={styles.assistantHeaderIcon}>
+									<Sparkle width={14} height={14} />
+								</span>
+								<span>{selectedModel || "AI"}</span>
+							</div>
+
+							{showThinking && (
+								<div className={styles.loader}>
+									<span className={styles.loaderSparkle}>
+										<Sparkle width={16} height={16} />
+									</span>
+									<span className={styles.shimmerText}>Thinking…</span>
+								</div>
+							)}
+
+							{(isStreaming ||
+								status === ChatStatus.Answered ||
+								status === ChatStatus.Stopped) &&
+								revealedAnswer.length > 0 && (
+									<div className={styles.assistantBody}>
+										{revealedAnswer}
+										{isStreaming && <span className={styles.caret} />}
+									</div>
+								)}
+
+							{status === ChatStatus.Stopped && (
+								<div className={styles.stoppedNote}>
+									<span className={styles.stoppedDot} />
+									<span>Stopped</span>
+								</div>
+							)}
+
+							{status === ChatStatus.Error && errorMessage && (
+								<p className={styles.errorMessage}>{errorMessage}</p>
+							)}
+
+							{showApplyButton && (
 								<button
 									type="button"
-									className={styles.stopButton}
-									onClick={handleStop}
-									aria-label="Stop"
+									className={styles.applyButton}
+									onClick={handleApply}
 								>
-									<svg width={10} height={10} viewBox="0 0 10 10">
-										<rect width={10} height={10} rx={2} fill="currentColor" />
-									</svg>
-								</button>
-							) : (
-								<button
-									type="button"
-									className={styles.sendButton}
-									onClick={handleSend}
-									disabled={sendDisabled}
-									aria-label="Send"
-								>
-									<svg width={14} height={14} viewBox="0 0 14 14" fill="none">
-										<path
-											d="M7 12 V2 M7 2 L3 6 M7 2 L11 6"
-											stroke="currentColor"
-											strokeWidth={1.8}
-											strokeLinecap="round"
-											strokeLinejoin="round"
-										/>
-									</svg>
+									Apply to editor
 								</button>
 							)}
 						</div>
-						<div className={styles.dockHint}>
-							<span>
-								<span className={styles.kbdInline}>↵</span> send ·{" "}
-								<span className={styles.kbdInline}>⇧↵</span> newline
-							</span>
-						</div>
+					</>
+				)}
+			</div>
+
+			<div className={styles.dock}>
+				<div className={styles.inputWrap}>
+					<div className={styles.inputRow}>
+						<textarea
+							ref={textareaRef}
+							className={styles.prompt}
+							placeholder={inputPlaceholder}
+							rows={1}
+							value={inputValue}
+							disabled={isProcessing}
+							onChange={handleInputChange}
+							onKeyDown={handleKeyDown}
+						/>
+						{isProcessing ? (
+							<button
+								type="button"
+								className={styles.stopButton}
+								onClick={handleStop}
+								aria-label="Stop"
+							>
+								<svg width={10} height={10} viewBox="0 0 10 10">
+									<rect width={10} height={10} rx={2} fill="currentColor" />
+								</svg>
+							</button>
+						) : (
+							<button
+								type="button"
+								className={styles.sendButton}
+								onClick={handleSend}
+								disabled={sendDisabled}
+								aria-label="Send"
+							>
+								<svg width={14} height={14} viewBox="0 0 14 14" fill="none">
+									<path
+										d="M7 12 V2 M7 2 L3 6 M7 2 L11 6"
+										stroke="currentColor"
+										strokeWidth={1.8}
+										strokeLinecap="round"
+										strokeLinejoin="round"
+									/>
+								</svg>
+							</button>
+						)}
+					</div>
+					<div className={styles.dockHint}>
+						<span>
+							<span className={styles.kbdInline}>↵</span> send ·{" "}
+							<span className={styles.kbdInline}>⇧↵</span> newline
+						</span>
 					</div>
 				</div>
 			</div>
-		</div>
+		</aside>
 	);
 
-	return createPortal(modalContent, document.body);
+	return createPortal(drawerContent, document.body);
 };
 
 export default AiChatModal;

--- a/app/components/CodeEditor/AiChatModal/aiChatModal.module.css
+++ b/app/components/CodeEditor/AiChatModal/aiChatModal.module.css
@@ -1,49 +1,29 @@
-.overlay {
+.drawer {
 	position: fixed;
-	inset: 0;
-	background-color: rgb(0 0 0 / 75%);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	z-index: 1000;
-	padding: 1rem;
-	animation: overlay-fade-in 0.18s ease-out;
-}
-
-@keyframes overlay-fade-in {
-	from {
-		opacity: 0;
-	}
-
-	to {
-		opacity: 1;
-	}
-}
-
-.modal {
-	width: min(640px, calc(100vw - 2rem));
-	max-height: min(640px, calc(100vh - 5rem));
+	top: 0.75rem;
+	right: 0.75rem;
+	bottom: 0.75rem;
+	width: min(440px, calc(100vw - 1.5rem));
 	display: flex;
 	flex-direction: column;
 	background: var(--bg-color-dark);
 	border: 1px solid var(--border-color);
 	border-radius: 0.75rem;
-	box-shadow:
-		0 1.875rem 5rem -1.25rem rgb(0 0 0 / 70%),
-		0 0.625rem 1.875rem -0.625rem rgb(0 0 0 / 50%);
+	box-shadow: -20px 0 60px -15px rgb(0 0 0 / 50%);
 	overflow: hidden;
-	animation: modal-pop-in 0.22s cubic-bezier(0.2, 0.9, 0.3, 1.2);
+	z-index: 1000;
+	animation: drawer-slide-in 280ms cubic-bezier(0.22, 0.9, 0.3, 1);
 }
 
-@keyframes modal-pop-in {
+@keyframes drawer-slide-in {
 	from {
+		transform: translateX(1.25rem);
 		opacity: 0;
-		transform: translateY(0.5rem) scale(0.98);
 	}
 
 	to {
+		transform: translateX(0);
 		opacity: 1;
-		transform: translateY(0) scale(1);
 	}
 }
 
@@ -54,6 +34,7 @@
 	padding: 0.875rem 1rem;
 	border-bottom: 1px solid var(--border-color);
 	background: var(--bg-color);
+	flex-shrink: 0;
 }
 
 .title {
@@ -76,7 +57,7 @@
 	color: var(--gray-color);
 	font-size: 0.75rem;
 	font-weight: 400;
-	max-width: 18rem;
+	max-width: 14rem;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -99,7 +80,7 @@
 	color: var(--gray-color);
 }
 
-.closeButton {
+.iconButton {
 	width: 1.75rem;
 	height: 1.75rem;
 	display: grid;
@@ -110,11 +91,11 @@
 	background: transparent;
 	cursor: pointer;
 	transition:
-		background 0.15s ease,
-		color 0.15s ease;
+		background 0.12s ease,
+		color 0.12s ease;
 }
 
-.closeButton:hover {
+.iconButton:hover {
 	background: var(--bg-color-dark);
 	color: var(--foreground-color);
 }
@@ -397,6 +378,7 @@
 	padding: 0.625rem;
 	border-top: 1px solid var(--border-color);
 	background: var(--bg-color);
+	flex-shrink: 0;
 }
 
 .inputWrap {
@@ -533,14 +515,11 @@
 }
 
 @media (width <= 768px) {
-	.overlay {
-		padding: 0;
-	}
-
-	.modal {
+	.drawer {
+		top: 0;
+		right: 0;
+		bottom: 0;
 		width: 100vw;
-		height: 100vh;
-		max-height: 100vh;
 		border-radius: 0;
 	}
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- Replaces centered overlay modal with a fixed right-side drawer (slides in from the right)
- Adds persistent chat history across turns, enabling multi-turn AI conversations
- Adds a "New chat" button to reset the conversation
- Auto-scrolls to the latest message as the stream arrives
- Input placeholder adapts ("Ask something…" → "Ask a follow-up…" once history exists)
- Mobile: drawer goes full-screen (existing breakpoint behavior preserved)

## Test plan

- [ ] Open AI chat modal — verify drawer slides in from the right (not centered overlay)
- [ ] Ask a question, get an answer — verify it's stored in history and a follow-up prompt appears
- [ ] Ask a follow-up — verify previous turn shows in the thread above the new response
- [ ] Click "New chat" button — verify history clears and empty state reappears
- [ ] Press Esc — verify drawer closes
- [ ] Apply an AI suggestion — verify it still works correctly
- [ ] On mobile viewport — verify drawer goes full-screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)