### PR TITLE
fix: P0 + P1 hardening — ownership, id-based selection, effect cleanups, AI errors, security headers

### DIFF
--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -269,6 +269,7 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
 		const ollamaModel = aiModel || process.env.OLLAMA_MODEL || "codellama";
 		const ollamaUrl = aiUrl || defaultOllamaUrl;
 		const ollamaApiKey = aiApiKey || process.env.OLLAMA_API_KEY || undefined;
+		const attempts: Array<{ provider: string; error: string }> = [];
 
 		// 1. Try custom Ollama URL (tunnel or local)
 		try {
@@ -282,8 +283,12 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
 			);
 
 			return NextResponse.json({ result, provider: "ollama" });
-		} catch (_ollamaError) {
-			// Custom Ollama URL failed
+		} catch (ollamaError) {
+			attempts.push({
+				provider: "ollama",
+				error:
+					ollamaError instanceof Error ? ollamaError.message : "Unknown error",
+			});
 		}
 
 		// 2. Try Ollama Cloud directly with API key
@@ -299,8 +304,14 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
 				);
 
 				return NextResponse.json({ result, provider: "ollama-cloud" });
-			} catch (_ollamaCloudError) {
-				// Ollama Cloud failed
+			} catch (ollamaCloudError) {
+				attempts.push({
+					provider: "ollama-cloud",
+					error:
+						ollamaCloudError instanceof Error
+							? ollamaCloudError.message
+							: "Unknown error",
+				});
 			}
 		}
 
@@ -312,19 +323,38 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
 				{
 					error:
 						"No AI provider configured. Set up your Ollama URL or API key in Account Settings > AI tab.",
+					code: "no_provider_configured",
+					attempts,
 				},
 				{ status: 503 }
 			);
 		}
 
-		const result = await requestClaude(
-			prompt,
-			systemPrompt,
-			fallbackApiKey,
-			stripFences
-		);
+		try {
+			const result = await requestClaude(
+				prompt,
+				systemPrompt,
+				fallbackApiKey,
+				stripFences
+			);
 
-		return NextResponse.json({ result, provider: "claude" });
+			return NextResponse.json({ result, provider: "claude" });
+		} catch (claudeError) {
+			attempts.push({
+				provider: "claude",
+				error:
+					claudeError instanceof Error ? claudeError.message : "Unknown error",
+			});
+
+			return NextResponse.json(
+				{
+					error: "All AI providers failed",
+					code: "all_providers_failed",
+					attempts,
+				},
+				{ status: 502 }
+			);
+		}
 	} catch (error) {
 		const errorMessage =
 			error instanceof Error ? error.message : "An unexpected error occurred";

--- a/app/components/AccountModal/AccountModal.tsx
+++ b/app/components/AccountModal/AccountModal.tsx
@@ -163,9 +163,9 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 				return new Error("Passwords do not match");
 			}
 
