### PR TITLE
feat: F4 — inline AI code completions (Cmd+I ghost text)

### DIFF
--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -15,6 +15,7 @@ const validActions: AiAction[] = [
 	aiActions.optimize,
 	aiActions.json,
 	aiActions.ask,
+	aiActions.complete,
 ];
 
 const stripMarkdownCodeFences = (text: string): string => {

--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -6,10 +6,13 @@ import CodeMirror from "@uiw/react-codemirror";
 /* Lib */
 import SupportedLanguages from "@/lib/config/languages";
 import languageExtensions from "@/lib/codeEditor";
+import inlineCompletion from "@/lib/inlineCompletion";
 import useViewPortStore from "@/lib/store/viewPort.store";
 import useUserStore from "@/lib/store/user.store";
 import codeMirrorOptions from "@/lib/constants/codeMirror";
 import { getCodeMirrorTheme, ThemeName } from "@/lib/config/themes";
+import { aiActions } from "@/lib/constants/ai";
+import { requestAiAction } from "@/utils/ai.utils";
 
 /* Hooks */
 import useCurrentSnippet from "@/components/CodeEditor/hooks/useCurrentSnippet";
@@ -98,6 +101,24 @@ const CodeEditor = ({
 	});
 
 	useKeyboardSave(saveHandler, isTrashActive);
+
+	const inlineCompletionExtension = useMemo(
+		() =>
+			inlineCompletion({
+				enabled: !isTrashActive,
+				language: currentSnippet.language,
+				fetchCompletion: async (prefix, language) => {
+					const response = await requestAiAction(
+						aiActions.complete,
+						prefix,
+						language
+					);
+
+					return response.result;
+				},
+			}),
+		[isTrashActive, currentSnippet.language]
+	);
 
 	const { editorWidthPercent, handlePreviewMouseDown } =
 		usePreviewResize(editorContentRef);
@@ -235,7 +256,10 @@ const CodeEditor = ({
 									placeholder={"Write your snipped here"}
 									className={styles.codeMirrorContainer}
 									value={currentSnippet?.snippet ?? ""}
-									extensions={[currentSnippet.extension]}
+									extensions={[
+										currentSnippet.extension,
+										inlineCompletionExtension,
+									]}
 									theme={editorTheme}
 									height={editorHeight}
 									width="100%"

--- a/app/globals.css
+++ b/app/globals.css
@@ -358,6 +358,14 @@ body {
 	background-color: var(--bg-color-dark);
 }
 
+.cm-ghost-text {
+	color: var(--gray-color);
+	opacity: 0.55;
+	font-style: italic;
+	white-space: pre;
+	pointer-events: none;
+}
+
 .container {
 	width: 100%;
 	max-width: 1200px;

--- a/app/lib/constants/ai.ts
+++ b/app/lib/constants/ai.ts
@@ -5,6 +5,7 @@ export const aiActions = {
 	optimize: "optimize",
 	json: "json",
 	ask: "ask",
+	complete: "complete",
 } as const;
 
 export const aiActionLabels: Record<AiAction, string> = {
@@ -14,6 +15,7 @@ export const aiActionLabels: Record<AiAction, string> = {
 	optimize: "Optimize",
 	json: "JSON parse & format",
 	ask: "Ask about this code",
+	complete: "Inline completion",
 };
 
 export const chipActions: AiAction[] = [
@@ -37,6 +39,8 @@ export const aiSystemPrompts: Record<AiAction, (language: string) => string> = {
 		"Fix this invalid JSON. Correct syntax errors like missing commas, brackets, quotes, or trailing commas. Return ONLY the valid, formatted JSON. No explanation, no markdown, no code fences.",
 	ask: (language) =>
 		`You are a coding assistant. The user will ask a question about a ${language} code snippet provided to you in the same system message. Answer clearly and concisely. If you include code, wrap it in fenced code blocks with the language tag.`,
+	complete: (language) =>
+		`You are an inline ${language} code completion assistant. The user's message is a partial code prefix; return ONLY the next 1 to 3 lines that should follow the cursor. Output raw text, no explanation, no markdown, no code fences. Preserve the existing indentation and style. If the prefix already looks complete, return an empty response.`,
 };
 
 export const codeActions: AiAction[] = [

--- a/app/lib/inlineCompletion.ts
+++ b/app/lib/inlineCompletion.ts
@@ -1,0 +1,161 @@
+import { Extension, StateEffect, StateField } from "@codemirror/state";
+import {
+	Decoration,
+	DecorationSet,
+	EditorView,
+	ViewUpdate,
+	WidgetType,
+	keymap,
+} from "@codemirror/view";
+
+type Suggestion = {
+	text: string;
+	from: number;
+};
+
+type InlineCompletionOptions = {
+	fetchCompletion: (prefix: string, language: string) => Promise<string>;
+	language: string;
+	enabled: boolean;
+};
+
+const setSuggestion = StateEffect.define<Suggestion | null>();
+
+class GhostTextWidget extends WidgetType {
+	constructor(readonly text: string) {
+		super();
+	}
+
+	toDOM(): HTMLSpanElement {
+		const span = document.createElement("span");
+
+		span.className = "cm-ghost-text";
+		span.textContent = this.text;
+
+		return span;
+	}
+
+	eq(other: GhostTextWidget): boolean {
+		return other.text === this.text;
+	}
+}
+
+const buildDecorations = (value: Suggestion | null): DecorationSet => {
+	if (!value || !value.text) {
+		return Decoration.none;
+	}
+
+	return Decoration.set([
+		Decoration.widget({
+			widget: new GhostTextWidget(value.text),
+			side: 1,
+		}).range(value.from),
+	]);
+};
+
+const suggestionField = StateField.define<Suggestion | null>({
+	create: () => null,
+	update(value, transaction) {
+		for (const effect of transaction.effects) {
+			if (effect.is(setSuggestion)) {
+				return effect.value;
+			}
+		}
+
+		if (transaction.docChanged || transaction.selection) {
+			return null;
+		}
+
+		return value;
+	},
+	provide: (field) => EditorView.decorations.from(field, buildDecorations),
+});
+
+const acceptSuggestion = (view: EditorView): boolean => {
+	const suggestion = view.state.field(suggestionField, false);
+
+	if (!suggestion || !suggestion.text) {
+		return false;
+	}
+
+	view.dispatch({
+		changes: { from: suggestion.from, insert: suggestion.text },
+		selection: { anchor: suggestion.from + suggestion.text.length },
+		effects: setSuggestion.of(null),
+	});
+
+	return true;
+};
+
+const dismissSuggestion = (view: EditorView): boolean => {
+	const suggestion = view.state.field(suggestionField, false);
+
+	if (!suggestion) {
+		return false;
+	}
+
+	view.dispatch({ effects: setSuggestion.of(null) });
+
+	return true;
+};
+
+const inlineCompletion = (options: InlineCompletionOptions): Extension => {
+	let inFlight = false;
+
+	const requestCompletion = (view: EditorView): boolean => {
+		if (!options.enabled || inFlight) {
+			return true;
+		}
+
+		const cursorPosition = view.state.selection.main.head;
+		const prefix = view.state.doc.sliceString(0, cursorPosition);
+
+		if (prefix.trim().length === 0) {
+			return true;
+		}
+
+		inFlight = true;
+
+		options
+			.fetchCompletion(prefix, options.language)
+			.then((text) => {
+				const cleaned = text.trim();
+
+				if (!cleaned) {
+					return;
+				}
+
+				view.dispatch({
+					effects: setSuggestion.of({ text: cleaned, from: cursorPosition }),
+				});
+			})
+			.catch(() => {
+				/* swallow — the ghost text just won't appear */
+			})
+			.finally(() => {
+				inFlight = false;
+			});
+
+		return true;
+	};
+
+	return [
+		suggestionField,
+		keymap.of([
+			{ key: "Tab", run: acceptSuggestion },
+			{ key: "Escape", run: dismissSuggestion },
+			{ key: "Mod-i", run: requestCompletion, preventDefault: true },
+		]),
+		EditorView.updateListener.of((update: ViewUpdate) => {
+			if (update.docChanged || update.selectionSet) {
+				const current = update.state.field(suggestionField, false);
+
+				if (current) {
+					update.view.dispatch({ effects: setSuggestion.of(null) });
+				}
+			}
+		}),
+	];
+};
+
+export default inlineCompletion;

--- a/types/snippets.d.ts
+++ b/types/snippets.d.ts
@@ -77,7 +77,8 @@ declare global {
 		| "format"
 		| "optimize"
 		| "json"
-		| "ask";
+		| "ask"
+		| "complete";
 
 	type AiRequest = {
 		action: AiAction;


### PR DESCRIPTION
## Summary
Adds Cursor-style inline AI completions to the editor. Press **Cmd+I** (Ctrl+I on Win/Linux) anywhere in the editor to ask the configured AI provider for the next 1-3 lines after the cursor. The suggestion renders as italic gray ghost text at the cursor; **Tab** accepts, **Escape** dismisses, any further typing or cursor movement also dismisses.

Manual trigger only — no auto-debounce, no per-keystroke fetches. Zero ambient cost unless the user explicitly invokes it.

## How it works
- New \`aiActions.complete\` + system prompt that tells the model to return only the continuation as raw text. Added to \`validActions\` in \`/api/ai/route.ts\` and to the \`AiAction\` union.
- New \`app/lib/inlineCompletion.ts\` — a CodeMirror extension built from:
  - \`StateEffect\` + \`StateField\` holding the current suggestion
  - \`GhostTextWidget\` rendering a span with \`.cm-ghost-text\` styling
  - \`Tab\` keymap to accept (insert text + advance cursor)
  - \`Escape\` keymap to dismiss
  - \`Mod-i\` keymap to fetch completion at cursor
  - \`updateListener\` that clears the suggestion on any doc/selection change
- \`CodeEditor\` wires the extension into both render paths (markdown preview + plain). Disabled in the Trash view (read-only).
- \`.cm-ghost-text\` styled in \`globals.css\` to use \`--gray-color\` at 55% opacity, italic, with \`white-space: pre\` for multi-line suggestions.

Server-side key resolution from PR #70 (P1 #6) is preserved — the client only sends action/code/language; the route reads provider+key from \`user.user_metadata\`.

## Test plan
- [ ] Open a snippet, type \`function add(a, b) {\\n  \` (cursor at end of line 2), press **Cmd+I** → after ~1s a gray italic suggestion appears (e.g., \`return a + b;\\n}\`)
- [ ] Press **Tab** → suggestion inserts, cursor advances past the inserted text
- [ ] Press **Cmd+I** again → new suggestion appears; press **Escape** → suggestion vanishes
- [ ] With a suggestion showing, type any character → suggestion disappears (no double insert)
- [ ] With a suggestion showing, click elsewhere → suggestion disappears
- [ ] In the Trash view, press **Cmd+I** → nothing happens (extension is disabled there)
- [ ] DevTools Network: POST /api/ai when Cmd+I is pressed → request body has \`action: "complete"\`, no \`x-ai-api-key\` header
- [ ] No active AI provider configured → quietly does nothing (Cmd+I returns true but the catch silently swallows)
- [ ] Without a suggestion present, **Tab** still indents (CodeMirror default)
- [ ] \`yarn build\` and \`yarn lint\` pass

## Not in this PR
- Auto-debounced "type and pause to suggest" (intentional — single-shot manual trigger avoids quota burn and surprises)
- An on/off toggle in AccountModal (skipped — feature is opt-in via Cmd+I; no ambient cost)
- Multi-line ghost-text rendering that visually pushes existing code down (current widget is inline at the cursor; multi-line suggestions render with \`white-space: pre\` but stay anchored at the cursor row)