### PR TITLE
feat(markdown): add keyboard shortcuts for bold, italic, code, and duplicate line

### DIFF
--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -9,6 +9,7 @@ import type { EditorView } from "@codemirror/view";
 import SupportedLanguages from "@/lib/config/languages";
 import languageExtensions from "@/lib/codeEditor";
 import inlineCompletion from "@/lib/inlineCompletion";
+import markdownKeymap from "@/lib/markdown/markdownKeymap";
 import wikiLinkAutocomplete from "@/lib/wikiLinkAutocomplete";
 import useViewPortStore from "@/lib/store/viewPort.store";
 import useUserStore from "@/lib/store/user.store";
@@ -307,6 +308,7 @@ const CodeEditor = ({
 										currentSnippet.extension,
 										inlineCompletionExtension,
 										wikiAutocompleteExtension,
+										...(isMarkdownLanguage ? [markdownKeymap] : []),
 									]}
 									theme={editorTheme}
 									height={editorHeight}

--- a/app/lib/constants/markdown.constants.ts
+++ b/app/lib/constants/markdown.constants.ts
@@ -19,3 +19,8 @@ export const linkUrlPlaceholder = "url";
 export const headingPattern = /^(#{1,6})\s/;
 export const numberedListPattern = /^\d+\.\s/;
 export const linkSyntaxPattern = /^\[(.*)\]\((.*)\)$/;
+
+export const boldShortcutKey = "Mod-b";
+export const duplicateLineShortcutKey = "Mod-d";
+export const inlineCodeShortcutKey = "Mod-e";
+export const italicShortcutKey = "Mod-i";

--- a/app/lib/constants/shortcuts.ts
+++ b/app/lib/constants/shortcuts.ts
@@ -17,13 +17,25 @@ const shortcutGroups: ShortcutGroup[] = [
 		heading: "Editor",
 		items: [
 			{ keys: ["Mod", "S"], description: "Save current snippet" },
-			{ keys: ["Mod", "I"], description: "Request AI inline completion" },
+			{
+				keys: ["Mod", "Shift", "I"],
+				description: "Request AI inline completion",
+			},
 			{ keys: ["Tab"], description: "Accept AI completion / indent" },
 			{ keys: ["Esc"], description: "Dismiss AI completion" },
 			{
 				keys: ["["],
 				description: "Type [[ in any snippet to link to another snippet",
 			},
+		],
+	},
+	{
+		heading: "Markdown editor",
+		items: [
+			{ keys: ["Mod", "B"], description: "Bold selected text" },
+			{ keys: ["Mod", "I"], description: "Italic selected text" },
+			{ keys: ["Mod", "E"], description: "Wrap selection in inline code" },
+			{ keys: ["Mod", "D"], description: "Duplicate current line below" },
 		],
 	},
 	{

--- a/app/lib/inlineCompletion.ts
+++ b/app/lib/inlineCompletion.ts
@@ -144,7 +144,7 @@ const inlineCompletion = (options: InlineCompletionOptions): Extension => {
 		keymap.of([
 			{ key: "Tab", run: acceptSuggestion },
 			{ key: "Escape", run: dismissSuggestion },
-			{ key: "Mod-i", run: requestCompletion, preventDefault: true },
+			{ key: "Mod-Shift-i", run: requestCompletion, preventDefault: true },
 		]),
 		EditorView.updateListener.of((update: ViewUpdate) => {
 			if (update.docChanged || update.selectionSet) {

--- a/app/lib/markdown/markdownKeymap.ts
+++ b/app/lib/markdown/markdownKeymap.ts
@@ -1,0 +1,73 @@
+import { Prec } from "@codemirror/state";
+import { keymap } from "@codemirror/view";
+
+import type { Extension } from "@codemirror/state";
+import type { Command, KeyBinding } from "@codemirror/view";
+
+/* Lib */
+import {
+	boldShortcutKey,
+	duplicateLineShortcutKey,
+	inlineCodeShortcutKey,
+	italicShortcutKey,
+} from "@/lib/constants/markdown.constants";
+import {
+	wrapSelectionWithBold,
+	wrapSelectionWithInlineCode,
+	wrapSelectionWithItalic,
+} from "@/lib/markdown/markdownToolbarActions";
+
+const toggleBold: Command = (view) => {
+	wrapSelectionWithBold(view);
+
+	return true;
+};
+
+const toggleItalic: Command = (view) => {
+	wrapSelectionWithItalic(view);
+
+	return true;
+};
+
+const toggleInlineCode: Command = (view) => {
+	wrapSelectionWithInlineCode(view);
+
+	return true;
+};
+
+const duplicateLineBelow: Command = (view) => {
+	const { state } = view;
+	const range = state.selection.main;
+	const startLine = state.doc.lineAt(range.from);
+	const endLine = state.doc.lineAt(range.to);
+	const blockStart = startLine.from;
+	const blockText = state.doc.sliceString(blockStart, endLine.to);
+	const insertFrom = endLine.to;
+	const duplicatedBlockStart = insertFrom + 1;
+
+	view.dispatch({
+		changes: { from: insertFrom, insert: `\n${blockText}` },
+		scrollIntoView: true,
+		selection: {
+			anchor: duplicatedBlockStart + (range.anchor - blockStart),
+			head: duplicatedBlockStart + (range.head - blockStart),
+		},
+	});
+
+	return true;
+};
+
+const markdownKeyBindings: KeyBinding[] = [
+	{ key: boldShortcutKey, preventDefault: true, run: toggleBold },
+	{ key: italicShortcutKey, preventDefault: true, run: toggleItalic },
+	{ key: inlineCodeShortcutKey, preventDefault: true, run: toggleInlineCode },
+	{
+		key: duplicateLineShortcutKey,
+		preventDefault: true,
+		run: duplicateLineBelow,
+	},
+];
+
+const markdownKeymap: Extension = Prec.high(keymap.of(markdownKeyBindings));
+
+export default markdownKeymap;

--- a/app/lib/markdown/markdownToolbarActions.ts
+++ b/app/lib/markdown/markdownToolbarActions.ts
@@ -170,13 +170,13 @@ const buildHeadingPrefix = (level: number): string => {
 const stripHeading = (lineText: string): string =>
 	lineText.replace(headingPattern, "");
 
-const wrapSelectionWithBold = (view: EditorView): void =>
+export const wrapSelectionWithBold = (view: EditorView): void =>
 	applyInlineWrap(view, boldMarker, boldPlaceholder);
 
-const wrapSelectionWithItalic = (view: EditorView): void =>
+export const wrapSelectionWithItalic = (view: EditorView): void =>
 	applyInlineWrap(view, italicMarker, italicPlaceholder);
 
-const wrapSelectionWithInlineCode = (view: EditorView): void =>
+export const wrapSelectionWithInlineCode = (view: EditorView): void =>
 	applyInlineWrap(view, inlineCodeMarker, inlineCodePlaceholder);
 
 const wrapSelectionWithCodeBlock = (view: EditorView): void => {


### PR DESCRIPTION
#### Why are you creating this PR?

Adds keyboard shortcuts to the CodeMirror editor when editing markdown snippets, mirroring the actions exposed by the formatting toolbar added in #96. Lets users stay in flow without reaching for the toolbar — and reclaims `Mod+I` from the AI completion hotkey (now `Mod+Shift+I`) so italic and bold get the familiar VS Code / GitHub bindings.

#### What changed

- New `markdownKeymap` extension (registered at `Prec.high`) that only mounts in the editor when the active language is markdown
- Bold / Italic / Inline code actions reuse the existing `wrapSelectionWith*` helpers from `markdownToolbarActions` (now exported)
- `Mod-D` duplicates the current line block (selection or full line) below the cursor and preserves the relative selection
- `Mod-I` rebind to italic — `Mod-Shift-I` now triggers AI inline completion (`inlineCompletion` updated to match)
- New shortcut-key constants in `markdown.constants` and a "Markdown editor" group in the shortcuts modal
- Shortcuts modal reorders the AI entry to `Mod+Shift+I`

#### Notes

- `yarn lint`, `yarn audit`, and `yarn build` all pass
- The auto-regenerated `next-env.d.ts` path was not included in the commit (Next.js manages that file)