### PR TITLE
feat: import markdown files via top-right editor action

### DIFF
--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -50,6 +50,7 @@ type CodeEditorProps = {
 	onStarred: (currentSnippet: CurrentSnippet) => void;
 	onPublicToggle: (currentSnippet: CurrentSnippet) => void;
 	onTouched: (touched: boolean) => void;
+	onImportMarkdown?: (files: FileList) => void;
 };
 
 const CodeEditor = ({
@@ -61,6 +62,7 @@ const CodeEditor = ({
 	onStarred,
 	onPublicToggle,
 	onTouched,
+	onImportMarkdown,
 }: CodeEditorProps): ReactElement => {
 	const isMobile = useViewPortStore((state) => state.isMobile);
 	const theme = useUserStore((state) => state.theme) as ThemeName;
@@ -168,6 +170,7 @@ const CodeEditor = ({
 								showHistory={showHistory}
 								hasVersions={versionCount > 0}
 								onApplyAiCode={updateCurrentSnippetValue}
+								onImportMarkdown={onImportMarkdown}
 							/>
 
 							{isMobile && (
@@ -182,6 +185,7 @@ const CodeEditor = ({
 										showHistory={showHistory}
 										hasVersions={versionCount > 0}
 										onApplyAiCode={updateCurrentSnippetValue}
+										onImportMarkdown={onImportMarkdown}
 									/>
 								</div>
 							)}

--- a/app/components/CodeEditor/CodeEditorActions.tsx
+++ b/app/components/CodeEditor/CodeEditorActions.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from "react";
+import { ChangeEvent, ReactElement, useRef, useState } from "react";
 
 /* Components */
 import Camera from "@/components/ui/icons/Camera";
@@ -8,6 +8,7 @@ import Globe from "@/components/ui/icons/Globe";
 import Info from "@/components/ui/icons/Info";
 import Share from "@/components/ui/icons/Share";
 import Sparkle from "@/components/ui/icons/Sparkle";
+import Upload from "@/components/ui/icons/Upload";
 import AiChatModal from "@/components/CodeEditor/AiChatModal/AiChatModal";
 import ScreenshotModal from "@/components/ScreenshotModal/ScreenshotModal";
 
@@ -28,6 +29,7 @@ type CodeEditorActionsProps = {
 	showHistory?: boolean;
 	hasVersions?: boolean;
 	onApplyAiCode?: (code: string) => void;
+	onImportMarkdown?: (files: FileList) => void;
 };
 
 const CodeEditorActions = ({
@@ -40,10 +42,26 @@ const CodeEditorActions = ({
 	showHistory = false,
 	hasVersions = false,
 	onApplyAiCode,
+	onImportMarkdown,
 }: CodeEditorActionsProps): ReactElement => {
 	const { addToast } = useToastStore();
 	const [aiChatOpen, setAiChatOpen] = useState(false);
 	const [screenshotModalOpen, setScreenshotModalOpen] = useState(false);
+	const importInputRef = useRef<HTMLInputElement | null>(null);
+
+	const handleImportClick = (): void => {
+		importInputRef.current?.click();
+	};
+
+	const handleImportChange = (event: ChangeEvent<HTMLInputElement>): void => {
+		const files = event.target.files;
+
+		if (files && files.length > 0 && onImportMarkdown) {
+			onImportMarkdown(files);
+		}
+
+		event.target.value = "";
+	};
 
 	const handleCopy = async (): Promise<void> => {
 		try {
@@ -107,6 +125,26 @@ const CodeEditorActions = ({
 						<span className={styles.tooltip}>AI</span>
 					</button>
 				</div>
+				{onImportMarkdown && (
+					<>
+						<button
+							className={styles.actionButton}
+							type="button"
+							onClick={handleImportClick}
+						>
+							<Upload width={24} height={24} />
+							<span className={styles.tooltip}>Import markdown</span>
+						</button>
+						<input
+							ref={importInputRef}
+							type="file"
+							accept=".md,.markdown,text/markdown,text/plain"
+							multiple
+							hidden
+							onChange={handleImportChange}
+						/>
+					</>
+				)}
 				<button
 					className={styles.actionButton}
 					type="button"

--- a/app/components/CodeEditor/CodeEditorTags.tsx
+++ b/app/components/CodeEditor/CodeEditorTags.tsx
@@ -26,6 +26,7 @@ type CodeEditorTagsProps = {
 	showHistory: boolean;
 	hasVersions: boolean;
 	onApplyAiCode?: (code: string) => void;
+	onImportMarkdown?: (files: FileList) => void;
 };
 
 const CodeEditorTags = ({
@@ -42,6 +43,7 @@ const CodeEditorTags = ({
 	showHistory,
 	hasVersions,
 	onApplyAiCode,
+	onImportMarkdown,
 }: CodeEditorTagsProps): ReactElement => {
 	const [tagList, setTagList] = useState<string[]>([]);
 	const getTagForSnippet = (snippetTag: Tags): string[] =>
@@ -108,6 +110,7 @@ const CodeEditorTags = ({
 					showHistory={showHistory}
 					hasVersions={hasVersions}
 					onApplyAiCode={onApplyAiCode}
+					onImportMarkdown={onImportMarkdown}
 				/>
 			</div>
 		</section>

--- a/app/components/ui/icons/Upload.tsx
+++ b/app/components/ui/icons/Upload.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from "react";
+
+import IconContainer from "@/components/ui/icons/Icon";
+
+const Upload = (props: Icon): ReactElement => {
+	return (
+		<IconContainer viewBox="0 0 256 256" {...props}>
+			<path d="M213.66,82.34l-56-56A8,8,0,0,0,152,24H56A16,16,0,0,0,40,40V216a16,16,0,0,0,16,16H200a16,16,0,0,0,16-16V88A8,8,0,0,0,213.66,82.34ZM160,51.31,188.69,80H160ZM200,216H56V40h88V88a8,8,0,0,0,8,8h48V216ZM82.34,141.66a8,8,0,0,1,0-11.32l40-40a8,8,0,0,1,11.32,0l40,40a8,8,0,0,1-11.32,11.32L136,113.66V184a8,8,0,0,1-16,0V113.66L93.66,141.66A8,8,0,0,1,82.34,141.66Z"></path>
+		</IconContainer>
+	);
+};
+
+export default Upload;

--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -16,6 +16,7 @@ import {
 	getSnippetsByState,
 	getSnippetsByTag,
 	getUncategorizedSnippets,
+	getUserIdBySession,
 	saveSnippet,
 	saveSnippetVersion,
 	setNewSnippet,
@@ -26,6 +27,8 @@ import { useDeviceViewPort } from "@/utils/ui.utils";
 import { MenuItems } from "@/lib/constants/core";
 import useToastStore from "@/lib/store/toast.store";
 import { ToastType } from "@/lib/constants/toast";
+import SupportedLanguages from "@/lib/config/languages";
+import SnippetValueObject from "@/lib/models/Snippet";
 
 export default function Page(): ReactElement {
 	// Allow isMobile to be used across all Snippets page components
@@ -472,6 +475,63 @@ export default function Page(): ReactElement {
 		}
 	};
 
+	const importMarkdownFiles = async (files: FileList): Promise<void> => {
+		if (files.length === 0) return;
+
+		const userId = await getUserIdBySession();
+
+		if (!userId) {
+			addToast({
+				type: ToastType.Error,
+				message: "You must be signed in to import files",
+			});
+
+			return;
+		}
+
+		const imported: Snippet[] = [];
+		const failedFiles: string[] = [];
+
+		for (const file of Array.from(files)) {
+			try {
+				const content = await file.text();
+				const nameFromFile = file.name
+					.replace(/\.(md|markdown|txt)$/i, "")
+					.trim();
+				const newSnippet = new SnippetValueObject(userId as UUID);
+
+				newSnippet.name = nameFromFile.length > 0 ? nameFromFile : "Imported";
+				newSnippet.snippet = content;
+				newSnippet.language = SupportedLanguages.Markdown;
+
+				await saveSnippet(newSnippet as CurrentSnippet);
+				imported.push(newSnippet as Snippet);
+			} catch {
+				failedFiles.push(file.name);
+			}
+		}
+
+		if (imported.length > 0) {
+			setSnippets([...imported, ...snippets]);
+			setActiveSnippetId(imported[0].snippet_id);
+			addToast({
+				type: ToastType.Success,
+				message:
+					imported.length === 1
+						? "Imported 1 snippet"
+						: `Imported ${imported.length} snippets`,
+			});
+			updateSnippetTagList().then(() => null);
+		}
+
+		if (failedFiles.length > 0) {
+			addToast({
+				type: ToastType.Error,
+				message: `Failed to import ${failedFiles.length} file${failedFiles.length === 1 ? "" : "s"}`,
+			});
+		}
+	};
+
 	useEffect(() => {
 		getSnippets().then(() => null);
 	}, []);
@@ -537,6 +597,7 @@ export default function Page(): ReactElement {
 						onStarred={onStarredHandler}
 						onPublicToggle={onPublicToggleHandler}
 						onTouched={touchedHandler}
+						onImportMarkdown={importMarkdownFiles}
 					/>
 				}
 			/>


### PR DESCRIPTION
Adds an Import icon (Phosphor file-arrow-up) to the editor's top-right action bar alongside Screenshot / History / Details / Copy / Share / Public. Clicking opens a multi-select file picker for .md / .markdown / .txt files.

Each selected file becomes a new snippet:
- Name: filename with the extension stripped
- Content: the file's text
- Language: Markdown
- user_id: forced from the session (consistent with the server-side ownership rules)

After import:
- All new snippets prepend to the local snippets list
- Active selection jumps to the first imported snippet
- Tag list / counts refresh via updateSnippetTagList()
- A success toast reports the count; individual failures (e.g., a binary file with the wrong extension) are surfaced via an error toast listing how many failed

The button is mounted in CodeEditorActions and rendered in both the desktop (CodeEditorTags) and mobile (CodeEditor mobile section) paths. It only renders when onImportMarkdown is provided, so other callers of CodeEditorActions (none today, but future-proofing) get no UI change.

New icon: app/components/ui/icons/Upload.tsx.