### PR TITLE
feat: F2 — [[wiki-links]] between snippets

### DIFF
--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -7,6 +7,7 @@ import CodeMirror from "@uiw/react-codemirror";
 import SupportedLanguages from "@/lib/config/languages";
 import languageExtensions from "@/lib/codeEditor";
 import inlineCompletion from "@/lib/inlineCompletion";
+import wikiLinkAutocomplete from "@/lib/wikiLinkAutocomplete";
 import useViewPortStore from "@/lib/store/viewPort.store";
 import useUserStore from "@/lib/store/user.store";
 import codeMirrorOptions from "@/lib/constants/codeMirror";
@@ -43,6 +44,7 @@ type CodeEditorProps = {
 	snippet: Snippet | null;
 	defaultLanguage?: SupportedLanguages;
 	codeEditorStates: SnippetEditorStates;
+	allSnippets: Snippet[];
 	onSave: (
 		currentSnippet: CurrentSnippet,
 		fromButton: boolean | "favorite"
@@ -50,6 +52,7 @@ type CodeEditorProps = {
 	onStarred: (currentSnippet: CurrentSnippet) => void;
 	onPublicToggle: (currentSnippet: CurrentSnippet) => void;
 	onTouched: (touched: boolean) => void;
+	onWikiNavigate?: (target: string) => void;
 };
 
 const CodeEditor = ({
@@ -57,10 +60,12 @@ const CodeEditor = ({
 	snippet,
 	codeEditorStates,
 	defaultLanguage = SupportedLanguages.Markdown,
+	allSnippets,
 	onSave,
 	onStarred,
 	onPublicToggle,
 	onTouched,
+	onWikiNavigate,
 }: CodeEditorProps): ReactElement => {
 	const isMobile = useViewPortStore((state) => state.isMobile);
 	const theme = useUserStore((state) => state.theme) as ThemeName;
@@ -118,6 +123,11 @@ const CodeEditor = ({
 				},
 			}),
 		[isTrashActive, currentSnippet.language]
+	);
+
+	const wikiAutocompleteExtension = useMemo(
+		() => wikiLinkAutocomplete(allSnippets),
+		[allSnippets]
 	);
 
 	const { editorWidthPercent, handlePreviewMouseDown } =
@@ -259,6 +269,7 @@ const CodeEditor = ({
 									extensions={[
 										currentSnippet.extension,
 										inlineCompletionExtension,
+										wikiAutocompleteExtension,
 									]}
 									theme={editorTheme}
 									height={editorHeight}
@@ -275,6 +286,7 @@ const CodeEditor = ({
 							<MarkdownPreview
 								content={currentSnippet.snippet}
 								height={previewHeight}
+								onWikiNavigate={onWikiNavigate}
 							/>
 						</div>
 					) : (
@@ -287,7 +299,7 @@ const CodeEditor = ({
 							placeholder={"Write your snipped here"}
 							className={styles.codeMirrorContainer}
 							value={currentSnippet?.snippet ?? ""}
-							extensions={[currentSnippet.extension]}
+							extensions={[currentSnippet.extension, wikiAutocompleteExtension]}
 							theme={editorTheme}
 							height={editorHeight}
 							width="100%"

--- a/app/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/app/components/MarkdownPreview/MarkdownPreview.tsx
@@ -1,28 +1,53 @@
 "use client";
 
-import { ReactElement, useMemo } from "react";
+import { MouseEvent, ReactElement, useMemo } from "react";
 import { marked } from "marked";
 import DOMPurify from "isomorphic-dompurify";
+
+/* Lib */
+import wikiLinkMarked from "@/lib/wikiLinkMarked";
 
 /* Styles */
 import styles from "./markdownPreview.module.css";
 
+marked.use(wikiLinkMarked);
+
 type MarkdownPreviewProps = {
 	content: string;
 	height: string;
+	onWikiNavigate?: (target: string) => void;
 };
 
 const MarkdownPreview = ({
 	content,
 	height,
+	onWikiNavigate,
 }: MarkdownPreviewProps): ReactElement => {
 	const htmlContent = useMemo(() => {
 		if (!content) return "";
 
 		const rawHtml = marked.parse(content, { async: false }) as string;
 
-		return DOMPurify.sanitize(rawHtml);
+		return DOMPurify.sanitize(rawHtml, {
+			ADD_ATTR: ["data-wiki-target"],
+		});
 	}, [content]);
+
+	const handleClick = (event: MouseEvent<HTMLDivElement>): void => {
+		if (!onWikiNavigate) return;
+
+		const target = event.target as HTMLElement;
+		const link = target.closest<HTMLElement>(".wiki-link");
+
+		if (!link) return;
+
+		const wikiTarget = link.getAttribute("data-wiki-target");
+
+		if (wikiTarget) {
+			event.preventDefault();
+			onWikiNavigate(wikiTarget);
+		}
+	};
 
 	return (
 		<div className={styles.previewContainer} style={{ height }}>
@@ -31,6 +56,7 @@ const MarkdownPreview = ({
 			</div>
 			<div
 				className={styles.previewContent}
+				onClick={handleClick}
 				dangerouslySetInnerHTML={{ __html: htmlContent }}
 			/>
 		</div>

--- a/app/components/MarkdownPreview/markdownPreview.module.css
+++ b/app/components/MarkdownPreview/markdownPreview.module.css
@@ -151,6 +151,35 @@
 	height: auto;
 }
 
+.previewContent :global(.wiki-link) {
+	display: inline;
+	background: none;
+	border: none;
+	padding: 0;
+	color: var(--purple-color);
+	font: inherit;
+	cursor: pointer;
+	text-decoration: none;
+	border-bottom: 1px dashed var(--purple-color);
+}
+
+.previewContent :global(.wiki-link::before) {
+	content: "[[";
+	color: var(--gray-color);
+	margin-right: 1px;
+}
+
+.previewContent :global(.wiki-link::after) {
+	content: "]]";
+	color: var(--gray-color);
+	margin-left: 1px;
+}
+
+.previewContent :global(.wiki-link:hover) {
+	color: var(--cyan-color);
+	border-bottom-color: var(--cyan-color);
+}
+
 /* Scrollbar styles matching code editor */
 .previewContent::-webkit-scrollbar {
 	width: 10px;

--- a/app/lib/wikiLinkAutocomplete.ts
+++ b/app/lib/wikiLinkAutocomplete.ts
@@ -1,0 +1,39 @@
+import {
+	autocompletion,
+	CompletionContext,
+	CompletionResult,
+	Completion,
+} from "@codemirror/autocomplete";
+import { Extension } from "@codemirror/state";
+
+const maxSuggestions = 20;
+
+const wikiLinkAutocomplete = (snippets: Snippet[]): Extension => {
+	const source = (context: CompletionContext): CompletionResult | null => {
+		const match = context.matchBefore(/\[\[([^[\]\n]*)/);
+
+		if (!match) return null;
+
+		const query = match.text.slice(2).toLowerCase();
+		const options: Completion[] = snippets
+			.filter(
+				(snippet) => snippet.name && snippet.name.toLowerCase().includes(query)
+			)
+			.slice(0, maxSuggestions)
+			.map((snippet) => ({
+				label: snippet.name,
+				type: "text",
+				apply: `[[${snippet.name}]]`,
+			}));
+
+		return {
+			from: match.from,
+			options,
+			validFor: /^\[\[[^[\]\n]*$/,
+		};
+	};
+
+	return autocompletion({ override: [source] });
+};
+
+export default wikiLinkAutocomplete;

--- a/app/lib/wikiLinkMarked.ts
+++ b/app/lib/wikiLinkMarked.ts
@@ -1,0 +1,49 @@
+import type { MarkedExtension, Tokens } from "marked";
+
+type WikiLinkToken = Tokens.Generic & {
+	type: "wikiLink";
+	raw: string;
+	target: string;
+};
+
+const escapeHtml = (text: string): string =>
+	text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+
+const wikiLinkMarked: MarkedExtension = {
+	extensions: [
+		{
+			name: "wikiLink",
+			level: "inline",
+			start(src: string): number | undefined {
+				const index = src.indexOf("[[");
+
+				return index === -1 ? undefined : index;
+			},
+			tokenizer(src: string): WikiLinkToken | undefined {
+				const match = /^\[\[([^[\]\n]+)\]\]/.exec(src);
+
+				if (match) {
+					return {
+						type: "wikiLink",
+						raw: match[0],
+						target: match[1].trim(),
+					};
+				}
+
+				return undefined;
+			},
+			renderer(token: Tokens.Generic): string {
+				const target = (token as WikiLinkToken).target;
+				const escaped = escapeHtml(target);
+
+				return `<button type="button" class="wiki-link" data-wiki-target="${escaped}">${escaped}</button>`;
+			},
+		},
+	],
+};
+
+export default wikiLinkMarked;

--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -464,6 +464,45 @@ export default function Page(): ReactElement {
 		setIsAccountModalOpen(false);
 	};
 
+	const handleWikiNavigate = async (target: string): Promise<void> => {
+		const trimmed = target.trim();
+
+		if (!trimmed) return;
+
+		const inCurrentView = snippets.find(
+			(item: Snippet): boolean =>
+				item.name.toLowerCase() === trimmed.toLowerCase()
+		);
+
+		if (inCurrentView) {
+			setActiveSnippetId(inCurrentView.snippet_id);
+
+			return;
+		}
+
+		const allActive = await getAllSnippets();
+		const found = allActive.find(
+			(item: Snippet): boolean =>
+				item.name.toLowerCase() === trimmed.toLowerCase()
+		);
+
+		if (!found) {
+			addToast({
+				type: ToastType.Warning,
+				message: `No snippet found matching "${trimmed}"`,
+			});
+
+			return;
+		}
+
+		setSnippets(allActive);
+		setCodedEditorStates({
+			...defaultCodeEditorStates,
+			menuType: MenuItems.All,
+			activeSnippetId: found.snippet_id,
+		});
+	};
+
 	const createSnippetFromPalette = async (): Promise<void> => {
 		const newSnippet = await setNewSnippet();
 
@@ -533,10 +572,12 @@ export default function Page(): ReactElement {
 								: null
 						}
 						codeEditorStates={codeEditorStates}
+						allSnippets={snippets}
 						onSave={saveSnippetHandler}
 						onStarred={onStarredHandler}
 						onPublicToggle={onPublicToggleHandler}
 						onTouched={touchedHandler}
+						onWikiNavigate={handleWikiNavigate}
 					/>
 				}
 			/>


### PR DESCRIPTION
Type [[ in any snippet to autocomplete a link to another of your snippets. In the markdown preview, [[name]] renders as a clickable purple link with [[ ]] hint brackets. Clicking jumps to that snippet, auto-switching to All Snippets if it's not in the current filtered view.

Implementation:
- New app/lib/wikiLinkAutocomplete.ts — a CodeMirror autocompletion() extension. matchBefore detects /\[\[([^[\]\n]*)/ at the cursor, filters the user's snippet names against the typed query, and inserts [[full-name]] on selection. validFor regex keeps the popup open while typing within the bracket pair.
- New app/lib/wikiLinkMarked.ts — a Marked v17 inline tokenizer that parses [[name]] and renders as <button type="button" class="wiki-link" data-wiki-target="name">name</button>. HTML-escapes the target.
- MarkdownPreview.tsx now applies the marked extension once at module scope, allows the data-wiki-target attribute through DOMPurify, and attaches an onClick handler that calls onWikiNavigate(target) when a .wiki-link is clicked. The button-as-link pattern works with DOMPurify's default allowed tags (anchor without href would be stripped) and renders inline.
- markdownPreview.module.css styles .wiki-link with purple underline, hover-cyan, and gray ::before/::after [[ ]] markers so the syntax stays visible.
- CodeEditor accepts new allSnippets and onWikiNavigate props and installs the wikiLinkAutocomplete extension in both render paths (preview-split and plain). The extension recomputes when snippets change so suggestions stay current after saves/deletes/imports.
- page.tsx adds handleWikiNavigate(target): tries to resolve the name in the current view first, falls back to a full getAllSnippets() if the user is on a filtered menu, surfaces a warning toast when no snippet matches.

Resolution is name-based and case-insensitive. Known limitation: if two snippets share a name, the first match wins — documented for a follow-up that adds id-based linking.

V1 scope only. Not in this PR:
- Backlinks panel (sidebar that lists snippets linking TO the current)
- Broken-link visual indicator (gray-out [[ ]] for non-existent names)
- Hover preview of the linked snippet