### PR TITLE
feat: F1 — Cmd+K command palette

### DIFF
--- a/app/components/CommandPalette/CommandPalette.tsx
+++ b/app/components/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { ReactElement, useEffect, useState } from "react";
+import { Command } from "cmdk";
+
+/* Components */
+import Book from "@/components/ui/icons/Book";
+import Tray from "@/components/ui/icons/Tray";
+import Globe from "@/components/ui/icons/Globe";
+import Star from "@/components/ui/icons/Star";
+import Trash from "@/components/ui/icons/Trash";
+import Bookmark from "@/components/ui/icons/Bookmark";
+import Settings from "@/components/ui/icons/Settings";
+import NewFile from "@/components/ui/icons/NewFile";
+import LanguageBadge from "@/components/ui/LanguageBadge/LanguageBadge";
+
+/* Styles */
+import styles from "./commandPalette.module.css";
+
+type CommandPaletteProps = {
+	snippets: Snippet[];
+	tags: TagItem[];
+	onActiveSnippet: (snippetId: UUID) => void;
+	onNewSnippet: () => void;
+	onGetAll: () => void;
+	onGetUncategorized: () => void;
+	onGetPublic: () => void;
+	onGetFavorites: () => void;
+	onGetTrash: () => void;
+	onTagClick: (tag: string) => void;
+	onAccountClick: () => void;
+};
+
+const CommandPalette = ({
+	snippets,
+	tags,
+	onActiveSnippet,
+	onNewSnippet,
+	onGetAll,
+	onGetUncategorized,
+	onGetPublic,
+	onGetFavorites,
+	onGetTrash,
+	onTagClick,
+	onAccountClick,
+}: CommandPaletteProps): ReactElement => {
+	const [open, setOpen] = useState(false);
+
+	useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent): void => {
+			if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+				event.preventDefault();
+				setOpen((current) => !current);
+			}
+		};
+
+		document.addEventListener("keydown", handleKeyDown);
+
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, []);
+
+	const runAction = (action: () => void): void => {
+		setOpen(false);
+		action();
+	};
+
+	return (
+		<Command.Dialog
+			open={open}
+			onOpenChange={setOpen}
+			label="Command palette"
+			className={styles.dialog}
+			overlayClassName={styles.overlay}
+			contentClassName={styles.content}
+		>
+			<Command.Input
+				placeholder="Search snippets, run a command..."
+				className={styles.input}
+			/>
+
+			<Command.List className={styles.list}>
+				<Command.Empty className={styles.empty}>
+					No results found.
+				</Command.Empty>
+
+				<Command.Group heading="Actions" className={styles.group}>
+					<Command.Item
+						className={styles.item}
+						onSelect={() => runAction(onNewSnippet)}
+					>
+						<NewFile width={16} height={16} />
+						<span>New snippet</span>
+					</Command.Item>
+					<Command.Item
+						className={styles.item}
+						onSelect={() => runAction(onAccountClick)}
+					>
+						<Settings width={16} height={16} />
+						<span>Open settings</span>
+					</Command.Item>
+				</Command.Group>
+
+				<Command.Group heading="Navigate" className={styles.group}>
+					<Command.Item
+						className={styles.item}
+						onSelect={() => runAction(onGetAll)}
+					>
+						<Book width={16} height={16} />
+						<span>All snippets</span>
+					</Command.Item>
+					<Command.Item
+						className={styles.item}
+						onSelect={() => runAction(onGetUncategorized)}
+					>
+						<Tray width={16} height={16} />
+						<span>Uncategorized</span>
+					</Command.Item>
+					<Command.Item
+						className={styles.item}
+						onSelect={() => runAction(onGetPublic)}
+					>
+						<Globe width={16} height={16} />
+						<span>Public</span>
+					</Command.Item>
+					<Command.Item
+						className={styles.item}
+						onSelect={() => runAction(onGetFavorites)}
+					>
+						<Star width={16} height={16} />
+						<span>Favorites</span>
+					</Command.Item>
+					<Command.Item
+						className={styles.item}
+						onSelect={() => runAction(onGetTrash)}
+					>
+						<Trash width={16} height={16} />
+						<span>Trash</span>
+					</Command.Item>
+				</Command.Group>
+
+				{tags.length > 0 && (
+					<Command.Group heading="Tags" className={styles.group}>
+						{tags.map((tag) => (
+							<Command.Item
+								key={tag.name}
+								value={`tag-${tag.name}`}
+								className={styles.item}
+								onSelect={() => runAction(() => onTagClick(tag.name))}
+							>
+								<Bookmark width={16} height={16} />
+								<span>{tag.name}</span>
+								<span className={styles.count}>{tag.total}</span>
+							</Command.Item>
+						))}
+					</Command.Group>
+				)}
+
+				{snippets.length > 0 && (
+					<Command.Group heading="Jump to snippet" className={styles.group}>
+						{snippets.map((snippet) => (
+							<Command.Item
+								key={snippet.snippet_id}
+								value={`snippet-${snippet.snippet_id}-${snippet.name}`}
+								className={styles.item}
+								onSelect={() =>
+									runAction(() => onActiveSnippet(snippet.snippet_id))
+								}
+							>
+								<span className={styles.snippetName}>
+									{snippet.name || "Untitled"}
+								</span>
+								<LanguageBadge language={snippet.language} />
+							</Command.Item>
+						))}
+					</Command.Group>
+				)}
+			</Command.List>
+
+			<div className={styles.footer}>
+				<kbd className={styles.kbd}>↑↓</kbd>
+				<span>navigate</span>
+				<kbd className={styles.kbd}>↵</kbd>
+				<span>select</span>
+				<kbd className={styles.kbd}>esc</kbd>
+				<span>close</span>
+			</div>
+		</Command.Dialog>
+	);
+};
+
+export default CommandPalette;

