### PR TITLE
feat: F10 (folders) — single-level folders for snippet organization

### DIFF
--- a/app/components/Aside/Aside.tsx
+++ b/app/components/Aside/Aside.tsx
@@ -33,6 +33,7 @@ import Tray from "@/components/ui/icons/Tray";
 import Trash from "@/components/ui/icons/Trash";
 import Book from "@/components/ui/icons/Book";
 import Bookmark from "@/components/ui/icons/Bookmark";
+import Folder from "@/components/ui/icons/Folder";
 import Star from "@/components/ui/icons/Star";
 import Loading from "@/components/ui/icons/Loading";
 import List from "@/components/ui/icons/List";
@@ -47,6 +48,7 @@ type AsideProps = {
 	isLoading: boolean;
 	codeEditorStates: SnippetEditorStates;
 	tags: TagItem[];
+	folders: TagItem[];
 	publicCount: number;
 	allCount: number;
 	uncategorizedCount: number;
@@ -57,6 +59,7 @@ type AsideProps = {
 	onGetFavorites: () => void;
 	onGetTrash: () => void;
 	onTagClick: (tag: string) => void;
+	onFolderClick: (folder: string) => void;
 	onAccountClick: () => void;
 };
 
@@ -64,6 +67,7 @@ const Aside = ({
 	isLoading,
 	codeEditorStates,
 	tags,
+	folders,
 	publicCount,
 	allCount,
 	uncategorizedCount,
@@ -74,6 +78,7 @@ const Aside = ({
 	onGetPublic,
 	onGetTrash,
 	onTagClick,
+	onFolderClick,
 	onAccountClick,
 }: AsideProps): ReactElement => {
 	const { menuType } = codeEditorStates;
@@ -83,6 +88,7 @@ const Aside = ({
 	const userSectionRef = useRef<HTMLDivElement | null>(null);
 	const [isLoginOut, setIsLoginOut] = useState<boolean>(false);
 	const [isTagsExpanded, setIsTagsExpanded] = useState<boolean>(false);
+	const [isFoldersExpanded, setIsFoldersExpanded] = useState<boolean>(true);
 	const [isUserMenuOpen, setIsUserMenuOpen] = useState<boolean>(false);
 	const [isMac, setIsMac] = useState<boolean>(true);
 
@@ -172,8 +178,17 @@ const Aside = ({
 		openSnippetListMobile();
 	};
 
+	const handlerFolderClick = (folder: string): void => {
+		onFolderClick(folder);
+		openSnippetListMobile();
+	};
+
 	const toggleTagsExpansion = (): void => {
 		setIsTagsExpanded(!isTagsExpanded);
+	};
+
+	const toggleFoldersExpansion = (): void => {
+		setIsFoldersExpanded(!isFoldersExpanded);
 	};
 
 	const handleSettingsClick = (): void => {
@@ -329,6 +344,39 @@ const Aside = ({
 							Trash
 						</a>
 					</section>
+
+					{!isLoading && folders?.length > 0 && (
+						<section
+							className={`${styles.section} ${isFoldersExpanded && folders.length > 12 ? styles.tagsSection : ""}`}
+						>
+							<h2
+								className={`${styles.title} blue-color ${styles.titleClickable}`}
+								onClick={toggleFoldersExpansion}
+							>
+								<Folder className={styles.icon} width={18} height={18} />
+								Folders
+								<CaretDown
+									className={`${styles.caretIcon} ${isFoldersExpanded ? styles.caretExpanded : styles.caretCollapsed}`}
+									width={12}
+									height={12}
+								/>
+							</h2>
+
+							{isFoldersExpanded && (
+								<div
+									className={
+										folders.length > 12 ? styles.tagsListScrollable : undefined
+									}
+								>
+									<AsideItem
+										active={menuType}
+										items={folders}
+										onItemClicked={handlerFolderClick}
+									/>
+								</div>
+							)}
+						</section>
+					)}
 
 					{isLoading ? (
 						<section className={styles.section}>

--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -83,6 +83,7 @@ const CodeEditor = ({
 		updateCurrentSnippetName,
 		updateCurrentSnippetUrl,
 		updateCurrentSnippetNotes,
+		updateCurrentSnippetFolder,
 		setLanguageHandler,
 		starringHandler,
 		newTagHandler,
@@ -233,6 +234,7 @@ const CodeEditor = ({
 									onClose={() => setShowDetails(false)}
 									onUrlChange={updateCurrentSnippetUrl}
 									onNotesChange={updateCurrentSnippetNotes}
+									onFolderChange={updateCurrentSnippetFolder}
 								/>
 							)}
 						</>

--- a/app/components/CodeEditor/SnippetDetails/SnippetDetails.tsx
+++ b/app/components/CodeEditor/SnippetDetails/SnippetDetails.tsx
@@ -12,6 +12,7 @@ type SnippetDetailsProps = {
 	onClose: () => void;
 	onUrlChange: (event: ChangeEvent<HTMLInputElement>) => void;
 	onNotesChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+	onFolderChange: (event: ChangeEvent<HTMLInputElement>) => void;
 };
 
 const SnippetDetails = ({
@@ -20,6 +21,7 @@ const SnippetDetails = ({
 	onClose,
 	onUrlChange,
 	onNotesChange,
+	onFolderChange,
 }: SnippetDetailsProps): ReactElement => {
 	return (
 		<>
@@ -38,6 +40,17 @@ const SnippetDetails = ({
 					</button>
 				</div>
 				<div className={styles.detailsContainer}>
+					<div className={styles.detailsField}>
+						<label className={styles.detailsLabel}>Folder</label>
+						<Input
+							placeholder="e.g. Recipes, Work, Snippets-2026"
+							value={currentSnippet?.folder ?? ""}
+							onChange={onFolderChange}
+							maxLength={60}
+							disableMargin
+						/>
+					</div>
+
 					<div className={styles.detailsField}>
 						<label className={styles.detailsLabel}>Source URL</label>
 						<Input

--- a/app/components/CodeEditor/hooks/useCurrentSnippet.ts
+++ b/app/components/CodeEditor/hooks/useCurrentSnippet.ts
@@ -40,6 +40,7 @@ type UseCurrentSnippetReturn = {
 	updateCurrentSnippetName: (event: ChangeEvent<HTMLInputElement>) => void;
 	updateCurrentSnippetUrl: (event: ChangeEvent<HTMLInputElement>) => void;
 	updateCurrentSnippetNotes: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+	updateCurrentSnippetFolder: (event: ChangeEvent<HTMLInputElement>) => void;
 	setLanguageHandler: (selectedLanguage: string) => void;
 	starringHandler: () => void;
 	newTagHandler: (newTagValue: string) => void;
@@ -125,6 +126,18 @@ const useCurrentSnippet = ({
 		event: ChangeEvent<HTMLTextAreaElement>
 	): void => {
 		setCurrentSnippet({ ...currentSnippet, notes: event.target.value });
+		onTouched(true);
+	};
+
+	const updateCurrentSnippetFolder = (
+		event: ChangeEvent<HTMLInputElement>
+	): void => {
+		const value = event.target.value;
+
+		setCurrentSnippet({
+			...currentSnippet,
+			folder: value.trim().length > 0 ? value : null,
+		});
 		onTouched(true);
 	};
 
@@ -269,6 +282,7 @@ const useCurrentSnippet = ({
 		updateCurrentSnippetName,
 		updateCurrentSnippetUrl,
 		updateCurrentSnippetNotes,
+		updateCurrentSnippetFolder,
 		setLanguageHandler,
 		starringHandler,
 		newTagHandler,

--- a/app/lib/models/Snippet.ts
+++ b/app/lib/models/Snippet.ts
@@ -26,6 +26,8 @@ export default class SnippetValueObject implements Snippet {
 
 	public public_slug: string | null;
 
+	public folder: string | null;
+
 	language: SupportedLanguages;
 
 	constructor(user_id: UUID) {
@@ -42,5 +44,6 @@ export default class SnippetValueObject implements Snippet {
 		this.tags = null;
 		this.is_public = false;
 		this.public_slug = null;
+		this.folder = null;
 	}
 }

--- a/app/lib/supabase/queries.ts
+++ b/app/lib/supabase/queries.ts
@@ -103,6 +103,27 @@ export const getUncategorizedSnippets = async (): Promise<Snippet[]> => {
 	return [] as Snippet[];
 };
 
+export const getSnippetsByFolder = async (
+	folder: string
+): Promise<Snippet[]> => {
+	if (supabase && folder) {
+		const userId = await getUserIdBySession();
+
+		if (userId) {
+			const { data } = await supabase
+				.from("snippet")
+				.select()
+				.order("updated_at", { ascending: false })
+				.match({ user_id: userId, folder })
+				.neq("state", "inactive");
+
+			return (data ?? []) as Snippet[];
+		}
+	}
+
+	return [] as Snippet[];
+};
+
 export const getSnippetsByTag = async (tag: string): Promise<Snippet[]> => {
 	if (supabase && tag) {
 		const userId = await getUserIdBySession();
@@ -172,6 +193,7 @@ export const saveSnippet = async (
 		tags: currentSnippet?.tags ?? null,
 		url: currentSnippet?.url ?? null,
 		notes: currentSnippet?.notes ?? null,
+		folder: currentSnippet?.folder ?? null,
 	};
 
 	const { data: updated, error: updateError } = await supabase

--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -13,6 +13,7 @@ import CommandPalette from "@/components/CommandPalette/CommandPalette";
 /* Lib and Utils */
 import {
 	getAllSnippets,
+	getSnippetsByFolder,
 	getSnippetsByState,
 	getSnippetsByTag,
 	getUncategorizedSnippets,
@@ -39,6 +40,7 @@ export default function Page(): ReactElement {
 	};
 	const [snippets, setSnippets] = useState<Snippet[]>([]);
 	const [tags, setTags] = useState<TagItem[]>([]);
+	const [folders, setFolders] = useState<TagItem[]>([]);
 	const [codeEditorStates, setCodedEditorStates] =
 		useState<SnippetEditorStates>(defaultCodeEditorStates);
 	const [publicCount, setPublicCount] = useState<number>(0);
@@ -88,6 +90,24 @@ export default function Page(): ReactElement {
 			...codeEditorStates,
 			touched,
 		});
+	};
+
+	const getFolders = (snippetsLoaded: Snippet[]): void => {
+		const folderCounts: Record<string, number> = {};
+
+		snippetsLoaded?.forEach((snippet: Snippet) => {
+			const folderName = snippet?.folder?.trim();
+
+			if (folderName) {
+				folderCounts[folderName] = (folderCounts[folderName] ?? 0) + 1;
+			}
+		});
+
+		const nextFolders = Object.keys(folderCounts)
+			.sort()
+			.map((folder) => ({ name: folder, total: folderCounts[folder] }));
+
+		setFolders(nextFolders);
 	};
 
 	const getTags = (snippetsLoaded: Snippet[]): void => {
@@ -150,6 +170,7 @@ export default function Page(): ReactElement {
 
 		if (isActive) {
 			getTags(data);
+			getFolders(data);
 			updateMenuCounts(data);
 		}
 
@@ -198,9 +219,14 @@ export default function Page(): ReactElement {
 
 	const updateSnippetTagList = async (
 		updatedSnippet: Snippet | null = null,
-		previousTags: Tags = null
+		previousTags: Tags = null,
+		previousFolder: string | null = null
 	) => {
-		if (updatedSnippet && updatedSnippet.tags === previousTags) {
+		if (
+			updatedSnippet &&
+			updatedSnippet.tags === previousTags &&
+			(updatedSnippet.folder ?? null) === previousFolder
+		) {
 			return;
 		}
 
@@ -214,6 +240,7 @@ export default function Page(): ReactElement {
 			: allSnippets;
 
 		getTags(updatedSnippetList);
+		getFolders(updatedSnippetList);
 		updateMenuCounts(updatedSnippetList);
 	};
 
@@ -238,6 +265,7 @@ export default function Page(): ReactElement {
 			});
 
 			const previousTags = activeSnippet.tags ?? null;
+			const previousFolder = activeSnippet.folder ?? null;
 			const updatedSnippet = {
 				...currentSnippet,
 				updated_at: new Date().toISOString(),
@@ -254,7 +282,9 @@ export default function Page(): ReactElement {
 				).catch(() => null);
 			}
 
-			updateSnippetTagList(updatedSnippet, previousTags).then(() => null);
+			updateSnippetTagList(updatedSnippet, previousTags, previousFolder).then(
+				() => null
+			);
 
 			if (fromButton && codeEditorStates.touched) {
 				addToast({
@@ -398,6 +428,22 @@ export default function Page(): ReactElement {
 		}
 	};
 
+	const getSnippetsByFolderHandler = async (folder: string): Promise<void> => {
+		if (folder.length === 0) {
+			return;
+		}
+
+		const data = await getSnippetsByFolder(folder);
+
+		setCodedEditorStates({
+			...defaultCodeEditorStates,
+			menuType: folder,
+			activeSnippetId: data?.[0]?.snippet_id ?? null,
+		});
+
+		setSnippets(data);
+	};
+
 	const getSnippetsByTagHandler = async (tag: string): Promise<void> => {
 		if (tag.length === 0) {
 			return;
@@ -496,6 +542,7 @@ export default function Page(): ReactElement {
 						isLoading={isLoading}
 						codeEditorStates={codeEditorStates}
 						tags={tags}
+						folders={folders}
 						publicCount={publicCount}
 						allCount={allCount}
 						uncategorizedCount={uncategorizedCount}
@@ -506,6 +553,7 @@ export default function Page(): ReactElement {
 						onGetFavorites={getFavoritesHandler}
 						onGetTrash={getTrashHandler}
 						onTagClick={getSnippetsByTagHandler}
+						onFolderClick={getSnippetsByFolderHandler}
 						onAccountClick={handleAccountClick}
 					/>
 				}

--- a/supabase/migrations/003_add_folder_to_snippet.sql
+++ b/supabase/migrations/003_add_folder_to_snippet.sql
@@ -1,0 +1,10 @@
+-- Add folder column to snippet table for single-level folder organization.
+-- Folders are scoped per user (combined with the existing user_id RLS gate).
+
+ALTER TABLE snippet
+	ADD COLUMN IF NOT EXISTS folder TEXT;
+
+-- Composite partial index supports the per-user "snippets in folder X" query.
+CREATE INDEX IF NOT EXISTS snippet_user_folder_idx
+	ON snippet (user_id, folder)
+	WHERE folder IS NOT NULL;

--- a/supabase/migrations/rollback_003_remove_folder.sql
+++ b/supabase/migrations/rollback_003_remove_folder.sql
@@ -1,0 +1,6 @@
+-- Rollback for 003_add_folder_to_snippet.sql
+
+DROP INDEX IF EXISTS snippet_user_folder_idx;
+
+ALTER TABLE snippet
+	DROP COLUMN IF EXISTS folder;

--- a/types/snippets.d.ts
+++ b/types/snippets.d.ts
@@ -32,6 +32,7 @@ declare global {
 		tags?: Tags;
 		is_public: boolean;
 		public_slug: string | null;
+		folder?: string | null;
 	}
 
 	interface SnippetVersion {


### PR DESCRIPTION
Adds a Folder field on every snippet plus a sidebar Folders section, sitting alongside Tags. V1 keeps the model intentionally flat (no nesting), parity with how Tags work today.

Schema
- New migration supabase/migrations/003_add_folder_to_snippet.sql: ALTER TABLE snippet ADD COLUMN folder TEXT, plus a partial composite index (user_id, folder) WHERE folder IS NOT NULL so the per-user "snippets in folder X" query is O(log n). Rollback file included.
- Snippet interface gains folder?: string | null.
- SnippetValueObject initializes folder: null.

Queries
- New getSnippetsByFolder(folder) filtered by {user_id, folder}, soft- delete aware. Follows the existing pattern.
- saveSnippet payload now persists folder. Empty/whitespace input is normalized to null so the partial index doesn't see empty strings.

UI
- SnippetDetails has a new Folder input under the header. Plain text with a 60-char cap (datalist autocomplete deferred — would require passing folders through and extending shared Input to support the list attribute).
- useCurrentSnippet exposes updateCurrentSnippetFolder; the hook also exports folder in its return shape.
- Aside renders a new Folders section above Tags, using the existing AsideItem renderer (TagItem shape works as-is). Expanded by default; collapsible like Tags. Folder icon already existed in /icons.
- page.tsx tracks folders state via a new getFolders() helper that mirrors getTags() — same call sites in getSnippets and updateSnippetTagList. getSnippetsByFolderHandler runs the filtered query and sets activeSnippetId to the first result.
- updateSnippetTagList's perf-skip from P2 #13 now considers both tags and folder changes — refreshes when either changed.

Not in this PR
- Smart groups (saved searches in user_metadata + sidebar section)
- Nested folders (parent_id tree)
- Drag-drop snippets into folders
- Rename folder (currently only via per-snippet edit)