### PR TITLE
fix: P1 #9 — enforce snippet_version retention via Postgres trigger

### DIFF
--- a/app/lib/supabase/queries.ts
+++ b/app/lib/supabase/queries.ts
@@ -293,21 +293,6 @@ export const saveSnippetVersion = async (
 		if (error) {
 			throw new Error("Error saving snippet version");
 		}
-
-		const { data: allVersions } = await supabase
-			.from("snippet_version")
-			.select("version_id")
-			.eq("snippet_id", snippetId)
-			.order("version_number", { ascending: false });
-
-		if (allVersions && allVersions.length > 5) {
-			const excessIds = allVersions.slice(5).map((v) => v.version_id);
-
-			await supabase
-				.from("snippet_version")
-				.delete()
-				.in("version_id", excessIds);
-		}
 	}
 };
 

--- a/supabase/migrations/004_snippet_version_cleanup_trigger.sql
+++ b/supabase/migrations/004_snippet_version_cleanup_trigger.sql
@@ -1,0 +1,31 @@
+-- P1 #9 — atomic "keep the last 5 versions per snippet" enforcement.
+--
+-- The previous JS-side enforcement (in queries.ts saveSnippetVersion) was racy:
+-- it fetched all versions, then deleted the older ones in a second round-trip.
+-- Two concurrent saves of the same snippet (e.g. autosave + manual save) could
+-- interleave and prune the wrong rows.
+--
+-- This Postgres trigger runs synchronously inside the same transaction as the
+-- INSERT, so retention is enforced atomically per snippet.
+
+CREATE OR REPLACE FUNCTION enforce_max_snippet_versions()
+RETURNS TRIGGER AS $$
+BEGIN
+	DELETE FROM snippet_version
+	WHERE version_id IN (
+		SELECT version_id FROM snippet_version
+		WHERE snippet_id = NEW.snippet_id
+		ORDER BY version_number DESC
+		OFFSET 5
+	);
+
+	RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS snippet_version_max_versions ON snippet_version;
+
+CREATE TRIGGER snippet_version_max_versions
+	AFTER INSERT ON snippet_version
+	FOR EACH ROW
+	EXECUTE FUNCTION enforce_max_snippet_versions();

--- a/supabase/migrations/rollback_004_drop_trigger.sql
+++ b/supabase/migrations/rollback_004_drop_trigger.sql
@@ -1,0 +1,5 @@
+-- Rollback for 004_snippet_version_cleanup_trigger.sql
+
+DROP TRIGGER IF EXISTS snippet_version_max_versions ON snippet_version;
+
+DROP FUNCTION IF EXISTS enforce_max_snippet_versions();


### PR DESCRIPTION
Replaces the JS-side "keep the last 5 versions" cleanup in saveSnippetVersion with an AFTER INSERT trigger on snippet_version.

The old flow was racy: fetch all version ids, then DELETE the ones past position 5 in a second round-trip. Two concurrent saves of the same snippet (autosave + manual save) could interleave and prune the wrong rows, occasionally erasing a version the user wanted to keep.

The trigger runs inside the same transaction as the INSERT, so retention is atomic per snippet_id. The function uses OFFSET 5 on an ordered subselect to delete only the rows beyond the newest five.

- supabase/migrations/004_snippet_version_cleanup_trigger.sql — creates enforce_max_snippet_versions() and the snippet_version_max_versions AFTER INSERT trigger. Idempotent (CREATE OR REPLACE / DROP IF EXISTS).
- supabase/migrations/rollback_004_drop_trigger.sql — companion rollback.
- app/lib/supabase/queries.ts — saveSnippetVersion drops the post-insert fetch + delete block. Net: one fewer client round-trip per version insert, plus the race goes away.