--- a/app/components/CommandPalette/commandPalette.module.css
+++ b/app/components/CommandPalette/commandPalette.module.css
@@ -1,0 +1,152 @@
+.overlay {
+	position: fixed;
+	inset: 0;
+	background-color: rgb(0 0 0 / 55%);
+	backdrop-filter: blur(2px);
+	z-index: 1000;
+	animation: fade-in 120ms ease-out;
+}
+
+.content {
+	position: fixed;
+	top: 18vh;
+	left: 50%;
+	transform: translateX(-50%);
+	width: min(92vw, 640px);
+	max-height: 70vh;
+	z-index: 1001;
+	display: flex;
+	flex-direction: column;
+	background: var(--color-background-elevated, #1e1e2e);
+	border: 1px solid var(--color-border, #45475a);
+	border-radius: 12px;
+	box-shadow: 0 20px 50px rgb(0 0 0 / 40%);
+	overflow: hidden;
+	animation: pop-in 140ms ease-out;
+}
+
+.dialog {
+	outline: none;
+}
+
+.input {
+	width: 100%;
+	padding: 16px 20px;
+	border: none;
+	border-bottom: 1px solid var(--color-border, #45475a);
+	background: transparent;
+	color: var(--color-text, #cdd6f4);
+	font-size: 15px;
+	font-family: inherit;
+	outline: none;
+}
+
+.input::placeholder {
+	color: var(--color-text-muted, #7f849c);
+}
+
+.list {
+	flex: 1;
+	overflow-y: auto;
+	padding: 8px;
+	scroll-padding-block: 8px;
+}
+
+.empty {
+	padding: 32px 16px;
+	text-align: center;
+	color: var(--color-text-muted, #7f849c);
+	font-size: 14px;
+}
+
+.group {
+	margin-bottom: 8px;
+}
+
+.group [cmdk-group-heading] {
+	padding: 8px 12px 4px;
+	font-size: 11px;
+	font-weight: 600;
+	color: var(--color-text-muted, #7f849c);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.item {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 9px 12px;
+	border-radius: 6px;
+	color: var(--color-text, #cdd6f4);
+	font-size: 14px;
+	cursor: pointer;
+	user-select: none;
+}
+
+.item[data-selected="true"] {
+	background: var(--color-background-hover, #313244);
+}
+
+.item:hover {
+	background: var(--color-background-hover, #313244);
+}
+
+.snippetName {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.count {
+	margin-left: auto;
+	font-size: 12px;
+	color: var(--color-text-muted, #7f849c);
+}
+
+.footer {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 10px 16px;
+	border-top: 1px solid var(--color-border, #45475a);
+	font-size: 12px;
+	color: var(--color-text-muted, #7f849c);
+}
+
+.kbd {
+	padding: 2px 6px;
+	border: 1px solid var(--color-border, #45475a);
+	border-radius: 4px;
+	background: var(--color-background, #181825);
+	font-family: inherit;
+	font-size: 11px;
+	color: var(--color-text, #cdd6f4);
+}
+
+.footer span:not(:last-child) {
+	margin-right: 8px;
+}
+
+@keyframes fade-in {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes pop-in {
+	from {
+		opacity: 0;
+		transform: translateX(-50%) scale(0.96);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateX(-50%) scale(1);
+	}
+}

--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -8,6 +8,7 @@ import SnippetList from "@/components/SnippetList/SnippetList";
 import CodeEditor from "@/components/CodeEditor/CodeEditor";
 import ResizableLayout from "@/components/ResizableLayout/ResizableLayout";
 import AccountModal from "@/components/AccountModal/AccountModal";
+import CommandPalette from "@/components/CommandPalette/CommandPalette";
 
 /* Lib and Utils */
 import {
@@ -17,6 +18,7 @@ import {
 	getUncategorizedSnippets,
 	saveSnippet,
 	saveSnippetVersion,
+	setNewSnippet,
 	trashRestoreSnippet,
 } from "@/lib/supabase/queries";
 import sortSnippetsByUpdatedAt from "@/utils/array.utils";
@@ -462,6 +464,14 @@ export default function Page(): ReactElement {
 		setIsAccountModalOpen(false);
 	};
 
+	const createSnippetFromPalette = async (): Promise<void> => {
+		const newSnippet = await setNewSnippet();
+
+		if (newSnippet) {
+			newSnippetHandler(newSnippet);
+		}
+	};
+
 	useEffect(() => {
 		getSnippets().then(() => null);
 	}, []);
@@ -533,6 +543,19 @@ export default function Page(): ReactElement {
 			<AccountModal
 				isOpen={isAccountModalOpen}
 				onClose={handleAccountModalClose}
+			/>
+			<CommandPalette
+				snippets={snippets}
+				tags={tags}
+				onActiveSnippet={setActiveSnippetId}
+				onNewSnippet={createSnippetFromPalette}
+				onGetAll={getSnippetsHandler}
+				onGetUncategorized={getUncategorizedHandler}
+				onGetPublic={getPublicHandler}
+				onGetFavorites={getFavoritesHandler}
+				onGetTrash={getTrashHandler}
+				onTagClick={getSnippetsByTagHandler}
+				onAccountClick={handleAccountClick}
 			/>
 		</>
 	);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"@uiw/codemirror-themes": "^4.25.8",
 		"@uiw/react-codemirror": "^4.25.8",
 		"@vercel/analytics": "^2.0.1",
+		"cmdk": "^1.1.1",
 		"html-to-image": "^1.11.13",
 		"isomorphic-dompurify": "^3.13.0",
 		"marked": "^17.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,6 +1023,149 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@radix-ui/primitive@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.3.tgz#e2dbc13bdc5e4168f4334f75832d7bdd3e2de5ba"
+  integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
+
+"@radix-ui/react-compose-refs@1.1.2", "@radix-ui/react-compose-refs@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
+  integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
+
+"@radix-ui/react-context@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"
+  integrity sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==
+
+"@radix-ui/react-dialog@^1.1.6":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz#1de3d7a7e9a17a9874d29c07f5940a18a119b632"
+  integrity sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.11"
+    "@radix-ui/react-focus-guards" "1.1.3"
+    "@radix-ui/react-focus-scope" "1.1.7"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-portal" "1.1.9"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.6.3"
+
+"@radix-ui/react-dismissable-layer@1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz#e33ab6f6bdaa00f8f7327c408d9f631376b88b37"
+  integrity sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-escape-keydown" "1.1.1"
+
+"@radix-ui/react-focus-guards@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz#2a5669e464ad5fde9f86d22f7fdc17781a4dfa7f"
+  integrity sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==
+
+"@radix-ui/react-focus-scope@1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz#dfe76fc103537d80bf42723a183773fd07bfb58d"
+  integrity sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+
+"@radix-ui/react-id@1.1.1", "@radix-ui/react-id@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.1.tgz#1404002e79a03fe062b7e3864aa01e24bd1471f7"
+  integrity sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-portal@1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.9.tgz#14c3649fe48ec474ac51ed9f2b9f5da4d91c4472"
+  integrity sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-presence@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.5.tgz#5d8f28ac316c32f078afce2996839250c10693db"
+  integrity sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-primitive@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz#db9b8bcff49e01be510ad79893fb0e4cda50f1bc"
+  integrity sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==
+  dependencies:
+    "@radix-ui/react-slot" "1.2.3"
+
+"@radix-ui/react-primitive@^2.0.2":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz#2626ea309ebd63bf5767d3e7fc4081f81b993df0"
+  integrity sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==
+  dependencies:
+    "@radix-ui/react-slot" "1.2.4"
+
+"@radix-ui/react-slot@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"
+  integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+
+"@radix-ui/react-slot@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.4.tgz#63c0ba05fdf90cc49076b94029c852d7bac1fb83"
+  integrity sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+
+"@radix-ui/react-use-callback-ref@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
+  integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
+
+"@radix-ui/react-use-controllable-state@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz#905793405de57d61a439f4afebbb17d0645f3190"
+  integrity sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==
+  dependencies:
+    "@radix-ui/react-use-effect-event" "0.0.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-use-effect-event@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz#090cf30d00a4c7632a15548512e9152217593907"
+  integrity sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-use-escape-keydown@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz#b3fed9bbea366a118f40427ac40500aa1423cc29"
+  integrity sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+
+"@radix-ui/react-use-layout-effect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
+  integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
@@ -1539,6 +1682,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-hidden@^1.2.4:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.6.tgz#73051c9b088114c795b1ea414e9c0fff874ffc1a"
+  integrity sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==
+  dependencies:
+    tslib "^2.0.0"
+
 aria-query@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
@@ -1822,6 +1972,16 @@ client-only@0.0.1:
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
+cmdk@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-1.1.1.tgz#b8524272699ccaa37aaf07f36850b376bf3d58e5"
+  integrity sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==
+  dependencies:
+    "@radix-ui/react-compose-refs" "^1.1.1"
+    "@radix-ui/react-dialog" "^1.1.6"
+    "@radix-ui/react-id" "^1.1.0"
+    "@radix-ui/react-primitive" "^2.0.2"
+
 codemirror@^6.0.0:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.2.tgz#4d3fea1ad60b6753f97ca835f2f48c6936a8946e"
@@ -2020,6 +2180,11 @@ detect-libc@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 devlop@^1.0.0:
   version "1.1.0"
@@ -2648,6 +2813,11 @@ get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@
     has-symbols "^1.1.0"
     hasown "^2.0.2"
     math-intrinsics "^1.1.0"
+
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-proto@^1.0.0, get-proto@^1.0.1:
   version "1.0.1"
@@ -3820,6 +3990,33 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-remove-scroll-bar@^2.3.7:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
+  dependencies:
+    react-style-singleton "^2.2.2"
+    tslib "^2.0.0"
+
+react-remove-scroll@^2.6.3:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz#6442da56791117661978ae99cd29be9026fecca0"
+  integrity sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==
+  dependencies:
+    react-remove-scroll-bar "^2.3.7"
+    react-style-singleton "^2.2.3"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.3"
+    use-sidecar "^1.1.3"
+
+react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
+  dependencies:
+    get-nonce "^1.0.0"
+    tslib "^2.0.0"
+
 react@^19.2.0:
   version "19.2.6"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.6.tgz#3dadb8e12b2a7934c1d5317973e5dce1301f9a4d"
@@ -4480,7 +4677,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.8.1, tslib@^2.4.0, tslib@^2.8.0:
+tslib@2.8.1, tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -4651,6 +4848,21 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-callback-ref@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
+  dependencies:
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.3.tgz#10e7fd897d130b896e2c546c63a5e8233d00efdb"
+  integrity sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary
Adds the Linear/Vercel-style command palette from the audit feature list (F1). Closes the highest daily-use ROI item among the remaining feature ideas — one keyboard surface replaces clicks through the sidebar.

## Behavior
- **Cmd+K** (macOS) / **Ctrl+K** (Win/Linux) toggles the palette. Escape and click-outside close it.
- Fuzzy search across:
  - **Jump to snippet** — every snippet by name
  - **Tags** — every tag with its count
  - **Navigate** — All / Uncategorized / Public / Favorites / Trash
  - **Actions** — New snippet, Open settings
- Selecting an item runs its handler and closes the palette.

## Files
- \`app/components/CommandPalette/CommandPalette.tsx\` — cmdk-based \`Command.Dialog\` with a global Cmd+K listener.
- \`app/components/CommandPalette/commandPalette.module.css\` — themed dialog, dark surface, kbd footer.
- \`app/snippets/page.tsx\` — mounts \`<CommandPalette>\` alongside \`<AccountModal>\`. Adds \`createSnippetFromPalette\` to glue \`setNewSnippet\` + \`newSnippetHandler\` so the palette can create without duplicating SnippetList's flow.
- \`cmdk\` added to dependencies.

## Test plan
- [ ] On /snippets, press **Cmd+K** → palette opens centered, focused on the input
- [ ] Type a snippet name → it filters; Enter → editor jumps to that snippet
- [ ] Type a tag name → tag filter applies and the list updates
- [ ] Type "favorites" / "trash" / "public" → menu navigates
- [ ] Type "new" → new snippet created and selected
- [ ] Type "settings" → AccountModal opens
- [ ] **Escape** closes the palette; click outside also closes
- [ ] **Cmd+K** with palette open → palette closes (toggle)
- [ ] Verify no conflict with **Cmd+,** (settings shortcut in Aside) or **Cmd+S** (save in CodeEditor)
- [ ] \`yarn build\` and \`yarn lint\` pass

## Not in this PR (deferred per audit feature ideas)
- F2 wiki-links between snippets (medium scope, biggest moat feature)
- F3 multi-file AI agent mode (large, needs embeddings)
- F4 inline AI completions / ghost text (medium, CodeMirror extension)
- F5 in-place markdown rendering (medium)
- F6 Mermaid/LaTeX diagrams (small, Mermaid already in lockfile)
- F7 Raycast/Alfred companion (separate extension repo)
- F8 real-time collab (large, CRDT infra)
- F10 folders / smart groups (medium, DB schema)