### PR TITLE
P1 #6 + F9 — AI keys server-side + Open Graph previews for public snippets

### DIFF
--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -210,10 +210,11 @@ export const POST = async (request: NextRequest): Promise<NextResponse> => {
 			: aiSystemPrompts[action](language || "unknown");
 		const prompt = isAskAction ? (userPrompt as string) : code;
 		const stripFences = !isAskAction;
-		const aiProvider = request.headers.get("x-ai-provider") || "ollama";
-		const aiApiKey = request.headers.get("x-ai-api-key") || "";
-		const aiModel = request.headers.get("x-ai-model") || "";
-		const aiUrl = request.headers.get("x-ai-url") || "";
+		const metadata = user.user_metadata ?? {};
+		const aiProvider = (metadata.ai_provider as string) || "ollama";
+		const aiApiKey = (metadata.ai_api_key as string) || "";
+		const aiModel = (metadata.ai_model as string) || "";
+		const aiUrl = (metadata.ai_url as string) || "";
 
 		// OpenAI provider
 		if (aiProvider === "openai") {

--- a/app/components/CodeEditor/AiChatModal/AiChatModal.tsx
+++ b/app/components/CodeEditor/AiChatModal/AiChatModal.tsx
@@ -232,17 +232,11 @@ const AiChatModal = ({
 		requestAnimationFrame(autosizeTextarea);
 
 		try {
-			const session = await getUserDataFromSession();
-			const metadata = session?.user?.user_metadata;
 			const response = await requestAiAction(
 				action,
 				currentSnippet.snippet,
 				currentSnippet.language,
 				{
-					aiProvider: metadata?.ai_provider,
-					aiApiKey: metadata?.ai_api_key,
-					aiModel: metadata?.ai_model,
-					aiUrl: metadata?.ai_url,
 					userPrompt,
 					signal: controller.signal,
 				}

--- a/app/lib/supabase/public.ts
+++ b/app/lib/supabase/public.ts
@@ -1,0 +1,22 @@
+import { createClient } from "@supabase/supabase-js";
+
+const publicClient = createClient(
+	process.env.NEXT_PUBLIC_SUPABASE_URL || "",
+	process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ""
+);
+
+export const getPublicSnippetBySlug = async (
+	slug: string
+): Promise<Snippet | null> => {
+	if (!slug) return null;
+
+	const { data } = await publicClient
+		.from("snippet")
+		.select()
+		.eq("public_slug", slug)
+		.eq("is_public", true)
+		.neq("state", "inactive")
+		.maybeSingle();
+
+	return data as Snippet | null;
+};

--- a/app/lib/supabase/queries.ts
+++ b/app/lib/supabase/queries.ts
@@ -377,24 +377,6 @@ export const toggleSnippetPublic = async (
 	return slug;
 };
 
-export const getPublicSnippet = async (
-	slug: string
-): Promise<Snippet | null> => {
-	if (supabase && slug) {
-		const { data } = await supabase
-			.from("snippet")
-			.select()
-			.eq("public_slug", slug)
-			.eq("is_public", true)
-			.neq("state", "inactive")
-			.single();
-
-		return data as Snippet | null;
-	}
-
-	return null;
-};
-
 export const updateUser = async (
 	attributes: UserAttributes
 ): Promise<UserResponse> => {

--- a/app/s/[slug]/PublicSnippetView.tsx
+++ b/app/s/[slug]/PublicSnippetView.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { ReactElement, useState } from "react";
+import CodeMirror from "@uiw/react-codemirror";
+
+/* Components */
+import NavHeader from "@/components/NavHeader/NavHeader";
+import Footer from "@/components/Footer/Footer";
+import Badge from "@/components/ui/Badge/Badge";
+import Button from "@/components/ui/Button/Button";
+import Camera from "@/components/ui/icons/Camera";
+import ScreenshotModal from "@/components/ScreenshotModal/ScreenshotModal";
+
+/* Lib and Utils */
+import languageExtensions from "@/lib/codeEditor";
+import { getCodeMirrorTheme, ThemeNames } from "@/lib/config/themes";
+import SupportedLanguages from "@/lib/config/languages";
+
+/* Styles */
+import styles from "./publicSnippet.module.css";
+
+type Props = {
+	snippet: Snippet | null;
+};
+
+export default function PublicSnippetView({ snippet }: Props): ReactElement {
+	const [screenshotModalOpen, setScreenshotModalOpen] = useState(false);
+
+	const editorTheme = getCodeMirrorTheme(ThemeNames.Dracula);
+	const extension =
+		languageExtensions[snippet?.language ?? SupportedLanguages.Markdown];
+	const tagList =
+		snippet?.tags && snippet.tags.length > 0 ? snippet.tags.split(",") : [];
+
+	if (!snippet) {
+		return (
+			<main className={styles.main}>
+				<NavHeader />
+				<div className={styles.container}>
+					<h1 className={styles.errorTitle}>Snippet not found</h1>
+					<p className={styles.errorText}>
+						This snippet may have been removed or made private.
+					</p>
+				</div>
+				<Footer />
+			</main>
+		);
+	}
+
+	return (
+		<main className={styles.main}>
+			<NavHeader />
+			<div className={styles.container}>
+				<div className={styles.header}>
+					<h1 className={styles.title}>{snippet.name}</h1>
+
+					<div className={styles.headerActions}>
+						<span className={styles.language}>{snippet.language}</span>
+
+						<Button
+							className={styles.screenshotButton}
+							variant="secondary"
+							onClick={() => setScreenshotModalOpen(true)}
+						>
+							<Camera height={15} width={15} />
+							Screenshot
+						</Button>
+					</div>
+				</div>
+
+				{tagList.length > 0 && (
+					<div className={styles.tags}>
+						{tagList.map((tag, index) => (
+							<Badge key={`${index}-public-tag`}>{tag.trim()}</Badge>
+						))}
+					</div>
+				)}
+
+				{snippet.notes && <p className={styles.notes}>{snippet.notes}</p>}
+
+				<div className={styles.editor}>
+					<CodeMirror
+						value={snippet.snippet}
+						extensions={extension ? [extension] : []}
+						theme={editorTheme}
+						readOnly={true}
+						basicSetup={{ lineNumbers: true, foldGutter: false }}
+						height="auto"
+					/>
+				</div>
+
+				{snippet.url && (
+					<a
+						className={styles.sourceUrl}
+						href={snippet.url}
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Source: {snippet.url}
+					</a>
+				)}
+			</div>
+
+			<ScreenshotModal
+				isOpen={screenshotModalOpen}
+				snippet={snippet}
+				onClose={() => setScreenshotModalOpen(false)}
+			/>
+
+			<Footer />
+		</main>
+	);
+}

--- a/app/s/[slug]/opengraph-image.tsx
+++ b/app/s/[slug]/opengraph-image.tsx
@@ -1,0 +1,136 @@
+import { ImageResponse } from "next/og";
+
+import { getPublicSnippetBySlug } from "@/lib/supabase/public";
+
+export const alt = "Snippet preview";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+type Props = {
+	params: Promise<{ slug: string }>;
+};
+
+const previewLines = 8;
+const previewLineMaxLength = 70;
+
+const buildCodePreview = (code: string): string =>
+	code
+		.split("\n")
+		.slice(0, previewLines)
+		.map((line) =>
+			line.length > previewLineMaxLength
+				? `${line.slice(0, previewLineMaxLength)}…`
+				: line
+		)
+		.join("\n");
+
+export default async function Image({ params }: Props): Promise<ImageResponse> {
+	const { slug } = await params;
+	const snippet = await getPublicSnippetBySlug(slug);
+
+	if (!snippet) {
+		return new ImageResponse(
+			<div
+				style={{
+					width: "100%",
+					height: "100%",
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					background: "#1e1e2e",
+					color: "#cdd6f4",
+					fontSize: 56,
+					fontFamily: "sans-serif",
+				}}
+			>
+				Snippet not found
+			</div>,
+			size
+		);
+	}
+
+	const preview = buildCodePreview(snippet.snippet);
+
+	return new ImageResponse(
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				background: "linear-gradient(135deg, #1e1e2e 0%, #313244 100%)",
+				color: "#cdd6f4",
+				padding: 64,
+				fontFamily: "sans-serif",
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+					marginBottom: 24,
+				}}
+			>
+				<div
+					style={{
+						fontSize: 56,
+						fontWeight: 700,
+						color: "#ffffff",
+						display: "flex",
+						maxWidth: 900,
+						overflow: "hidden",
+					}}
+				>
+					{snippet.name.slice(0, 60)}
+				</div>
+				<div
+					style={{
+						fontSize: 22,
+						color: "#1e1e2e",
+						background: "#89b4fa",
+						padding: "8px 18px",
+						borderRadius: 999,
+						display: "flex",
+						fontWeight: 600,
+					}}
+				>
+					{snippet.language}
+				</div>
+			</div>
+
+			<div
+				style={{
+					flex: 1,
+					background: "rgba(0, 0, 0, 0.45)",
+					borderRadius: 18,
+					padding: 36,
+					fontSize: 26,
+					lineHeight: 1.45,
+					color: "#a6e3a1",
+					fontFamily: "monospace",
+					whiteSpace: "pre",
+					overflow: "hidden",
+					display: "flex",
+				}}
+			>
+				{preview}
+			</div>
+
+			<div
+				style={{
+					display: "flex",
+					justifyContent: "space-between",
+					alignItems: "center",
+					marginTop: 28,
+					fontSize: 22,
+					color: "#7f849c",
+				}}
+			>
+				<div style={{ display: "flex" }}>snippets.vianch.com</div>
+				<div style={{ display: "flex" }}>/s/{slug}</div>
+			</div>
+		</div>,
+		size
+	);
+}

--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -1,162 +1,61 @@
-"use client";
+import { ReactElement } from "react";
+import { Metadata } from "next";
 
-import { ReactElement, useEffect, useState, use } from "react";
-import CodeMirror from "@uiw/react-codemirror";
-
-/* Components */
-import NavHeader from "@/components/NavHeader/NavHeader";
-import Footer from "@/components/Footer/Footer";
-import Badge from "@/components/ui/Badge/Badge";
-import Button from "@/components/ui/Button/Button";
-import Camera from "@/components/ui/icons/Camera";
-import ScreenshotModal from "@/components/ScreenshotModal/ScreenshotModal";
-
-/* Lib and Utils */
-import languageExtensions from "@/lib/codeEditor";
-import { getCodeMirrorTheme, ThemeNames } from "@/lib/config/themes";
-import { getPublicSnippet } from "@/lib/supabase/queries";
-import SupportedLanguages from "@/lib/config/languages";
-
-/* Styles */
-import styles from "./publicSnippet.module.css";
+import { getPublicSnippetBySlug } from "@/lib/supabase/public";
+import PublicSnippetView from "./PublicSnippetView";
 
 type PageProps = {
 	params: Promise<{ slug: string }>;
 };
 
-export default function PublicSnippetPage({ params }: PageProps): ReactElement {
-	const { slug } = use(params);
-	const [snippet, setSnippet] = useState<Snippet | null>(null);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState(false);
-	const [screenshotModalOpen, setScreenshotModalOpen] = useState(false);
-
-	useEffect(() => {
-		let isMounted = true;
-
-		const fetchSnippet = async () => {
-			try {
-				const data = await getPublicSnippet(slug);
-
-				if (!isMounted) return;
-
-				if (data) {
-					setSnippet(data);
-				} else {
-					setError(true);
-				}
-			} catch {
-				if (isMounted) {
-					setError(true);
-				}
-			}
-
-			if (isMounted) {
-				setLoading(false);
-			}
-		};
-
-		fetchSnippet();
-
-		return () => {
-			isMounted = false;
-		};
-	}, [slug]);
-
-	const editorTheme = getCodeMirrorTheme(ThemeNames.Dracula);
-	const extension =
-		languageExtensions[snippet?.language ?? SupportedLanguages.Markdown];
-	const tagList =
-		snippet?.tags && snippet.tags.length > 0 ? snippet.tags.split(",") : [];
-
-	if (loading) {
-		return (
-			<main className={styles.main}>
-				<NavHeader />
-				<div className={styles.container}>
-					<p className={styles.loading}>Loading snippet...</p>
-				</div>
-				<Footer />
-			</main>
-		);
+const buildDescription = (snippet: Snippet): string => {
+	if (snippet.notes && snippet.notes.trim().length > 0) {
+		return snippet.notes.slice(0, 160);
 	}
 
-	if (error || !snippet) {
-		return (
-			<main className={styles.main}>
-				<NavHeader />
-				<div className={styles.container}>
-					<h1 className={styles.errorTitle}>Snippet not found</h1>
-					<p className={styles.errorText}>
-						This snippet may have been removed or made private.
-					</p>
-				</div>
-				<Footer />
-			</main>
-		);
+	const firstLine = snippet.snippet.split("\n").find((line) => line.trim());
+
+	return firstLine
+		? firstLine.slice(0, 160)
+		: `A ${snippet.language} snippet shared via Snippets`;
+};
+
+export async function generateMetadata({
+	params,
+}: PageProps): Promise<Metadata> {
+	const { slug } = await params;
+	const snippet = await getPublicSnippetBySlug(slug);
+
+	if (!snippet) {
+		return {
+			title: "Snippet not found",
+			robots: { index: false, follow: false },
+		};
 	}
 
-	return (
-		<main className={styles.main}>
-			<NavHeader />
-			<div className={styles.container}>
-				<div className={styles.header}>
-					<h1 className={styles.title}>{snippet.name}</h1>
+	const description = buildDescription(snippet);
 
-					<div className={styles.headerActions}>
-						<span className={styles.language}>{snippet.language}</span>
+	return {
+		title: `${snippet.name} — Snippets`,
+		description,
+		openGraph: {
+			title: snippet.name,
+			description,
+			type: "article",
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: snippet.name,
+			description,
+		},
+	};
+}
 
-						<Button
-							className={styles.screenshotButton}
-							variant="secondary"
-							onClick={() => setScreenshotModalOpen(true)}
-						>
-							<Camera height={15} width={15} />
-							Screenshot
-						</Button>
-					</div>
-				</div>
+export default async function PublicSnippetPage({
+	params,
+}: PageProps): Promise<ReactElement> {
+	const { slug } = await params;
+	const snippet = await getPublicSnippetBySlug(slug);
 
-				{tagList.length > 0 && (
-					<div className={styles.tags}>
-						{tagList.map((tag, index) => (
-							<Badge key={`${index}-public-tag`}>{tag.trim()}</Badge>
-						))}
-					</div>
-				)}
-
-				{snippet.notes && <p className={styles.notes}>{snippet.notes}</p>}
-
-				<div className={styles.editor}>
-					<CodeMirror
-						value={snippet.snippet}
-						extensions={extension ? [extension] : []}
-						theme={editorTheme}
-						readOnly={true}
-						basicSetup={{ lineNumbers: true, foldGutter: false }}
-						height="auto"
-					/>
-				</div>
-
-				{snippet.url && (
-					<a
-						className={styles.sourceUrl}
-						href={snippet.url}
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Source: {snippet.url}
-					</a>
-				)}
-			</div>
-
-			<ScreenshotModal
-				isOpen={screenshotModalOpen}
-				snippet={snippet}
-				onClose={() => setScreenshotModalOpen(false)}
-			/>
-
-			<Footer />
-		</main>
-	);
+	return <PublicSnippetView snippet={snippet} />;
 }

--- a/app/utils/ai.utils.ts
+++ b/app/utils/ai.utils.ts
@@ -52,10 +52,6 @@ export const fetchOllamaModels = async (
 };
 
 type RequestAiActionOptions = {
-	aiProvider?: AiProvider;
-	aiApiKey?: string;
-	aiModel?: string;
-	aiUrl?: string;
 	userPrompt?: string;
 	signal?: AbortSignal;
 };
@@ -66,30 +62,13 @@ export const requestAiAction = async (
 	language: string,
 	options: RequestAiActionOptions = {}
 ): Promise<AiResponse> => {
-	const { aiProvider, aiApiKey, aiModel, aiUrl, userPrompt, signal } = options;
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-	};
-
-	if (aiProvider) {
-		headers["x-ai-provider"] = aiProvider;
-	}
-
-	if (aiApiKey) {
-		headers["x-ai-api-key"] = aiApiKey;
-	}
-
-	if (aiModel) {
-		headers["x-ai-model"] = aiModel;
-	}
-
-	if (aiUrl) {
-		headers["x-ai-url"] = aiUrl;
-	}
+	const { userPrompt, signal } = options;
 
 	const response = await fetch("/api/ai", {
 		method: "POST",
-		headers,
+		headers: {
+			"Content-Type": "application/json",
+		},
 		body: JSON.stringify({ action, code, language, userPrompt }),
 		signal,
 	});


### PR DESCRIPTION
## Summary
Two independent commits — a security fix and the first marketing-surface feature from the audit roadmap.

### \`4e79800\` fix: P1 #6 — AI provider key never leaves the server
- \`/api/ai\` now reads \`aiProvider\` / \`aiApiKey\` / \`aiModel\` / \`aiUrl\` from \`user.user_metadata\` server-side instead of trusting \`x-ai-*\` request headers.
- \`requestAiAction\`'s options type was narrowed to \`{ userPrompt, signal }\` so callers physically can't send a key.
- \`AiChatModal\` no longer fetches user metadata before every chat request.
- \`/api/ai/models\` is intentionally untouched — AccountModal's "test connection before save" flow still needs to send a freshly-typed key.

### \`2e39727\` feat: F9 — Open Graph preview images for public snippets
- New \`app/s/[slug]/opengraph-image.tsx\` — Next OG convention route rendering a 1200×630 \`ImageResponse\` (snippet name, language badge, first 8 lines of code on the Dracula-inspired gradient).
- \`app/s/[slug]/page.tsx\` converted from a client to an async server component with \`generateMetadata\` emitting title / description / \`og:*\` / Twitter card tags. Snippet body is now fetched server-side, so the public page no longer renders a loading spinner.
- New client extraction at \`app/s/[slug]/PublicSnippetView.tsx\` keeps the screenshot modal and CodeMirror render exactly as they were.
- New \`app/lib/supabase/public.ts\` — server-side anon-key client used by both the page and the OG route. RLS on the public read path is still the only access gate.
- Removed unused \`getPublicSnippet\` from \`queries.ts\`.

## Test plan
**P1 #6**
- [ ] Open the AI side drawer → Explain → response succeeds
- [ ] DevTools Network → POST /api/ai → no \`x-ai-*\` headers in the request
- [ ] AccountModal: saving a new Claude/OpenAI key still surfaces the models dropdown
- [ ] POST /api/ai without auth → 401

**F9**
- [ ] Make a snippet public, copy /s/<slug>, paste in Slack / Twitter / iMessage → preview card shows snippet name, language, first lines
- [ ] \`curl -s https://<preview>/s/<slug>/opengraph-image\` → PNG returned, 1200×630
- [ ] View source on /s/<slug> → see \`<meta property="og:title">\`, \`og:description\`, \`og:image\`, Twitter card tags
- [ ] /s/<slug> for a non-existent slug → OG image shows "Snippet not found"; page shows existing error state
- [ ] Public page no longer flashes "Loading snippet..." (SSR)
- [ ] \`yarn build\` and \`yarn lint\` pass

## Known limitations
- OG images are cached by social platforms / CDNs. If you make a snippet private after it's been shared, the cached preview can persist until those caches expire. Standard OG behavior; out of scope here.
- Iframe-embeddable read-only view from the audit's F9 description is intentionally deferred — different URL shape, different auth model. Worth a follow-up.

## Not in this PR
- AccountModal masking the displayed AI key value (UX polish)
- \`/api/ai/models\` server-side metadata fallback (would break test-before-save flow)