-			if (userData?.newPassword?.length < 6) {
+			if (userData?.newPassword?.length < 12) {
 				setMessage({
-					text: "Password must be at least 6 characters",
+					text: "Password must be at least 12 characters",
 					type: FormMessageTypes.Error,
 				});
 
@@ -305,6 +305,8 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 
 	// Load user data when modal opens
 	useEffect(() => {
+		let isMounted = true;
+
 		const loadUserData = async () => {
 			if (!isOpen) {
 				return;
@@ -314,6 +316,8 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 				resetMessages();
 				resetStateData();
 				const userEmail = await getUserEmailBySession();
+
+				if (!isMounted) return;
 
 				if (userEmail) {
 					const username = userEmail?.split("@")[0] || "";
@@ -326,6 +330,9 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 				}
 
 				const dataFromSession = await getUserDataFromSession();
+
+				if (!isMounted) return;
+
 				const userMetadata = dataFromSession?.user?.user_metadata;
 
 				if (userMetadata) {
@@ -391,16 +398,24 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 						activeProvider === "ollama" ? userMetadata?.ai_api_key : undefined,
 				});
 
+				if (!isMounted) return;
+
 				setAiModels(models);
 			} catch (_catchError) {
-				setMessage({
-					text: "Error loading user data",
-					type: FormMessageTypes.Error,
-				});
+				if (isMounted) {
+					setMessage({
+						text: "Error loading user data",
+						type: FormMessageTypes.Error,
+					});
+				}
 			}
 		};
 
 		loadUserData();
+
+		return () => {
+			isMounted = false;
+		};
 	}, [isOpen]);
 
 	const modelDropdown = (): ReactElement => {

--- a/app/components/CodeEditor/hooks/useCurrentSnippet.ts
+++ b/app/components/CodeEditor/hooks/useCurrentSnippet.ts
@@ -233,9 +233,11 @@ const useCurrentSnippet = ({
 	useEffect(() => {
 		if (!snippet) return;
 
-		const isSnippetSwitch =
-			previousSnippetIdRef.current !== null &&
-			previousSnippetIdRef.current !== snippet.snippet_id;
+		if (previousSnippetIdRef.current === snippet.snippet_id) {
+			return;
+		}
+
+		const isSnippetSwitch = previousSnippetIdRef.current !== null;
 
 		if (isSnippetSwitch && autoSave && touched && !isTrashActive) {
 			onSave(currentSnippet, false);
@@ -251,7 +253,7 @@ const useCurrentSnippet = ({
 
 		onTouched(false);
 		setPreRestoreSnapshot(null);
-	}, [snippet?.snippet_id]);
+	}, [snippet?.snippet_id, autoSave, touched, isTrashActive]);
 
 	// Refresh version count when snippet changes
 	useEffect(() => {

--- a/app/components/SnippetItem/SnippetItem.tsx
+++ b/app/components/SnippetItem/SnippetItem.tsx
@@ -14,16 +14,14 @@ import styles from "@/components/SnippetList/snippetlist.module.css";
 interface SnippetItemPropsComponent extends SnippetItemProps {
 	dateFormatted: string;
 	snippet: Snippet | null | undefined;
-	originalIndex: number;
 	isTrashActive: boolean;
 }
 
 const SnippetItem: FC<SnippetItemPropsComponent> = ({
 	snippet,
 	dateFormatted,
-	codeEditorStates: { activeSnippetIndex, touched },
+	codeEditorStates: { activeSnippetId, touched },
 	isTrashActive,
-	originalIndex,
 	onActiveSnippet,
 	onDeleteSnippet,
 	onRestoreSnippet,
@@ -32,28 +30,22 @@ const SnippetItem: FC<SnippetItemPropsComponent> = ({
 	const closeSnippetList = useMenuStore((state) => state.closeSnippetList);
 
 	if (snippet) {
-		const snippetClickHandler = (
-			event: MouseEvent<HTMLLIElement>,
-			index: number
-		): void => {
+		const snippetClickHandler = (event: MouseEvent<HTMLLIElement>): void => {
 			event.preventDefault();
-			onActiveSnippet(index);
+			onActiveSnippet(snippet.snippet_id);
 
-			// Close the snippet list on mobile when a snippet is selected
 			if (isMobile) {
 				closeSnippetList();
 			}
 		};
 
-		const isSnippetActive = activeSnippetIndex === originalIndex;
+		const isSnippetActive = activeSnippetId === snippet.snippet_id;
 
 		return (
 			<li
 				className={`${styles.snippetItem} ${isSnippetActive ? styles.active : ""}`}
 				key={snippet.snippet_id}
-				onClick={(event: MouseEvent<HTMLLIElement>) =>
-					snippetClickHandler(event, originalIndex)
-				}
+				onClick={snippetClickHandler}
 			>
 				<div className={styles.itemLeftSide}>
 					{!isTrashActive && (
@@ -61,9 +53,7 @@ const SnippetItem: FC<SnippetItemPropsComponent> = ({
 							className={styles.trashIcon}
 							width="18"
 							height="18"
-							onClick={() =>
-								onDeleteSnippet(snippet?.snippet_id, originalIndex, "inactive")
-							}
+							onClick={() => onDeleteSnippet(snippet?.snippet_id, "inactive")}
 						/>
 					)}
 
@@ -72,9 +62,7 @@ const SnippetItem: FC<SnippetItemPropsComponent> = ({
 							className={styles.restoreIcon}
 							width="18"
 							height="18"
-							onClick={() =>
-								onRestoreSnippet(snippet?.snippet_id, originalIndex, "active")
-							}
+							onClick={() => onRestoreSnippet(snippet?.snippet_id, "active")}
 						/>
 					)}
 					{touched && isSnippetActive && "* "}

--- a/app/components/SnippetList/SnippetList.tsx
+++ b/app/components/SnippetList/SnippetList.tsx
@@ -63,9 +63,12 @@ const SnippetList = ({
 	const mobileListOpen = useMenuStore((state) => state.snippetListOpen);
 	const isTrashActive = menuType === "trash";
 	const formattedDates = useMemo(
-		(): string[] =>
-			snippets?.map((snippet: Snippet) =>
-				formatDateToDDMMYYYY(snippet.updated_at ?? "")
+		(): Map<UUID, string> =>
+			new Map(
+				snippets?.map((snippet: Snippet) => [
+					snippet.snippet_id,
+					formatDateToDDMMYYYY(snippet.updated_at ?? ""),
+				]) ?? []
 			),
 		[snippets]
 	);
@@ -100,11 +103,6 @@ const SnippetList = ({
 					: searchData.originalSnippets,
 		});
 	};
-
-	const getSnippetIndex = (snippetId: UUID): number =>
-		searchData?.originalSnippets.findIndex(
-			(snippet: Snippet): boolean => snippet.snippet_id === snippetId
-		);
 
 	const handleDeleteAll = async (): Promise<void> => {
 		if (deleteAll) {
@@ -211,23 +209,18 @@ const SnippetList = ({
 						</Alert>
 					</li>
 
-					{searchData.snippetsFound.map((snippet: Snippet) => {
-						const originalIndex = getSnippetIndex(snippet.snippet_id);
-
-						return (
-							<SnippetItem
-								key={snippet.snippet_id}
-								snippet={snippet}
-								dateFormatted={formattedDates[originalIndex]}
-								isTrashActive={isTrashActive}
-								originalIndex={originalIndex}
-								codeEditorStates={codeEditorStates}
-								onActiveSnippet={onActiveSnippet}
-								onDeleteSnippet={onDeleteSnippet}
-								onRestoreSnippet={onRestoreSnippet}
-							/>
-						);
-					})}
+					{searchData.snippetsFound.map((snippet: Snippet) => (
+						<SnippetItem
+							key={snippet.snippet_id}
+							snippet={snippet}
+							dateFormatted={formattedDates.get(snippet.snippet_id) ?? ""}
+							isTrashActive={isTrashActive}
+							codeEditorStates={codeEditorStates}
+							onActiveSnippet={onActiveSnippet}
+							onDeleteSnippet={onDeleteSnippet}
+							onRestoreSnippet={onRestoreSnippet}
+						/>
+					))}
 				</ul>
 			) : (
 				<div className={styles.noSnippetContainer}>

--- a/app/lib/supabase/queries.ts
+++ b/app/lib/supabase/queries.ts
@@ -154,22 +154,46 @@ export const searchSnippets = async (query: string): Promise<Snippet[]> => {
 export const saveSnippet = async (
 	currentSnippet: CurrentSnippet
 ): Promise<void> => {
-	if (supabase) {
-		const { error } = await supabase.from("snippet").upsert({
-			snippet_id: currentSnippet.snippet_id,
-			snippet: currentSnippet.snippet,
-			language: currentSnippet.language,
-			name: currentSnippet?.name,
-			updated_at: currentSnippet?.updated_at,
-			state: currentSnippet?.state,
-			tags: currentSnippet?.tags ?? null,
-			url: currentSnippet?.url ?? null,
-			notes: currentSnippet?.notes ?? null,
-		});
+	if (!supabase) return;
 
-		if (error) {
-			throw new Error("Error saving snippet");
-		}
+	const userId = await getUserIdBySession();
+
+	if (!userId) {
+		throw new Error("Not authenticated");
+	}
+
+	const payload = {
+		snippet_id: currentSnippet.snippet_id,
+		snippet: currentSnippet.snippet,
+		language: currentSnippet.language,
+		name: currentSnippet?.name,
+		updated_at: currentSnippet?.updated_at,
+		state: currentSnippet?.state,
+		tags: currentSnippet?.tags ?? null,
+		url: currentSnippet?.url ?? null,
+		notes: currentSnippet?.notes ?? null,
+	};
+
+	const { data: updated, error: updateError } = await supabase
+		.from("snippet")
+		.update(payload)
+		.match({ snippet_id: currentSnippet.snippet_id, user_id: userId })
+		.select("snippet_id");
+
+	if (updateError) {
+		throw new Error("Error saving snippet");
+	}
+
+	if (updated && updated.length > 0) {
+		return;
+	}
+
+	const { error: insertError } = await supabase
+		.from("snippet")
+		.insert({ ...payload, user_id: userId });
+
+	if (insertError) {
+		throw new Error("Error saving snippet");
 	}
 };
 
@@ -177,15 +201,21 @@ export const trashRestoreSnippet = async (
 	snippetId: UUID,
 	state: SnippetState = "inactive"
 ): Promise<void> => {
-	if (supabase) {
-		const { error } = await supabase
-			.from("snippet")
-			.update({ state })
-			.match({ snippet_id: snippetId });
+	if (!supabase) return;
 
-		if (error) {
-			throw new Error("Error trashing snippet");
-		}
+	const userId = await getUserIdBySession();
+
+	if (!userId) {
+		throw new Error("Not authenticated");
+	}
+
+	const { error } = await supabase
+		.from("snippet")
+		.update({ state })
+		.match({ snippet_id: snippetId, user_id: userId });
+
+	if (error) {
+		throw new Error("Error trashing snippet");
 	}
 };
 
@@ -225,6 +255,22 @@ export const saveSnippetVersion = async (
 	currentSnippet: CurrentSnippet
 ): Promise<void> => {
 	if (supabase) {
+		const userId = await getUserIdBySession();
+
+		if (!userId) {
+			throw new Error("Not authenticated");
+		}
+
+		const { data: parent } = await supabase
+			.from("snippet")
+			.select("snippet_id")
+			.match({ snippet_id: snippetId, user_id: userId })
+			.maybeSingle();
+
+		if (!parent) {
+			throw new Error("Snippet not found");
+		}
+
 		const { data: latestVersion } = await supabase
 			.from("snippet_version")
 			.select("version_number")
@@ -309,22 +355,26 @@ export const toggleSnippetPublic = async (
 	isPublic: boolean,
 	existingSlug: string | null = null
 ): Promise<string | null> => {
-	if (supabase) {
-		const slug = isPublic ? (existingSlug ?? generateSlug()) : existingSlug;
+	if (!supabase) return null;
 
-		const { error } = await supabase
-			.from("snippet")
-			.update({ is_public: isPublic, public_slug: slug })
-			.match({ snippet_id: snippetId });
+	const userId = await getUserIdBySession();
 
-		if (error) {
-			throw new Error("Error toggling snippet visibility");
-		}
-
-		return slug;
+	if (!userId) {
+		throw new Error("Not authenticated");
 	}
 
-	return null;
+	const slug = isPublic ? (existingSlug ?? generateSlug()) : existingSlug;
+
+	const { error } = await supabase
+		.from("snippet")
+		.update({ is_public: isPublic, public_slug: slug })
+		.match({ snippet_id: snippetId, user_id: userId });
+
+	if (error) {
+		throw new Error("Error toggling snippet visibility");
+	}
+
+	return slug;
 };
 
 export const getPublicSnippet = async (

--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -32,9 +32,13 @@ export default function PublicSnippetPage({ params }: PageProps): ReactElement {
 	const [screenshotModalOpen, setScreenshotModalOpen] = useState(false);
 
 	useEffect(() => {
+		let isMounted = true;
+
 		const fetchSnippet = async () => {
 			try {
 				const data = await getPublicSnippet(slug);
+
+				if (!isMounted) return;
 
 				if (data) {
 					setSnippet(data);
@@ -42,13 +46,21 @@ export default function PublicSnippetPage({ params }: PageProps): ReactElement {
 					setError(true);
 				}
 			} catch {
-				setError(true);
+				if (isMounted) {
+					setError(true);
+				}
 			}
 
-			setLoading(false);
+			if (isMounted) {
+				setLoading(false);
+			}
 		};
 
 		fetchSnippet();
+
+		return () => {
+			isMounted = false;
+		};
 	}, [slug]);
 
 	const editorTheme = getCodeMirrorTheme(ThemeNames.Dracula);

--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -30,7 +30,7 @@ export default function Page(): ReactElement {
 	useDeviceViewPort();
 
 	const defaultCodeEditorStates: SnippetEditorStates = {
-		activeSnippetIndex: 0,
+		activeSnippetId: null,
 		isSaving: false,
 		touched: false,
 		menuType: "none",
@@ -53,12 +53,32 @@ export default function Page(): ReactElement {
 				snippet.snippet_id === currentSnippet.snippet_id
 		);
 
-	const setActiveSnippetIndex = (index: number): void => {
+	const setActiveSnippetId = (snippetId: UUID | null): void => {
 		setCodedEditorStates({
 			...codeEditorStates,
-			activeSnippetIndex: index,
+			activeSnippetId: snippetId,
 			isSaving: codeEditorStates.touched,
 		});
+	};
+
+	const findSnippetIndexById = (snippetId: UUID | null): number =>
+		snippetId
+			? snippets.findIndex(
+					(snippet: Snippet): boolean => snippet.snippet_id === snippetId
+				)
+			: -1;
+
+	const pickNextActiveId = (
+		removedIndex: number,
+		remainingSnippets: Snippet[]
+	): UUID | null => {
+		if (remainingSnippets.length === 0) {
+			return null;
+		}
+
+		const nextIndex = Math.min(removedIndex, remainingSnippets.length - 1);
+
+		return remainingSnippets[nextIndex].snippet_id;
 	};
 
 	const touchedHandler = (touched: boolean): void => {
@@ -131,27 +151,35 @@ export default function Page(): ReactElement {
 			updateMenuCounts(data);
 		}
 
-		setCodedEditorStates(defaultCodeEditorStates);
+		setCodedEditorStates({
+			...defaultCodeEditorStates,
+			activeSnippetId: data?.[0]?.snippet_id ?? null,
+		});
 		setIsLoading(false);
 	};
 
 	const updateSnippet = (
 		currentSnippet: CurrentSnippet | null = null,
 		fromButton: boolean | "favorite" = false
-	): number => {
+	): void => {
 		if (!currentSnippet) {
-			return 0;
+			return;
 		}
 
-		const foundIndex = findIndexForCurrentSnippet(currentSnippet);
+		const exists = snippets.some(
+			(snippet: Snippet): boolean =>
+				snippet.snippet_id === currentSnippet.snippet_id
+		);
 
-		if (foundIndex === -1) {
-			return 0;
+		if (!exists) {
+			return;
 		}
 
 		if (fromButton !== "favorite") {
-			const updatedSnippets = snippets.map((snippet, index) =>
-				index === foundIndex ? { ...snippet, ...currentSnippet } : snippet
+			const updatedSnippets = snippets.map((snippet) =>
+				snippet.snippet_id === currentSnippet.snippet_id
+					? { ...snippet, ...currentSnippet }
+					: snippet
 			);
 
 			const snippetsSorted = sortSnippetsByUpdatedAt(updatedSnippets);
@@ -159,22 +187,11 @@ export default function Page(): ReactElement {
 			setSnippets(snippetsSorted);
 		}
 
-		const newActiveSnippetIndex =
-			codeEditorStates.activeSnippetIndex > foundIndex
-				? codeEditorStates.activeSnippetIndex
-				: codeEditorStates.activeSnippetIndex + 1;
-		const activeSnippetIndex = fromButton === true ? 0 : newActiveSnippetIndex;
-
-		const updatedCodeEditorStates = {
+		setCodedEditorStates({
 			...codeEditorStates,
-			activeSnippetIndex,
 			isSaving: false,
 			touched: false,
-		};
-
-		setCodedEditorStates(updatedCodeEditorStates);
-
-		return activeSnippetIndex;
+		});
 	};
 
 	const updateSnippetTagList = async (
@@ -197,8 +214,13 @@ export default function Page(): ReactElement {
 		currentSnippet: CurrentSnippet,
 		fromButton: boolean | "favorite" = false
 	): Promise<void> => {
+		const activeSnippet = snippets.find(
+			(snippet: Snippet): boolean =>
+				snippet.snippet_id === codeEditorStates.activeSnippetId
+		);
+
 		if (
-			snippets[codeEditorStates?.activeSnippetIndex ?? 0]?.snippet_id &&
+			activeSnippet?.snippet_id &&
 			currentSnippet?.name &&
 			currentSnippet?.name?.length > 0 &&
 			currentSnippet?.snippet
@@ -213,7 +235,7 @@ export default function Page(): ReactElement {
 				updated_at: new Date().toISOString(),
 			};
 
-			const activeSnippetIndex = updateSnippet(updatedSnippet, fromButton);
+			updateSnippet(updatedSnippet, fromButton);
 
 			await saveSnippet(updatedSnippet);
 
@@ -230,15 +252,6 @@ export default function Page(): ReactElement {
 				addToast({
 					type: ToastType.Success,
 					message: "Snippet saved successfully",
-				});
-			}
-
-			if (activeSnippetIndex && fromButton !== "favorite" && !fromButton) {
-				setCodedEditorStates({
-					...codeEditorStates,
-					isSaving: false,
-					touched: false,
-					activeSnippetIndex,
 				});
 			}
 		} else {
@@ -270,7 +283,7 @@ export default function Page(): ReactElement {
 		cloneSnippets.splice(currentIndex, 1);
 		setSnippets(cloneSnippets);
 
-		setActiveSnippetIndex(currentIndex > 0 ? currentIndex - 1 : 0);
+		setActiveSnippetId(pickNextActiveId(currentIndex, cloneSnippets));
 	};
 
 	const onPublicToggleHandler = (currentSnippet: CurrentSnippet): void => {
@@ -301,7 +314,7 @@ export default function Page(): ReactElement {
 			cloneSnippets.splice(currentIndex, 1);
 			setSnippets(cloneSnippets);
 
-			setActiveSnippetIndex(currentIndex > 0 ? currentIndex - 1 : 0);
+			setActiveSnippetId(pickNextActiveId(currentIndex, cloneSnippets));
 		}
 	};
 
@@ -309,9 +322,7 @@ export default function Page(): ReactElement {
 		if (newSnippet) {
 			setSnippets([newSnippet, ...snippets]);
 
-			setActiveSnippetIndex(
-				!codeEditorStates.touched ? 0 : codeEditorStates.activeSnippetIndex + 1
-			);
+			setActiveSnippetId(newSnippet.snippet_id);
 		}
 	};
 
@@ -319,10 +330,10 @@ export default function Page(): ReactElement {
 		if (codeEditorStates.menuType !== MenuItems.Trash) {
 			await getSnippets("inactive");
 
-			setCodedEditorStates({
-				...codeEditorStates,
+			setCodedEditorStates((prev) => ({
+				...prev,
 				menuType: MenuItems.Trash,
-			});
+			}));
 		}
 	};
 
@@ -330,10 +341,10 @@ export default function Page(): ReactElement {
 		if (codeEditorStates.menuType !== MenuItems.All) {
 			await getSnippets();
 
-			setCodedEditorStates({
-				...codeEditorStates,
+			setCodedEditorStates((prev) => ({
+				...prev,
 				menuType: MenuItems.All,
-			});
+			}));
 		}
 	};
 
@@ -346,6 +357,7 @@ export default function Page(): ReactElement {
 			setCodedEditorStates({
 				...defaultCodeEditorStates,
 				menuType: MenuItems.Uncategorized,
+				activeSnippetId: data?.[0]?.snippet_id ?? null,
 			});
 		}
 	};
@@ -362,6 +374,7 @@ export default function Page(): ReactElement {
 			setCodedEditorStates({
 				...defaultCodeEditorStates,
 				menuType: MenuItems.Public,
+				activeSnippetId: publicSnippets?.[0]?.snippet_id ?? null,
 			});
 		}
 	};
@@ -370,10 +383,10 @@ export default function Page(): ReactElement {
 		if (codeEditorStates.menuType !== MenuItems.Favorites) {
 			await getSnippets("favorite");
 
-			setCodedEditorStates({
-				...codeEditorStates,
+			setCodedEditorStates((prev) => ({
+				...prev,
 				menuType: MenuItems.Favorites,
-			});
+			}));
 		}
 	};
 
@@ -384,21 +397,22 @@ export default function Page(): ReactElement {
 
 		const data = await getSnippetsByTag(tag);
 
-		setCodedEditorStates({ ...defaultCodeEditorStates, ...{ menuType: tag } });
+		setCodedEditorStates({
+			...defaultCodeEditorStates,
+			menuType: tag,
+			activeSnippetId: data?.[0]?.snippet_id ?? null,
+		});
 
 		setSnippets(data);
 	};
 
 	const trashRestoreSnippetHandler = async (
 		snippetId: UUID,
-		index: number,
 		state: SnippetState = "inactive"
 	): Promise<void> => {
 		if (!snippetId) return;
 
-		const foundIndex = snippets.findIndex(
-			(snippet: Snippet): boolean => snippet.snippet_id === snippetId
-		);
+		const foundIndex = findSnippetIndexById(snippetId);
 
 		if (foundIndex === -1) return;
 
@@ -407,13 +421,11 @@ export default function Page(): ReactElement {
 		cloneSnippets.splice(foundIndex, 1);
 		setSnippets(cloneSnippets);
 
-		const isLastSnippet = index > cloneSnippets.length - 1;
-
 		setCodedEditorStates((prevStates) => ({
 			...prevStates,
 			isSaving: true,
 			touched: true,
-			activeSnippetIndex: isLastSnippet ? 0 : index,
+			activeSnippetId: pickNextActiveId(foundIndex, cloneSnippets),
 		}));
 
 		await trashRestoreSnippet(snippetId, state);
@@ -433,7 +445,7 @@ export default function Page(): ReactElement {
 
 	const emptyTrashHandler = (): void => {
 		setSnippets([]);
-		setActiveSnippetIndex(0);
+		setActiveSnippetId(null);
 	};
 
 	const handleAccountClick = (): void => {
@@ -487,7 +499,7 @@ export default function Page(): ReactElement {
 						snippets={snippets}
 						codeEditorStates={codeEditorStates}
 						onNewSnippet={newSnippetHandler}
-						onActiveSnippet={setActiveSnippetIndex}
+						onActiveSnippet={setActiveSnippetId}
 						onDeleteSnippet={trashRestoreSnippetHandler}
 						onRestoreSnippet={trashRestoreSnippetHandler}
 						onEmptyTrash={emptyTrashHandler}
@@ -498,7 +510,10 @@ export default function Page(): ReactElement {
 						isLoading={isLoading}
 						snippet={
 							snippets?.length > 0
-								? snippets[codeEditorStates.activeSnippetIndex]
+								? (snippets.find(
+										(snippet: Snippet): boolean =>
+											snippet.snippet_id === codeEditorStates.activeSnippetId
+									) ?? snippets[0])
 								: null
 						}
 						codeEditorStates={codeEditorStates}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,24 @@
 /** @type {import('next').NextConfig} */
+const securityHeaders = [
+	{ key: "X-Frame-Options", value: "DENY" },
+	{ key: "X-Content-Type-Options", value: "nosniff" },
+	{ key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+	{
+		key: "Strict-Transport-Security",
+		value: "max-age=63072000; includeSubDomains; preload",
+	},
+];
+
 const nextConfig = {
 	reactStrictMode: false,
+	async headers() {
+		return [
+			{
+				source: "/:path*",
+				headers: securityHeaders,
+			},
+		];
+	},
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
 	},
 	"resolutions": {
 		"flatted": ">=3.4.2",
-		"brace-expansion": ">=2.0.2",
 		"postcss": ">=8.5.10"
 	},
 	"devDependencies": {

--- a/types/snippets.d.ts
+++ b/types/snippets.d.ts
@@ -12,7 +12,7 @@ declare global {
 	type MenuItemType = MenuItems | string;
 
 	type SnippetEditorStates = {
-		activeSnippetIndex: number;
+		activeSnippetId: UUID | null;
 		isSaving: boolean;
 		touched: boolean;
 		menuType: MenuItemType;
@@ -54,11 +54,7 @@ declare global {
 		[key: SupportedLanguages | string]: LanguageSupport;
 	};
 
-	type DeleteRestoreFunction = (
-		snippetId: UUID,
-		index: number,
-		state: SnippetState
-	) => void;
+	type DeleteRestoreFunction = (snippetId: UUID, state: SnippetState) => void;
 
 	type SearchData = {
 		searchQuery: string;
@@ -68,7 +64,7 @@ declare global {
 
 	type SnippetItemProps = {
 		codeEditorStates: SnippetEditorStates;
-		onActiveSnippet: (index: number) => void;
+		onActiveSnippet: (snippetId: UUID) => void;
 		onDeleteSnippet: DeleteRestoreFunction;
 		onRestoreSnippet: DeleteRestoreFunction;
 	};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,6 +1672,11 @@ axobject-query@^4.1.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
 balanced-match@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
@@ -1694,7 +1699,15 @@ bidi-js@^1.0.3:
   dependencies:
     require-from-string "^2.0.2"
 
-brace-expansion@>=2.0.2, brace-expansion@^1.1.7, brace-expansion@^5.0.5:
+brace-expansion@^1.1.7:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.14.tgz#d9de602370d91347cd9ddad1224d4fd701eb348b"
+  integrity sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+brace-expansion@^5.0.5:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
   integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
@@ -1853,6 +1866,11 @@ commander@^14.0.3:
   version "14.0.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
   integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 convert-source-map@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary
Bundles six fixes from the audit at \`~/.claude/plans/read-the-entire-code-composed-metcalfe.md\`. Two commits for reviewability — the ownership fix is self-contained on \`app/lib/supabase/queries.ts\`; the hardening commit covers the rest.

### Security (P0 / P1)
- **P0 #4** — \`saveSnippet\` now fetches \`user_id\` from the session and force-overwrites it in the payload, then splits the upsert into update-by-\`{snippet_id, user_id}\` with insert fallback. Cross-user updates affect 0 rows; cross-user inserts fail on PK conflict. \`trashRestoreSnippet\`, \`toggleSnippetPublic\`, and \`saveSnippetVersion\` (via parent-snippet ownership check) also enforce \`user_id\`. RLS tightening to \`WITH CHECK (user_id = auth.uid())\` should follow in a Supabase migration PR.
- **P1 #12** — \`/api/ai\` collects per-provider failure reasons into \`attempts[]\` and returns typed error codes (\`no_provider_configured\` / \`all_providers_failed\`). No more silent cascade swallowing.
- **P1 #7 (partial)** — security headers (X-Frame-Options DENY, nosniff, Referrer-Policy, HSTS) added in \`next.config.js\`. CSP intentionally **not** in this PR — needs a browser smoke pass to avoid breaking Vercel Analytics / Supabase fetches.
- **P2 #20** — password minimum 6 → 12.

### Behavioural fixes (P0 #5 / P1 #8)
- Active snippet is now identified by \`activeSnippetId: UUID | null\` instead of an array index. Save/create no longer drifts to a wrong row; deleting from a search-filtered list removes the *clicked* snippet, not whatever lives at the same index in the unfiltered list.
- \`useCurrentSnippet\` snippet-switch effect now guards on a real id change and includes \`autoSave\`/\`touched\`/\`isTrashActive\` in its deps. \`/s/[slug]\` and \`AccountModal\` async loaders use an \`isMounted\` flag to suppress setState-on-unmount.

### Tooling
- Dropped the \`brace-expansion\` resolution. Next 16.2.6 transitively pulls a non-vulnerable version, and the resolution was force-bumping it to v2 which broke minimatch's CJS require inside ESLint's config-array. \`yarn audit\` stays at 0 vulnerabilities without it.

## Test plan
- [ ] \`yarn audit\` → 0 vulnerabilities
- [ ] \`yarn build\` passes
- [ ] Click rows, save, create, favorite, unfavorite, trash, restore, empty trash, switch menus — active snippet behaves correctly in each
- [ ] Search "foo", delete one of N matches — the clicked match disappears, not a different one
- [ ] Open AccountModal then close immediately while it loads — no React warning in console
- [ ] Navigate to a public /s/<slug>, then navigate away mid-load — no warning
- [ ] \`curl -I https://<preview>/snippets\` → X-Frame-Options, nosniff, Referrer-Policy, Strict-Transport-Security all present
- [ ] DevTools network: POST /api/ai with Ollama URL pointing at a closed port → response includes \`attempts: [{ provider: "ollama", error: "..." }]\`
- [ ] Try to change password to "short1" → blocked with "Password must be at least 12 characters"
- [ ] As user A, capture a snippet_id. As user B, attempt \`update snippet where snippet_id = <A's>\` via Supabase JS — update affects 0 rows; insert with that snippet_id fails with PK conflict

## Not in this PR
- **P1 #6** AI provider keys server-side only (needs AccountModal redesign)
- **P1 #9** version-cleanup race → Postgres trigger (needs \`supabase/migrations\` infra)
- **P1 #11** demo creds on /login (product decision — keep with "Try demo" button, or remove?)
- **P1 #7 full** CSP headers (needs browser smoke pass)
- **P2 #14, #15** SQL-side tag derivation and DB FTS wiring