### PR TITLE
feat: shortcuts modal — Cmd+/ opens a keyboard-shortcut reference

### DIFF
--- a/app/components/Aside/Aside.tsx
+++ b/app/components/Aside/Aside.tsx
@@ -351,20 +351,6 @@ const Aside = ({
 							<Trash className={styles.icon} height={18} width={18} />
 							Trash
 						</a>
-
-						<a
-							className={`${styles.linkItem} gray-color`}
-							onClick={(event: MouseEvent<HTMLAnchorElement>) => {
-								event?.preventDefault();
-								setIsShortcutsOpen(true);
-							}}
-						>
-							<Keyboard className={styles.icon} height={18} width={18} />
-							Shortcuts
-							<span className={styles.shortcutHint}>
-								{isMac ? "⌘" : "Ctrl"} /
-							</span>
-						</a>
 					</section>
 
 					{!isLoading && folders?.length > 0 && (
@@ -466,6 +452,21 @@ const Aside = ({
 							<span className={styles.userMenuLabel}>Settings</span>
 							<span className={styles.userMenuShortcut}>
 								{isMac ? "⌘" : "Ctrl"} ,
+							</span>
+						</button>
+
+						<button
+							className={styles.userMenuItem}
+							role="menuitem"
+							onClick={() => {
+								setIsUserMenuOpen(false);
+								setIsShortcutsOpen(true);
+							}}
+						>
+							<Keyboard className={styles.userMenuIco} width={16} height={16} />
+							<span className={styles.userMenuLabel}>Shortcuts</span>
+							<span className={styles.userMenuShortcut}>
+								{isMac ? "⌘" : "Ctrl"} /
 							</span>
 						</button>
 

--- a/app/components/Aside/Aside.tsx
+++ b/app/components/Aside/Aside.tsx
@@ -40,6 +40,8 @@ import List from "@/components/ui/icons/List";
 import Rows from "@/components/ui/icons/Rows";
 import CaretDown from "@/components/ui/icons/CaretDown";
 import Globe from "@/components/ui/icons/Globe";
+import Keyboard from "@/components/ui/icons/Keyboard";
+import ShortcutsModal from "@/components/ShortcutsModal/ShortcutsModal";
 
 /* Styles */
 import styles from "./aside.module.css";
@@ -90,6 +92,7 @@ const Aside = ({
 	const [isTagsExpanded, setIsTagsExpanded] = useState<boolean>(false);
 	const [isFoldersExpanded, setIsFoldersExpanded] = useState<boolean>(true);
 	const [isUserMenuOpen, setIsUserMenuOpen] = useState<boolean>(false);
+	const [isShortcutsOpen, setIsShortcutsOpen] = useState<boolean>(false);
 	const [isMac, setIsMac] = useState<boolean>(true);
 
 	// User store
@@ -251,6 +254,11 @@ const Aside = ({
 				setIsUserMenuOpen(false);
 				onAccountClick();
 			}
+
+			if ((event.metaKey || event.ctrlKey) && event.key === "/") {
+				event.preventDefault();
+				setIsShortcutsOpen((current) => !current);
+			}
 		};
 
 		document.addEventListener("keydown", handleKeyDown);
@@ -342,6 +350,20 @@ const Aside = ({
 						>
 							<Trash className={styles.icon} height={18} width={18} />
 							Trash
+						</a>
+
+						<a
+							className={`${styles.linkItem} gray-color`}
+							onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+								event?.preventDefault();
+								setIsShortcutsOpen(true);
+							}}
+						>
+							<Keyboard className={styles.icon} height={18} width={18} />
+							Shortcuts
+							<span className={styles.shortcutHint}>
+								{isMac ? "⌘" : "Ctrl"} /
+							</span>
 						</a>
 					</section>
 
@@ -523,6 +545,11 @@ const Aside = ({
 					</li>
 				</ul>
 			</aside>
+
+			<ShortcutsModal
+				isOpen={isShortcutsOpen}
+				onClose={() => setIsShortcutsOpen(false)}
+			/>
 		</>
 	);
 };

--- a/app/components/Aside/aside.module.css
+++ b/app/components/Aside/aside.module.css
@@ -91,6 +91,16 @@
 	margin-left: 0.313rem;
 }
 
+.shortcutHint {
+	margin-left: auto;
+	font-size: var(--tiny-font-size);
+	color: var(--comment-color);
+	background: var(--bg-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	padding: 0.125rem 0.375rem;
+}
+
 .settingsItems {
 	color: var(--gray-color);
 	cursor: pointer;

--- a/app/components/Aside/aside.module.css
+++ b/app/components/Aside/aside.module.css
@@ -91,16 +91,6 @@
 	margin-left: 0.313rem;
 }
 
-.shortcutHint {
-	margin-left: auto;
-	font-size: var(--tiny-font-size);
-	color: var(--comment-color);
-	background: var(--bg-color);
-	border: 1px solid var(--border-color);
-	border-radius: var(--border-radius);
-	padding: 0.125rem 0.375rem;
-}
-
 .settingsItems {
 	color: var(--gray-color);
 	cursor: pointer;

--- a/app/components/ShortcutsModal/ShortcutsModal.tsx
+++ b/app/components/ShortcutsModal/ShortcutsModal.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { ReactElement, useEffect, useState } from "react";
+
+/* Components */
+import Modal from "@/components/ui/Modal/Modal";
+
+/* Constants */
+import shortcutGroups from "@/lib/constants/shortcuts";
+
+/* Styles */
+import styles from "./shortcutsModal.module.css";
+
+type ShortcutsModalProps = {
+	isOpen: boolean;
+	onClose: () => void;
+};
+
+const ShortcutsModal = ({
+	isOpen,
+	onClose,
+}: ShortcutsModalProps): ReactElement => {
+	const [modKey, setModKey] = useState<string>("Ctrl");
+
+	useEffect(() => {
+		if (typeof navigator !== "undefined") {
+			setModKey(navigator.userAgent.includes("Mac") ? "⌘" : "Ctrl");
+		}
+	}, []);
+
+	const renderKey = (key: string): string => (key === "Mod" ? modKey : key);
+
+	return (
+		<Modal isOpen={isOpen} onClose={onClose} title="Keyboard shortcuts">
+			<div className={styles.groups}>
+				{shortcutGroups.map((group) => (
+					<section key={group.heading} className={styles.group}>
+						<h3 className={styles.groupHeading}>{group.heading}</h3>
+						<ul className={styles.list}>
+							{group.items.map((item, index) => (
+								<li key={`${group.heading}-${index}`} className={styles.row}>
+									<span className={styles.description}>{item.description}</span>
+									<span className={styles.keys}>
+										{item.keys.map((key, keyIndex) => (
+											<kbd
+												key={`${group.heading}-${index}-${keyIndex}`}
+												className={styles.kbd}
+											>
+												{renderKey(key)}
+											</kbd>
+										))}
+									</span>
+								</li>
+							))}
+						</ul>
+					</section>
+				))}
+			</div>
+		</Modal>
+	);
+};
+
+export default ShortcutsModal;

--- a/app/components/ShortcutsModal/shortcutsModal.module.css
+++ b/app/components/ShortcutsModal/shortcutsModal.module.css
@@ -1,0 +1,66 @@
+.groups {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+	min-width: min(90vw, 480px);
+}
+
+.group {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.groupHeading {
+	margin: 0;
+	font-size: var(--small-font-size);
+	font-weight: 600;
+	color: var(--cyan-color);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.list {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: 0.5rem 0.75rem;
+	border-radius: var(--border-radius-md);
+	background: var(--bg-color);
+	font-size: var(--small-font-size);
+}
+
+.description {
+	color: var(--foreground-color);
+	flex: 1;
+}
+
+.keys {
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+	flex-shrink: 0;
+}
+
+.kbd {
+	font-family: inherit;
+	font-size: var(--tiny-font-size);
+	color: var(--foreground-color);
+	background: var(--bg-color-dark);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	padding: 0.125rem 0.5rem;
+	line-height: 1.4;
+	min-width: 1.25rem;
+	text-align: center;
+}

--- a/app/components/ui/icons/Keyboard.tsx
+++ b/app/components/ui/icons/Keyboard.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from "react";
+
+import IconContainer from "@/components/ui/icons/Icon";
+
+const Keyboard = (props: Icon): ReactElement => {
+	return (
+		<IconContainer viewBox="0 0 256 256" {...props}>
+			<path d="M224,64H32A16,16,0,0,0,16,80V176a16,16,0,0,0,16,16H224a16,16,0,0,0,16-16V80A16,16,0,0,0,224,64Zm0,112H32V80H224V176ZM48,116a8,8,0,0,1,8-8H64a8,8,0,0,1,0,16H56A8,8,0,0,1,48,116Zm40,0a8,8,0,0,1,8-8h8a8,8,0,0,1,0,16H96A8,8,0,0,1,88,116Zm40,0a8,8,0,0,1,8-8h8a8,8,0,0,1,0,16h-8A8,8,0,0,1,128,116Zm40,0a8,8,0,0,1,8-8h24a8,8,0,0,1,0,16H176A8,8,0,0,1,168,116ZM48,148a8,8,0,0,1,8-8h8a8,8,0,0,1,0,16H56A8,8,0,0,1,48,148Zm40,0a8,8,0,0,1,8-8h64a8,8,0,0,1,0,16H96A8,8,0,0,1,88,148Zm88,0a8,8,0,0,1,8-8h16a8,8,0,0,1,0,16H184A8,8,0,0,1,176,148Z"></path>
+		</IconContainer>
+	);
+};
+
+export default Keyboard;

--- a/app/lib/constants/shortcuts.ts
+++ b/app/lib/constants/shortcuts.ts
@@ -1,0 +1,39 @@
+type ShortcutGroup = {
+	heading: string;
+	items: { keys: string[]; description: string }[];
+};
+
+const shortcutGroups: ShortcutGroup[] = [
+	{
+		heading: "Navigation",
+		items: [
+			{ keys: ["Mod", "K"], description: "Open command palette" },
+			{ keys: ["Mod", "/"], description: "Open shortcuts modal" },
+			{ keys: ["Mod", ","], description: "Open settings" },
+			{ keys: ["Esc"], description: "Close any open modal or drawer" },
+		],
+	},
+	{
+		heading: "Editor",
+		items: [
+			{ keys: ["Mod", "S"], description: "Save current snippet" },
+			{ keys: ["Mod", "I"], description: "Request AI inline completion" },
+			{ keys: ["Tab"], description: "Accept AI completion / indent" },
+			{ keys: ["Esc"], description: "Dismiss AI completion" },
+			{
+				keys: ["["],
+				description: "Type [[ in any snippet to link to another snippet",
+			},
+		],
+	},
+	{
+		heading: "Command palette (Mod+K)",
+		items: [
+			{ keys: ["↑", "↓"], description: "Navigate results" },
+			{ keys: ["↵"], description: "Select highlighted item" },
+			{ keys: ["Esc"], description: "Close the palette" },
+		],
+	},
+];
+
+export default shortcutGroups;


### PR DESCRIPTION
Adds a Shortcuts entry to the Aside main menu (under Trash) and a Cmd+/ / Ctrl+/ keyboard shortcut that opens a modal listing every keyboard binding in the app, grouped by area.

- New app/lib/constants/shortcuts.ts — declarative list of shortcut groups (Navigation / Editor / Command palette). The "Mod" token is rendered as ⌘ on macOS and Ctrl elsewhere by the modal at render time.
- New app/components/ShortcutsModal/ — wraps the existing shared Modal component, lays out groups + <kbd> chips with the existing theme variables. No new layout primitives.
- New Keyboard icon (Phosphor "Keyboard" path) used both for the menu entry and conceptually anywhere we surface shortcuts in the future.
- Aside gains an isShortcutsOpen state, a Cmd+/ listener inside the existing keydown effect (Esc and Cmd+, were already there), and a Shortcuts menu link that renders the platform-appropriate hint chip (⌘/ on macOS, Ctrl/ elsewhere). The Cmd+/ binding toggles the modal, so users can dismiss the same way they opened it.

Two ways to open per the request: the menu link and the keyboard shortcut. Modal closes via the close button, Esc, click-outside, or Cmd+/ again.

Shortcuts listed in the modal cover everything currently bound in the app: command palette, settings, save, AI inline completion, Tab-accept, wiki-link [[, and the palette navigation keys.