### PR TITLE
perf: skip redundant work on save, toast dismiss, snippet switch

### DIFF
--- a/app/components/CodeEditor/hooks/useCurrentSnippet.ts
+++ b/app/components/CodeEditor/hooks/useCurrentSnippet.ts
@@ -222,13 +222,6 @@ const useCurrentSnippet = ({
 		onSave(currentSnippet, true);
 	};
 
-	// Sync language extension when snippet language changes
-	useEffect(() => {
-		if (snippet?.language) {
-			setLanguageExtension(snippet.language);
-		}
-	}, [snippet?.language]);
-
 	// Load new snippet when switching
 	useEffect(() => {
 		if (!snippet) return;

--- a/app/lib/store/toast.store.tsx
+++ b/app/lib/store/toast.store.tsx
@@ -6,30 +6,42 @@ import { ToastPositions, ToastTimeOut } from "@/lib/constants/toast";
 /* Utils */
 import uuidv4 from "@/utils/string.utilts";
 
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
 const useToastStore = create<ToastState & ToastActions>((set) => ({
 	toasts: null,
 	position: ToastPositions.BottomRight,
 	addToast: (toast: Toast) => {
 		const newToast = {
 			...toast,
-			id: toast.id || uuidv4(), // Use existing id or generate a new one
+			id: toast.id || uuidv4(),
 		};
 
 		set((state) => ({
 			toasts: state.toasts ? [...state.toasts, newToast] : [newToast],
 		}));
 
-		// Automatically close the toast after 3000ms
-		setTimeout(() => {
+		const timeoutId = setTimeout(() => {
+			toastTimeouts.delete(newToast.id);
 			useToastStore.getState().closeSingleToast(newToast.id);
 		}, ToastTimeOut);
+
+		toastTimeouts.set(newToast.id, timeoutId);
 	},
-	closeSingleToast: (id: string) =>
+	closeSingleToast: (id: string) => {
+		const timeoutId = toastTimeouts.get(id);
+
+		if (timeoutId !== undefined) {
+			clearTimeout(timeoutId);
+			toastTimeouts.delete(id);
+		}
+
 		set((state) => ({
 			toasts: state.toasts
 				? state.toasts.filter((toast) => toast.id !== id)
 				: null,
-		})),
+		}));
+	},
 	setToastPosition: (position: ToastPositions) => set({ position }),
 }));
 

--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -195,8 +195,13 @@ export default function Page(): ReactElement {
 	};
 
 	const updateSnippetTagList = async (
-		updatedSnippet: Snippet | null = null
+		updatedSnippet: Snippet | null = null,
+		previousTags: Tags = null
 	) => {
+		if (updatedSnippet && updatedSnippet.tags === previousTags) {
+			return;
+		}
+
 		const allSnippets = await getAllSnippets();
 		const updatedSnippetList = updatedSnippet
 			? allSnippets.map((snippet) =>
@@ -230,6 +235,7 @@ export default function Page(): ReactElement {
 				isSaving: true,
 			});
 
+			const previousTags = activeSnippet.tags ?? null;
 			const updatedSnippet = {
 				...currentSnippet,
 				updated_at: new Date().toISOString(),
@@ -246,7 +252,7 @@ export default function Page(): ReactElement {
 				).catch(() => null);
 			}
 
-			updateSnippetTagList(updatedSnippet).then(() => null);
+			updateSnippetTagList(updatedSnippet, previousTags).then(() => null);
 
 			if (fromButton && codeEditorStates.touched) {
 				addToast({


### PR DESCRIPTION
## Summary
Three small perf wins from the audit at \`~/.claude/plans/read-the-entire-code-composed-metcalfe.md\`. Mechanical, no behavioral change.

- **P2 #13** \`updateSnippetTagList\` skips the \`getAllSnippets()\` round-trip when the saved snippet's tags didn't change. Most saves (content/name/notes edits) avoid the network call entirely. \`saveSnippetHandler\` captures pre-save tags from the active snippet and threads them through.
- **P2 #17** Toast store tracks per-toast \`setTimeout\` ids in a Map. Manual dismiss now clears the pending timer so it doesn't fire \`closeSingleToast\` on an already-removed id.
- **P2 #18** Removed the redundant language-sync effect in \`useCurrentSnippet\`. The snippet-switch effect already sets \`currentSnippet.extension\`; the second effect produced a duplicate setState with the same result.

## Test plan
- [ ] Save a snippet with no tag changes — Network tab: no GET to \`snippet\` table after save
- [ ] Save a snippet after adding/removing a tag — Network tab: GET runs, sidebar tag list updates
- [ ] Trigger a success toast and dismiss it manually before the 3s timeout — no second close attempt fires
- [ ] Switch between two snippets with different languages — editor swaps languages cleanly, no flicker
- [ ] Switch between two snippets with the same language — no extra renders
- [ ] \`yarn build\` and \`yarn lint\` pass

## Not in this PR (still on the audit roadmap)
- P1 #6 AI provider keys server-side (AccountModal redesign needed)
- P1 #9 snippet_version cleanup as Postgres trigger (needs supabase/migrations infra)
- P1 #11 demo creds on /login (product decision)
- P1 #7 full CSP headers (browser smoke pass needed)
- P2 #14 SQL-side tag derivation (needs migrations infra)
- P2 #15 wire DB FTS to search input (UX rethink — adds debounce + loading state)
- P2 #16 memoize AiChatModal history rows (negligible gain for typical chat sizes)