### PR TITLE
feat: F10 (smart groups) — saved searches stored in user_metadata

### DIFF
--- a/app/components/Aside/Aside.tsx
+++ b/app/components/Aside/Aside.tsx
@@ -34,6 +34,8 @@ import Trash from "@/components/ui/icons/Trash";
 import Book from "@/components/ui/icons/Book";
 import Bookmark from "@/components/ui/icons/Bookmark";
 import Folder from "@/components/ui/icons/Folder";
+import Floppy from "@/components/ui/icons/Floppy";
+import MagnifyingGlass from "@/components/ui/icons/MagnifyingGlass";
 import Star from "@/components/ui/icons/Star";
 import Loading from "@/components/ui/icons/Loading";
 import List from "@/components/ui/icons/List";
@@ -49,6 +51,7 @@ type AsideProps = {
 	codeEditorStates: SnippetEditorStates;
 	tags: TagItem[];
 	folders: TagItem[];
+	smartGroups: SmartGroup[];
 	publicCount: number;
 	allCount: number;
 	uncategorizedCount: number;
@@ -60,6 +63,8 @@ type AsideProps = {
 	onGetTrash: () => void;
 	onTagClick: (tag: string) => void;
 	onFolderClick: (folder: string) => void;
+	onSmartGroupClick: (group: SmartGroup) => void;
+	onSmartGroupRemove: (name: string) => void;
 	onAccountClick: () => void;
 };
 
@@ -68,6 +73,7 @@ const Aside = ({
 	codeEditorStates,
 	tags,
 	folders,
+	smartGroups,
 	publicCount,
 	allCount,
 	uncategorizedCount,
@@ -79,6 +85,8 @@ const Aside = ({
 	onGetTrash,
 	onTagClick,
 	onFolderClick,
+	onSmartGroupClick,
+	onSmartGroupRemove,
 	onAccountClick,
 }: AsideProps): ReactElement => {
 	const { menuType } = codeEditorStates;
@@ -344,6 +352,42 @@ const Aside = ({
 							Trash
 						</a>
 					</section>
+
+					{!isLoading && smartGroups?.length > 0 && (
+						<section className={styles.section}>
+							<h2 className={`${styles.title} cyan-color`}>
+								<MagnifyingGlass
+									className={styles.icon}
+									width={18}
+									height={18}
+								/>
+								Smart Groups
+							</h2>
+							<ul>
+								{smartGroups.map((group) => (
+									<li
+										key={`smart-group-${group.name}`}
+										className={`${styles.smartGroupItem} ${menuType === `smart:${group.name}` ? styles.linkItemActive : ""}`}
+										onClick={() => onSmartGroupClick(group)}
+									>
+										<Floppy className={styles.icon} width={14} height={14} />
+										<span className={styles.smartGroupName}>{group.name}</span>
+										<button
+											type="button"
+											className={styles.smartGroupRemove}
+											aria-label={`Remove smart group ${group.name}`}
+											onClick={(event) => {
+												event.stopPropagation();
+												onSmartGroupRemove(group.name);
+											}}
+										>
+											×
+										</button>
+									</li>
+								))}
+							</ul>
+						</section>
+					)}
 
 					{!isLoading && folders?.length > 0 && (
 						<section

--- a/app/components/Aside/aside.module.css
+++ b/app/components/Aside/aside.module.css
@@ -91,6 +91,46 @@
 	margin-left: 0.313rem;
 }
 
+.smartGroupItem {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.313rem 0.938rem;
+	cursor: pointer;
+	font-size: var(--small-font-size);
+	color: var(--foreground-color);
+}
+
+.smartGroupItem:hover {
+	background: var(--current-line);
+}
+
+.smartGroupName {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.smartGroupRemove {
+	background: none;
+	border: none;
+	color: var(--gray-color);
+	cursor: pointer;
+	font-size: 1rem;
+	line-height: 1;
+	padding: 0 0.25rem;
+	visibility: hidden;
+}
+
+.smartGroupRemove:hover {
+	color: var(--red-color);
+}
+
+.smartGroupItem:hover .smartGroupRemove {
+	visibility: visible;
+}
+
 .settingsItems {
 	color: var(--gray-color);
 	cursor: pointer;

--- a/app/components/SnippetList/SnippetList.tsx
+++ b/app/components/SnippetList/SnippetList.tsx
@@ -26,6 +26,7 @@ import NewFile from "@/components/ui/icons/NewFile";
 import Alert from "@/components/ui/Alert/Alert";
 import Check from "@/components/ui/icons/Check";
 import CloseSquare from "@/components/ui/icons/CloseSquare";
+import Floppy from "@/components/ui/icons/Floppy";
 import Loading from "@/components/ui/icons/Loading";
 import SkeletonSnippetItem from "@/components/ui/Skeleton/SkeletonSnippetItem";
 import SnippetItem from "@/components/SnippetItem/SnippetItem";
@@ -37,19 +38,27 @@ import styles from "./snippetlist.module.css";
 interface SnippetListProps extends SnippetItemProps {
 	isLoading: boolean;
 	snippets?: Snippet[];
+	seedSearchQuery?: string | null;
+	canSaveSmartGroup?: boolean;
 	onNewSnippet: (newSnippet: Snippet) => void;
 	onEmptyTrash: () => void;
+	onSaveSmartGroup?: (name: string, query: string) => Promise<void> | void;
 }
+
+const maxSmartGroupNameLength = 40;
 
 const SnippetList = ({
 	isLoading,
 	snippets = [],
 	codeEditorStates,
+	seedSearchQuery,
+	canSaveSmartGroup,
 	onNewSnippet,
 	onActiveSnippet,
 	onDeleteSnippet,
 	onRestoreSnippet,
 	onEmptyTrash,
+	onSaveSmartGroup,
 }: SnippetListProps): ReactElement => {
 	const { menuType } = codeEditorStates ?? {};
 	const [searchData, setSearchData] = useState<SearchData>({
@@ -59,6 +68,9 @@ const SnippetList = ({
 	});
 	const [deleteAll, setDeleteAll] = useState<boolean>(false);
 	const [isDeleting, setIsDeleting] = useState<boolean>(false);
+	const [smartGroupFormOpen, setSmartGroupFormOpen] = useState<boolean>(false);
+	const [smartGroupName, setSmartGroupName] = useState<string>("");
+	const [isSavingSmartGroup, setIsSavingSmartGroup] = useState<boolean>(false);
 	const asideRef = useRef<HTMLDivElement | null>(null);
 	const mobileListOpen = useMenuStore((state) => state.snippetListOpen);
 	const isTrashActive = menuType === "trash";
@@ -123,6 +135,51 @@ const SnippetList = ({
 	}, [snippets]);
 
 	useEffect(() => {
+		if (!seedSearchQuery) return;
+
+		setSearchData((prev) => ({
+			searchQuery: seedSearchQuery,
+			originalSnippets: prev.originalSnippets,
+			snippetsFound: prev.originalSnippets.filter((item: Snippet) => {
+				const lowerQuery = seedSearchQuery.toLowerCase();
+
+				return (
+					item.name.toLowerCase().includes(lowerQuery) ||
+					item.snippet.toLowerCase().includes(lowerQuery) ||
+					(item.tags ?? "").toLowerCase().includes(lowerQuery)
+				);
+			}),
+		}));
+	}, [seedSearchQuery]);
+
+	const handleStartSaveSmartGroup = (): void => {
+		setSmartGroupName(searchData.searchQuery.slice(0, maxSmartGroupNameLength));
+		setSmartGroupFormOpen(true);
+	};
+
+	const handleCancelSaveSmartGroup = (): void => {
+		setSmartGroupName("");
+		setSmartGroupFormOpen(false);
+	};
+
+	const handleSubmitSaveSmartGroup = async (): Promise<void> => {
+		const trimmedName = smartGroupName.trim();
+		const trimmedQuery = searchData.searchQuery.trim();
+
+		if (!trimmedName || !trimmedQuery || !onSaveSmartGroup) return;
+
+		setIsSavingSmartGroup(true);
+
+		try {
+			await onSaveSmartGroup(trimmedName, trimmedQuery);
+			setSmartGroupName("");
+			setSmartGroupFormOpen(false);
+		} finally {
+			setIsSavingSmartGroup(false);
+		}
+	};
+
+	useEffect(() => {
 		if (!isTrashActive && deleteAll) {
 			setDeleteAll(false);
 		}
@@ -154,6 +211,19 @@ const SnippetList = ({
 					onChange={handleSearchInputChange}
 				/>
 
+				{canSaveSmartGroup &&
+					searchData.searchQuery.length > 0 &&
+					!isTrashActive && (
+						<button
+							type="button"
+							className={styles.saveSearchButton}
+							title="Save as smart group"
+							onClick={handleStartSaveSmartGroup}
+						>
+							<Floppy width={20} height={20} />
+						</button>
+					)}
+
 				{isTrashActive ? (
 					<Trash
 						className={styles.addButton}
@@ -170,6 +240,42 @@ const SnippetList = ({
 					/>
 				)}
 			</div>
+
+			{smartGroupFormOpen && (
+				<div className={styles.smartGroupForm}>
+					<input
+						type="text"
+						className={styles.smartGroupInput}
+						placeholder="Smart group name"
+						value={smartGroupName}
+						maxLength={maxSmartGroupNameLength}
+						autoFocus
+						onChange={(event) => setSmartGroupName(event.target.value)}
+						onKeyDown={(event) => {
+							if (event.key === "Enter") {
+								void handleSubmitSaveSmartGroup();
+							} else if (event.key === "Escape") {
+								handleCancelSaveSmartGroup();
+							}
+						}}
+					/>
+					<button
+						type="button"
+						className={styles.smartGroupSaveButton}
+						disabled={isSavingSmartGroup || smartGroupName.trim().length === 0}
+						onClick={handleSubmitSaveSmartGroup}
+					>
+						Save
+					</button>
+					<button
+						type="button"
+						className={styles.smartGroupCancelButton}
+						onClick={handleCancelSaveSmartGroup}
+					>
+						Cancel
+					</button>
+				</div>
+			)}
 
 			{isLoading ? (
 				<ul className={styles.snippetsList}>

--- a/app/components/SnippetList/SnippetList.tsx
+++ b/app/components/SnippetList/SnippetList.tsx
@@ -35,10 +35,12 @@ import EmptyState from "@/components/ui/EmptyState/EmptyState";
 /* Styles */
 import styles from "./snippetlist.module.css";
 
+type SeedSearch = { query: string; nonce: number };
+
 interface SnippetListProps extends SnippetItemProps {
 	isLoading: boolean;
 	snippets?: Snippet[];
-	seedSearchQuery?: string | null;
+	seedSearch?: SeedSearch | null;
 	canSaveSmartGroup?: boolean;
 	onNewSnippet: (newSnippet: Snippet) => void;
 	onEmptyTrash: () => void;
@@ -51,7 +53,7 @@ const SnippetList = ({
 	isLoading,
 	snippets = [],
 	codeEditorStates,
-	seedSearchQuery,
+	seedSearch,
 	canSaveSmartGroup,
 	onNewSnippet,
 	onActiveSnippet,
@@ -135,14 +137,14 @@ const SnippetList = ({
 	}, [snippets]);
 
 	useEffect(() => {
-		if (!seedSearchQuery) return;
+		if (!seedSearch || !seedSearch.query) return;
+
+		const lowerQuery = seedSearch.query.toLowerCase();
 
 		setSearchData((prev) => ({
-			searchQuery: seedSearchQuery,
+			searchQuery: seedSearch.query,
 			originalSnippets: prev.originalSnippets,
 			snippetsFound: prev.originalSnippets.filter((item: Snippet) => {
-				const lowerQuery = seedSearchQuery.toLowerCase();
-
 				return (
 					item.name.toLowerCase().includes(lowerQuery) ||
 					item.snippet.toLowerCase().includes(lowerQuery) ||
@@ -150,7 +152,7 @@ const SnippetList = ({
 				);
 			}),
 		}));
-	}, [seedSearchQuery]);
+	}, [seedSearch?.nonce, seedSearch?.query]);
 
 	const handleStartSaveSmartGroup = (): void => {
 		setSmartGroupName(searchData.searchQuery.slice(0, maxSmartGroupNameLength));

--- a/app/components/SnippetList/snippetlist.module.css
+++ b/app/components/SnippetList/snippetlist.module.css
@@ -42,6 +42,77 @@
 	margin-bottom: 0;
 }
 
+.saveSearchButton {
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: var(--gray-color);
+	display: flex;
+	align-items: center;
+	padding: 0.25rem;
+	border-radius: var(--border-radius);
+}
+
+.saveSearchButton:hover {
+	color: var(--cyan-color);
+	background: var(--current-line);
+}
+
+.smartGroupForm {
+	display: flex;
+	gap: 0.5rem;
+	padding: 0.5rem 0.75rem;
+	background: var(--bg-color-dark);
+	border-bottom: 1px solid var(--border-color);
+	align-items: center;
+}
+
+.smartGroupInput {
+	flex: 1;
+	background: var(--bg-color);
+	color: var(--foreground-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	padding: 0.375rem 0.5rem;
+	font-size: var(--small-font-size);
+	font-family: inherit;
+	outline: none;
+}
+
+.smartGroupInput:focus {
+	border-color: var(--cyan-color);
+}
+
+.smartGroupSaveButton {
+	background: var(--cyan-color);
+	color: var(--bg-color-dark);
+	border: none;
+	border-radius: var(--border-radius);
+	padding: 0.375rem 0.75rem;
+	font-size: var(--small-font-size);
+	font-weight: 600;
+	cursor: pointer;
+}
+
+.smartGroupSaveButton:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.smartGroupCancelButton {
+	background: none;
+	border: 1px solid var(--border-color);
+	color: var(--foreground-color);
+	border-radius: var(--border-radius);
+	padding: 0.375rem 0.75rem;
+	font-size: var(--small-font-size);
+	cursor: pointer;
+}
+
+.smartGroupCancelButton:hover {
+	background: var(--current-line);
+}
+
 .snippetsListContainer {
 	display: block;
 	width: 100%;

--- a/app/lib/supabase/queries.ts
+++ b/app/lib/supabase/queries.ts
@@ -399,6 +399,35 @@ export const toggleSnippetPublic = async (
 	return slug;
 };
 
+export const getSmartGroups = async (): Promise<SmartGroup[]> => {
+	const session = await getUserDataFromSession();
+	const stored = session?.user?.user_metadata?.smart_groups;
+
+	if (!Array.isArray(stored)) {
+		return [];
+	}
+
+	return stored.filter(
+		(item): item is SmartGroup =>
+			Boolean(item) &&
+			typeof item === "object" &&
+			typeof (item as SmartGroup).name === "string" &&
+			typeof (item as SmartGroup).query === "string"
+	);
+};
+
+export const saveSmartGroups = async (groups: SmartGroup[]): Promise<void> => {
+	if (!supabase) return;
+
+	const { error } = await supabase.auth.updateUser({
+		data: { smart_groups: groups },
+	});
+
+	if (error) {
+		throw new Error("Error saving smart groups");
+	}
+};
+
 export const updateUser = async (
 	attributes: UserAttributes
 ): Promise<UserResponse> => {

--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -44,7 +44,10 @@ export default function Page(): ReactElement {
 	const [tags, setTags] = useState<TagItem[]>([]);
 	const [folders, setFolders] = useState<TagItem[]>([]);
 	const [smartGroups, setSmartGroups] = useState<SmartGroup[]>([]);
-	const [seedSearchQuery, setSeedSearchQuery] = useState<string | null>(null);
+	const [seedSearch, setSeedSearch] = useState<{
+		query: string;
+		nonce: number;
+	} | null>(null);
 	const [codeEditorStates, setCodedEditorStates] =
 		useState<SnippetEditorStates>(defaultCodeEditorStates);
 	const [publicCount, setPublicCount] = useState<number>(0);
@@ -575,7 +578,7 @@ export default function Page(): ReactElement {
 			...prev,
 			menuType: `smart:${group.name}`,
 		}));
-		setSeedSearchQuery(group.query);
+		setSeedSearch({ query: group.query, nonce: Date.now() });
 	};
 
 	const handleAccountModalClose = (): void => {
@@ -677,7 +680,7 @@ export default function Page(): ReactElement {
 						isLoading={isLoading}
 						snippets={snippets}
 						codeEditorStates={codeEditorStates}
-						seedSearchQuery={seedSearchQuery}
+						seedSearch={seedSearch}
 						canSaveSmartGroup
 						onNewSnippet={newSnippetHandler}
 						onActiveSnippet={setActiveSnippetId}

--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -13,10 +13,12 @@ import CommandPalette from "@/components/CommandPalette/CommandPalette";
 /* Lib and Utils */
 import {
 	getAllSnippets,
+	getSmartGroups,
 	getSnippetsByFolder,
 	getSnippetsByState,
 	getSnippetsByTag,
 	getUncategorizedSnippets,
+	saveSmartGroups,
 	saveSnippet,
 	saveSnippetVersion,
 	setNewSnippet,
@@ -41,6 +43,8 @@ export default function Page(): ReactElement {
 	const [snippets, setSnippets] = useState<Snippet[]>([]);
 	const [tags, setTags] = useState<TagItem[]>([]);
 	const [folders, setFolders] = useState<TagItem[]>([]);
+	const [smartGroups, setSmartGroups] = useState<SmartGroup[]>([]);
+	const [seedSearchQuery, setSeedSearchQuery] = useState<string | null>(null);
 	const [codeEditorStates, setCodedEditorStates] =
 		useState<SnippetEditorStates>(defaultCodeEditorStates);
 	const [publicCount, setPublicCount] = useState<number>(0);
@@ -506,6 +510,74 @@ export default function Page(): ReactElement {
 		setIsAccountModalOpen(true);
 	};
 
+	const loadSmartGroups = async (): Promise<void> => {
+		try {
+			const groups = await getSmartGroups();
+
+			setSmartGroups(groups);
+		} catch {
+			setSmartGroups([]);
+		}
+	};
+
+	const handleSaveSmartGroup = async (
+		name: string,
+		query: string
+	): Promise<void> => {
+		const trimmedName = name.trim();
+		const trimmedQuery = query.trim();
+
+		if (!trimmedName || !trimmedQuery) return;
+
+		const filtered = smartGroups.filter(
+			(group) => group.name.toLowerCase() !== trimmedName.toLowerCase()
+		);
+		const next = [...filtered, { name: trimmedName, query: trimmedQuery }];
+
+		setSmartGroups(next);
+
+		try {
+			await saveSmartGroups(next);
+			addToast({
+				type: ToastType.Success,
+				message: `Saved smart group "${trimmedName}"`,
+			});
+		} catch {
+			setSmartGroups(smartGroups);
+			addToast({
+				type: ToastType.Error,
+				message: "Failed to save smart group",
+			});
+		}
+	};
+
+	const handleRemoveSmartGroup = async (name: string): Promise<void> => {
+		const next = smartGroups.filter((group) => group.name !== name);
+		const previous = smartGroups;
+
+		setSmartGroups(next);
+
+		try {
+			await saveSmartGroups(next);
+		} catch {
+			setSmartGroups(previous);
+			addToast({
+				type: ToastType.Error,
+				message: "Failed to remove smart group",
+			});
+		}
+	};
+
+	const handleSmartGroupClick = async (group: SmartGroup): Promise<void> => {
+		await getSnippets();
+
+		setCodedEditorStates((prev) => ({
+			...prev,
+			menuType: `smart:${group.name}`,
+		}));
+		setSeedSearchQuery(group.query);
+	};
+
 	const handleAccountModalClose = (): void => {
 		setIsAccountModalOpen(false);
 	};
@@ -559,6 +631,7 @@ export default function Page(): ReactElement {
 
 	useEffect(() => {
 		getSnippets().then(() => null);
+		loadSmartGroups().then(() => null);
 	}, []);
 
 	useEffect(() => {
@@ -582,6 +655,7 @@ export default function Page(): ReactElement {
 						codeEditorStates={codeEditorStates}
 						tags={tags}
 						folders={folders}
+						smartGroups={smartGroups}
 						publicCount={publicCount}
 						allCount={allCount}
 						uncategorizedCount={uncategorizedCount}
@@ -593,6 +667,8 @@ export default function Page(): ReactElement {
 						onGetTrash={getTrashHandler}
 						onTagClick={getSnippetsByTagHandler}
 						onFolderClick={getSnippetsByFolderHandler}
+						onSmartGroupClick={handleSmartGroupClick}
+						onSmartGroupRemove={handleRemoveSmartGroup}
 						onAccountClick={handleAccountClick}
 					/>
 				}
@@ -601,11 +677,14 @@ export default function Page(): ReactElement {
 						isLoading={isLoading}
 						snippets={snippets}
 						codeEditorStates={codeEditorStates}
+						seedSearchQuery={seedSearchQuery}
+						canSaveSmartGroup
 						onNewSnippet={newSnippetHandler}
 						onActiveSnippet={setActiveSnippetId}
 						onDeleteSnippet={trashRestoreSnippetHandler}
 						onRestoreSnippet={trashRestoreSnippetHandler}
 						onEmptyTrash={emptyTrashHandler}
+						onSaveSmartGroup={handleSaveSmartGroup}
 					/>
 				}
 				codeEditor={

--- a/types/snippets.d.ts
+++ b/types/snippets.d.ts
@@ -72,6 +72,11 @@ declare global {
 
 	type AiProvider = "ollama" | "claude" | "openai";
 
+	interface SmartGroup {
+		name: string;
+		query: string;
+	}
+
 	type AiAction =
 		| "explain"
 		| "comments"

--- a/types/supabase.d.ts
+++ b/types/supabase.d.ts
@@ -24,6 +24,7 @@ interface User {
 		ai_model?: string;
 		ai_url?: string;
 		auto_save?: boolean;
+		smart_groups?: SmartGroup[];
 	};
 	aud: string;
 	confirmation_sent_at?: string;


### PR DESCRIPTION
Lets users save the current search query under a name, then re-run it with a single click from the sidebar. The full set is persisted as a JSON array on Supabase auth user_metadata.smart_groups, so no schema change is needed.

Capture
- New "Save as smart group" button next to the search input in SnippetList (only visible when there's text in the search and Trash is not active).
- Click opens a small inline form: name input + Save / Cancel. Enter submits, Escape cancels. Max name length 40 chars.
- The current search query is the saved query. The form pre-fills the name from the query so a one-keypress save is possible.

Display + run
- New Smart Groups section in Aside, between the main menu and Folders. Each entry shows a Floppy icon + the smart group name and a hover-visible × button to remove.
- Clicking a smart group reloads all snippets, sets menuType to "smart:<name>", and pushes the saved query down to SnippetList via a seedSearchQuery prop. SnippetList watches the prop in a useEffect and re-filters its in-memory list to match.

Plumbing
- types/snippets.d.ts: new SmartGroup interface ({ name, query }).
- types/supabase.d.ts: user_metadata gains optional smart_groups.
- app/lib/supabase/queries.ts: getSmartGroups() reads + validates the array from the session; saveSmartGroups() persists via supabase.auth.updateUser({ data: { smart_groups } }).
- Aside accepts smartGroups + onSmartGroupClick + onSmartGroupRemove and renders the section inline (not via AsideItem since the items need a delete affordance).
- SnippetList accepts seedSearchQuery, canSaveSmartGroup, and onSaveSmartGroup. The optimistic save updates local state first, rolls back on failure with an error toast.
- page.tsx loads smart groups on mount alongside snippets and wires the handlers. Optimistic remove with rollback on save failure.

Not in this PR
- Inline edit / rename smart group (delete + re-create works)
- Drag-reorder smart groups
- Smart groups that run server-side FTS instead of the existing client-side search filter (deferred with the wider P2 #15 FTS work)
- Replace the inline form with a proper modal (functional UX trade-off)