### PR TITLE
fix: command palette uses project theme variables

### DIFF
--- a/app/components/CommandPalette/commandPalette.module.css
+++ b/app/components/CommandPalette/commandPalette.module.css
@@ -17,9 +17,10 @@
 	z-index: 1001;
 	display: flex;
 	flex-direction: column;
-	background: var(--color-background-elevated, #1e1e2e);
-	border: 1px solid var(--color-border, #45475a);
-	border-radius: 12px;
+	background: var(--bg-color-dark);
+	color: var(--foreground-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-lg);
 	box-shadow: 0 20px 50px rgb(0 0 0 / 40%);
 	overflow: hidden;
 	animation: pop-in 140ms ease-out;
@@ -33,16 +34,16 @@
 	width: 100%;
 	padding: 16px 20px;
 	border: none;
-	border-bottom: 1px solid var(--color-border, #45475a);
-	background: transparent;
-	color: var(--color-text, #cdd6f4);
-	font-size: 15px;
+	border-bottom: 1px solid var(--border-color);
+	background: var(--bg-color);
+	color: var(--foreground-color);
+	font-size: var(--normal-font-size);
 	font-family: inherit;
 	outline: none;
 }
 
 .input::placeholder {
-	color: var(--color-text-muted, #7f849c);
+	color: var(--comment-color);
 }
 
 .list {
@@ -50,13 +51,14 @@
 	overflow-y: auto;
 	padding: 8px;
 	scroll-padding-block: 8px;
+	background: var(--bg-color-dark);
 }
 
 .empty {
 	padding: 32px 16px;
 	text-align: center;
-	color: var(--color-text-muted, #7f849c);
-	font-size: 14px;
+	color: var(--comment-color);
+	font-size: var(--small-font-size);
 }
 
 .group {
@@ -65,9 +67,9 @@
 
 .group [cmdk-group-heading] {
 	padding: 8px 12px 4px;
-	font-size: 11px;
+	font-size: var(--tiny-font-size);
 	font-weight: 600;
-	color: var(--color-text-muted, #7f849c);
+	color: var(--comment-color);
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
 }
@@ -77,19 +79,16 @@
 	align-items: center;
 	gap: 12px;
 	padding: 9px 12px;
-	border-radius: 6px;
-	color: var(--color-text, #cdd6f4);
-	font-size: 14px;
+	border-radius: var(--border-radius-md);
+	color: var(--foreground-color);
+	font-size: var(--small-font-size);
 	cursor: pointer;
 	user-select: none;
 }
 
-.item[data-selected="true"] {
-	background: var(--color-background-hover, #313244);
-}
-
+.item[data-selected="true"],
 .item:hover {
-	background: var(--color-background-hover, #313244);
+	background: var(--current-line);
 }
 
 .snippetName {
@@ -101,8 +100,8 @@
 
 .count {
 	margin-left: auto;
-	font-size: 12px;
-	color: var(--color-text-muted, #7f849c);
+	font-size: var(--tiny-font-size);
+	color: var(--comment-color);
 }
 
 .footer {
@@ -110,19 +109,20 @@
 	align-items: center;
 	gap: 6px;
 	padding: 10px 16px;
-	border-top: 1px solid var(--color-border, #45475a);
-	font-size: 12px;
-	color: var(--color-text-muted, #7f849c);
+	border-top: 1px solid var(--border-color);
+	background: var(--bg-color);
+	font-size: var(--tiny-font-size);
+	color: var(--comment-color);
 }
 
 .kbd {
 	padding: 2px 6px;
-	border: 1px solid var(--color-border, #45475a);
-	border-radius: 4px;
-	background: var(--color-background, #181825);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	background: var(--bg-color-dark);
 	font-family: inherit;
-	font-size: 11px;
-	color: var(--color-text, #cdd6f4);
+	font-size: var(--tiny-font-size);
+	color: var(--foreground-color);
 }
 
 .footer span:not(:last-child) {


### PR DESCRIPTION
## Summary
The palette CSS referenced made-up CSS variable names (\`--color-background-elevated\`, \`--color-border\`, \`--color-text\`, etc.) that don't exist in \`app/globals.css\`. Every browser fell through to the hardcoded Dracula-tinted fallbacks, so all six themes (Catppuccin Latte / Ayu Light / GitHub Light / Shades of Purple / GitHub Dark / Dracula) rendered the palette with the same dark surface and ignored the user's preference.

Swap to the project's real variables: \`--bg-color-dark\`, \`--bg-color\`, \`--border-color\`, \`--foreground-color\`, \`--comment-color\`, \`--current-line\`, plus the shared \`--border-radius-*\` and font-size tokens. Now matches the \`Modal\` component pattern and reflows correctly per the active \`[data-theme=...]\`.

## Test plan
- [ ] Open Account → Appearance, switch through each of the 6 themes
- [ ] Press Cmd+K after each switch — palette surface, border, text, hover, and footer chips all adopt the theme's palette
- [ ] Light themes (Catppuccin Latte, Ayu Light, GitHub Light) show a light dialog with dark text; not the previous always-dark dialog
- [ ] \`yarn build\` and \`yarn lint\` pass

## Not in this PR
Light/dark detection for keyboard hint contrast is fine since \`--foreground-color\` already inverts per theme.