### PR TITLE
feat(markdown): highlight fenced code blocks with active theme

### DIFF
--- a/app/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/app/components/MarkdownPreview/MarkdownPreview.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { MouseEvent, ReactElement, useMemo } from "react";
-import { marked } from "marked";
-import DOMPurify from "isomorphic-dompurify";
+import { MouseEvent, ReactElement, useEffect, useState } from "react";
 
 /* Lib */
-import wikiLinkMarked from "@/lib/wikiLinkMarked";
+import { renderMarkdownToHtml } from "@/lib/markdownRenderer";
+import useUserStore from "@/lib/store/user.store";
+
+/* Types */
+import type { ThemeName } from "@/lib/config/themes";
 
 /* Styles */
 import styles from "./markdownPreview.module.css";
-
-marked.use(wikiLinkMarked);
 
 type MarkdownPreviewProps = {
 	content: string;
@@ -23,23 +23,48 @@ const MarkdownPreview = ({
 	height,
 	onWikiNavigate,
 }: MarkdownPreviewProps): ReactElement => {
-	const htmlContent = useMemo(() => {
-		if (!content) return "";
+	// Store theme is a plain string; narrow it to the ThemeName shiki expects
+	const theme = useUserStore((state) => state.theme) as ThemeName;
+	const [htmlContent, setHtmlContent] = useState<string>("");
 
-		const rawHtml = marked.parse(content, { async: false }) as string;
+	useEffect(() => {
+		if (!content) {
+			setHtmlContent("");
 
-		return DOMPurify.sanitize(rawHtml, {
-			ADD_ATTR: ["data-wiki-target"],
-		});
-	}, [content]);
+			return;
+		}
+
+		let cancelled = false;
+
+		renderMarkdownToHtml(content, theme)
+			.then((html) => {
+				if (!cancelled) {
+					setHtmlContent(html);
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setHtmlContent("");
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [content, theme]);
 
 	const handleClick = (event: MouseEvent<HTMLDivElement>): void => {
-		if (!onWikiNavigate) return;
+		if (!onWikiNavigate) {
+			return;
+		}
 
+		// event.target is the clicked DOM node within the rendered markdown
 		const target = event.target as HTMLElement;
 		const link = target.closest<HTMLElement>(".wiki-link");
 
-		if (!link) return;
+		if (!link) {
+			return;
+		}
 
 		const wikiTarget = link.getAttribute("data-wiki-target");
 

--- a/app/components/MarkdownPreview/markdownPreview.module.css
+++ b/app/components/MarkdownPreview/markdownPreview.module.css
@@ -26,6 +26,16 @@
 }
 
 .previewContent {
+	/* Code-block surface: the palette's darkest token nudged toward the
+	   foreground colour. On dark palettes the foreground is light (blocks read
+	   slightly raised); on light palettes it is dark (blocks read slightly
+	   inset). Either way the block stays distinct from the pane in every theme. */
+	--code-block-bg: color-mix(
+		in srgb,
+		var(--bg-color-dark) 88%,
+		var(--foreground-color)
+	);
+
 	flex: 1;
 	min-height: 0;
 	overflow-y: auto;
@@ -85,11 +95,21 @@
 }
 
 .previewContent pre {
-	background: var(--bg-color);
+	background: var(--code-block-bg);
 	padding: 0.75rem;
 	border-radius: 4px;
 	overflow-x: auto;
 	margin: 0.75rem 0;
+}
+
+/* Shiki stamps the highlight theme's own background-color inline on the <pre>
+   and tags it with a global "shiki" class. Override it with the derived
+   code-block surface so highlighted blocks stay distinct from the pane and
+   consistent with the active palette. The class must be wrapped in :global
+   (CSS Modules would otherwise hash it and never match), and an inline style
+   can only be beaten with !important. */
+.previewContent :global(pre.shiki) {
+	background-color: var(--code-block-bg) !important;
 }
 
 .previewContent pre code {

--- a/app/lib/config/shiki.ts
+++ b/app/lib/config/shiki.ts
@@ -35,6 +35,33 @@ const shikiLanguageMap: Record<string, string> = {
 	yaml: "yaml",
 };
 
+// Maps lowercase markdown fence info-strings (```js, ```ts, ```bash, …) and
+// their common aliases to the shiki grammar id used to highlight the block.
+const markdownFenceLanguageMap: Record<string, string> = {
+	bash: "bash",
+	css: "css",
+	go: "go",
+	golang: "go",
+	javascript: "javascript",
+	js: "javascript",
+	json: "json",
+	jsx: "javascript",
+	py: "python",
+	python: "python",
+	rb: "ruby",
+	rs: "rust",
+	ruby: "ruby",
+	rust: "rust",
+	sh: "bash",
+	shell: "bash",
+	shellscript: "bash",
+	sql: "sql",
+	ts: "typescript",
+	tsx: "typescript",
+	typescript: "typescript",
+	zsh: "bash",
+};
+
 export const getHighlightedCode = async (
 	code: string,
 	language: string,
@@ -47,4 +74,27 @@ export const getHighlightedCode = async (
 		lang: shikiLanguage,
 		theme: shikiTheme,
 	});
+};
+
+export const getHighlightedFenceCode = async (
+	code: string,
+	fenceLanguage: string,
+	theme: ThemeName
+): Promise<string | null> => {
+	const shikiLanguage = markdownFenceLanguageMap[fenceLanguage];
+
+	if (!shikiLanguage) {
+		return null;
+	}
+
+	const shikiTheme = shikiThemeMap[theme] ?? "dracula";
+
+	try {
+		return await codeToHtml(code, {
+			lang: shikiLanguage,
+			theme: shikiTheme,
+		});
+	} catch {
+		return null;
+	}
 };

--- a/app/lib/markdownRenderer.ts
+++ b/app/lib/markdownRenderer.ts
@@ -1,0 +1,78 @@
+import DOMPurify from "isomorphic-dompurify";
+import { Marked } from "marked";
+
+/* Lib */
+import { getHighlightedFenceCode } from "@/lib/config/shiki";
+import wikiLinkMarked from "@/lib/wikiLinkMarked";
+
+/* Utils */
+import { escapeHtml } from "@/utils/string.utils";
+
+/* Types */
+import type { ThemeName } from "@/lib/config/themes";
+
+const normalizeFenceLanguage = (language?: string): string =>
+	(language ?? "").trim().split(/\s+/)[0]?.toLowerCase() ?? "";
+
+// A normalized language never contains whitespace, so a single space cannot
+// collide as a separator between the language and the (verbatim) code body.
+const fenceCacheKey = (language: string, code: string): string =>
+	`${language} ${code}`;
+
+export const renderMarkdownToHtml = async (
+	content: string,
+	theme: ThemeName
+): Promise<string> => {
+	const highlightedByKey = new Map<string, string>();
+	const markedInstance = new Marked();
+
+	markedInstance.use(wikiLinkMarked);
+
+	markedInstance.use({
+		async: true,
+		walkTokens: async (token) => {
+			if (token.type !== "code") {
+				return;
+			}
+
+			const fenceLanguage = normalizeFenceLanguage(token.lang);
+			const highlighted = await getHighlightedFenceCode(
+				token.text,
+				fenceLanguage,
+				theme
+			);
+
+			if (highlighted) {
+				highlightedByKey.set(
+					fenceCacheKey(fenceLanguage, token.text),
+					highlighted
+				);
+			}
+		},
+		renderer: {
+			code(token) {
+				const fenceLanguage = normalizeFenceLanguage(token.lang);
+				const highlighted = highlightedByKey.get(
+					fenceCacheKey(fenceLanguage, token.text)
+				);
+
+				if (highlighted) {
+					return highlighted;
+				}
+
+				const escaped = escapeHtml(token.text);
+				const languageClass = fenceLanguage
+					? ` class="language-${escapeHtml(fenceLanguage)}"`
+					: "";
+
+				return `<pre><code${languageClass}>${escaped}</code></pre>`;
+			},
+		},
+	});
+
+	const rawHtml = await markedInstance.parse(content);
+
+	return DOMPurify.sanitize(rawHtml, {
+		ADD_ATTR: ["data-wiki-target"],
+	});
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- Highlight fenced code blocks in `MarkdownPreview` via shiki, keyed by the user's active theme.
- Add `app/lib/markdownRenderer.ts` that walks `marked` code tokens, highlights them with `getHighlightedFenceCode`, and inlines the result back into the rendered HTML. Preview re-renders on theme change and falls back to escaped HTML for unknown languages.
- Introduce a `--code-block-bg` CSS variable derived from the palette so highlighted blocks stay distinct from the pane in every theme.
- Override shiki's inline `background-color` on `pre.shiki` (`:global` + `!important`) so the highlight palette wins but the surface still matches the active theme.
- Add `next-env.d.ts` path fix for the Next.js 16 routes types location.

## Test plan

- [ ] Open a markdown snippet with a `\`\`\`ts` fence and verify it renders with the active theme's palette.
- [ ] Switch themes and verify the highlight color updates without remounting the editor.
- [ ] Open a fence with an unknown language (e.g. `\`\`\`nonsense`) and verify the block falls back to plain escaped HTML.
- [ ] Confirm wiki links inside the preview (`[[target]]`) still navigate and `data-wiki-target` survives sanitization.