### PR TITLE
refactor(ai): restructure AI providers and improve streaming

### DIFF
--- a/app/api/ai/models/route.ts
+++ b/app/api/ai/models/route.ts
@@ -1,14 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { openAiExcludedPrefixes } from "@/lib/constants/ai";
+import {
+	anthropicVersion,
+	AiProviderId,
+	defaultNvidiaModel,
+	defaultOllamaUrl,
+	ollamaCloudUrl,
+	openAiBaseUrl,
+	openAiExcludedPrefixes,
+} from "@/lib/constants/ai";
 import { HttpStatusCode } from "@/lib/constants/ui.constants";
 import createSupabaseServerClient from "@/lib/supabase/server";
 import { isSafeRemoteUrl } from "@/utils/url.utils";
-
-const defaultOllamaUrl = process.env.OLLAMA_URL || "http://localhost:11434";
-const ollamaCloudUrl = "https://ollama.com";
-const anthropicVersion = process.env.ANTHROPIC_VERSION || "2023-06-01";
-const openAiBaseUrl = "https://api.openai.com/v1";
 
 const fetchOllamaModels = async (
 	baseUrl: string,
@@ -98,10 +101,11 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
 		);
 	}
 
-	const provider = request.nextUrl.searchParams.get("provider") || "ollama";
+	const provider =
+		request.nextUrl.searchParams.get("provider") || AiProviderId.Ollama;
 	const headerApiKey = request.headers.get("x-api-key") || "";
 
-	if (provider === "claude") {
+	if (provider === AiProviderId.Claude) {
 		const apiKey = headerApiKey || process.env.ANTHROPIC_API_KEY || "";
 
 		if (!apiKey) {
@@ -120,7 +124,7 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
 		}
 	}
 
-	if (provider === "openai") {
+	if (provider === AiProviderId.OpenAi) {
 		const apiKey = headerApiKey || process.env.OPENAI_API_KEY || "";
 
 		if (!apiKey) {
@@ -144,11 +148,8 @@ export const GET = async (request: NextRequest): Promise<NextResponse> => {
 		}
 	}
 
-	if (provider === "nvidia") {
-		const nvidiaModel =
-			process.env.NVIDIA_MODEL || "meta/llama-3.1-70b-instruct";
-
-		return NextResponse.json({ models: [nvidiaModel] });
+	if (provider === AiProviderId.Nvidia) {
+		return NextResponse.json({ models: [defaultNvidiaModel] });
 	}
 
 	// Default: Ollama

--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -34,7 +34,7 @@ const maxCodeLength = 50_000;
 const maxPromptLength = 4_000;
 const defaultOllamaModel = process.env.OLLAMA_MODEL || "codellama";
 
-export const maxDuration = 300;
+export const maxDuration = 60;
 
 const validActions: AiAction[] = [
 	aiActions.explain,

--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -2,31 +2,39 @@ import { NextRequest, NextResponse } from "next/server";
 
 import {
 	aiActions,
+	AiProviderId,
 	AiStreamEventType,
 	aiSystemPrompts,
-	claudeAdaptivePattern,
-	claudeAdaptiveSummarizedPattern,
-	claudeContentBlockDeltaEvent,
-	claudeExtendedThinkingPattern,
-	claudeMaxOutputTokens,
-	claudeTextDeltaType,
-	claudeThinkingBudgetTokens,
-	claudeThinkingDeltaType,
-	maxOutputTokens,
-	ollamaTimeout,
-	sseDoneSentinel,
-	ssePrefix,
+	defaultAnthropicModel,
+	defaultNvidiaModel,
+	defaultOllamaUrl,
+	defaultOpenAIModel,
+	nvidiaBaseUrl,
+	ollamaCloudUrl,
+	openAiBaseUrl,
 	UserRole,
 } from "@/lib/constants/ai";
 import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import { connectClaude, pumpClaudeStream } from "@/lib/ai/providers/claude";
+import {
+	connectOllama,
+	fetchOllamaContextWindow,
+	pumpOllamaStream,
+} from "@/lib/ai/providers/ollama";
+import {
+	connectOpenAiCompatible,
+	pumpOpenAiCompatibleStream,
+} from "@/lib/ai/providers/openAiCompatible";
 import createSupabaseServerClient from "@/lib/supabase/server";
 import { sanitizeHistory } from "@/utils/chat.utils";
+import { stripMarkdownCodeFences } from "@/utils/string.utils";
 import { isSafeRemoteUrl } from "@/utils/url.utils";
 
 const maxCodeLength = 50_000;
 const maxPromptLength = 4_000;
+const defaultOllamaModel = process.env.OLLAMA_MODEL || "codellama";
 
-export const maxDuration = 60;
+export const maxDuration = 300;
 
 const validActions: AiAction[] = [
 	aiActions.explain,
@@ -39,105 +47,38 @@ const validActions: AiAction[] = [
 	aiActions.complete,
 ];
 
-const stripMarkdownCodeFences = (text: string): string => {
-	const trimmed = text.trim();
-	const codeBlockRegex = /^```[\w]*\n?([\s\S]*?)```\s*$/;
-	const match = trimmed.match(codeBlockRegex);
-
-	return match ? match[1].trim() : trimmed;
-};
-
-const defaultOllamaUrl = process.env.OLLAMA_URL || "http://localhost:11434";
-const ollamaCloudUrl = "https://ollama.com";
-const anthropicVersion = process.env.ANTHROPIC_VERSION || "2023-06-01";
-const defaultAnthropicModel =
-	process.env.ANTHROPIC_MODEL || "claude-sonnet-4-20250514";
-const defaultOpenAIModel = process.env.OPENAI_MODEL || "gpt-4o";
-const defaultNvidiaModel =
-	process.env.NVIDIA_MODEL || "meta/llama-3.1-70b-instruct";
-const openAiBaseUrl = "https://api.openai.com/v1";
-const nvidiaBaseUrl = "https://integrate.api.nvidia.com/v1";
-
-const resolveClaudeThinking = (
-	model: string
-): Record<string, unknown> | null => {
-	if (claudeAdaptiveSummarizedPattern.test(model)) {
-		return { type: "adaptive", display: "summarized" };
-	}
-
-	if (claudeAdaptivePattern.test(model)) {
-		return { type: "adaptive" };
-	}
-
-	if (claudeExtendedThinkingPattern.test(model)) {
-		return { type: "enabled", budget_tokens: claudeThinkingBudgetTokens };
-	}
-
-	return null;
-};
-
-const ollamaContextWindowCache = new Map<string, number>();
-
-const fetchOllamaContextWindow = async (
-	baseUrl: string,
-	model: string,
-	apiKey: string | undefined
-): Promise<number> => {
-	const cacheKey = `${baseUrl}::${model}`;
-	const cached = ollamaContextWindowCache.get(cacheKey);
-
-	if (typeof cached === "number") {
-		return cached;
-	}
-
-	try {
-		const headers: Record<string, string> = {
-			"Content-Type": "application/json",
-		};
-
-		if (apiKey) {
-			headers["Authorization"] = `Bearer ${apiKey}`;
-		}
-
-		const response = await fetch(`${baseUrl}/api/show`, {
-			method: "POST",
-			headers,
-			body: JSON.stringify({ name: model }),
-		});
-
-		if (!response.ok) {
-			ollamaContextWindowCache.set(cacheKey, 0);
-
-			return 0;
-		}
-
-		const data = await response.json();
-		const modelInfo = (data.model_info as Record<string, unknown>) ?? {};
-		const contextEntry = Object.entries(modelInfo).find(([key]) =>
-			key.endsWith(".context_length")
-		);
-		const contextLength =
-			typeof contextEntry?.[1] === "number" ? (contextEntry[1] as number) : 0;
-
-		ollamaContextWindowCache.set(cacheKey, contextLength);
-
-		return contextLength;
-	} catch {
-		ollamaContextWindowCache.set(cacheKey, 0);
-
-		return 0;
-	}
-};
-
 const streamEncoder = new TextEncoder();
 
+const linkAbort = (source: AbortSignal, target: AbortController): void => {
+	if (source.aborted) {
+		target.abort();
+
+		return;
+	}
+
+	source.addEventListener("abort", () => target.abort(), { once: true });
+};
+
 const createStreamResponse = (
+	abortController: AbortController,
 	pump: (emit: AiStreamEmit) => Promise<void>
 ): Response => {
 	const stream = new ReadableStream<Uint8Array>({
 		start: async (controller) => {
+			let closed = false;
+
 			const emit: AiStreamEmit = (event) => {
-				controller.enqueue(streamEncoder.encode(`${JSON.stringify(event)}\n`));
+				if (closed) {
+					return;
+				}
+
+				try {
+					controller.enqueue(
+						streamEncoder.encode(`${JSON.stringify(event)}\n`)
+					);
+				} catch {
+					closed = true;
+				}
 			};
 
 			try {
@@ -150,8 +91,17 @@ const createStreamResponse = (
 
 				emit({ type: AiStreamEventType.Error, error: message });
 			} finally {
-				controller.close();
+				if (!closed) {
+					try {
+						controller.close();
+					} catch {
+						closed = true;
+					}
+				}
 			}
+		},
+		cancel: () => {
+			abortController.abort();
 		},
 	});
 
@@ -161,42 +111,6 @@ const createStreamResponse = (
 			"Content-Type": "application/x-ndjson; charset=utf-8",
 		},
 	});
-};
-
-const readLines = async (
-	upstream: Response,
-	onLine: (line: string) => void
-): Promise<void> => {
-	const reader = upstream.body?.getReader();
-
-	if (!reader) {
-		throw new Error("AI provider returned an empty response stream");
-	}
-
-	const decoder = new TextDecoder();
-	let buffer = "";
-
-	for (;;) {
-		const { done, value } = await reader.read();
-
-		if (done) {
-			break;
-		}
-
-		buffer += decoder.decode(value, { stream: true });
-
-		let newlineIndex = buffer.indexOf("\n");
-
-		while (newlineIndex !== -1) {
-			onLine(buffer.slice(0, newlineIndex));
-			buffer = buffer.slice(newlineIndex + 1);
-			newlineIndex = buffer.indexOf("\n");
-		}
-	}
-
-	if (buffer.trim().length > 0) {
-		onLine(buffer);
-	}
 };
 
 const emitDone = (
@@ -215,280 +129,6 @@ const emitDone = (
 		model,
 		usage,
 	});
-};
-
-const connectOllama = async (
-	messages: AiHistoryMessage[],
-	systemPrompt: string,
-	model: string,
-	baseUrl: string,
-	apiKey: string | undefined
-): Promise<Response> => {
-	const headers: Record<string, string> = {
-		"Content-Type": "application/json",
-	};
-
-	if (apiKey) {
-		headers["Authorization"] = `Bearer ${apiKey}`;
-	}
-
-	const requestOnce = async (withThinking: boolean): Promise<Response> => {
-		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), ollamaTimeout);
-
-		try {
-			return await fetch(`${baseUrl}/api/chat`, {
-				method: "POST",
-				headers,
-				body: JSON.stringify({
-					model,
-					messages: [
-						{ role: UserRole.System, content: systemPrompt },
-						...messages,
-					],
-					stream: true,
-					...(withThinking ? { think: true } : {}),
-				}),
-				signal: controller.signal,
-			});
-		} finally {
-			clearTimeout(timeoutId);
-		}
-	};
-
-	// Models without reasoning support reject `think`; retry once without it.
-	const thinkingResponse = await requestOnce(true);
-
-	if (thinkingResponse.ok) {
-		return thinkingResponse;
-	}
-
-	const plainResponse = await requestOnce(false);
-
-	if (!plainResponse.ok) {
-		throw new Error("Ollama request failed");
-	}
-
-	return plainResponse;
-};
-
-const pumpOllamaStream = async (
-	upstream: Response,
-	emit: AiStreamEmit
-): Promise<AiStreamOutcome> => {
-	let text = "";
-	let thinking = "";
-	let inputTokens = 0;
-	let outputTokens = 0;
-
-	await readLines(upstream, (line) => {
-		const trimmed = line.trim();
-
-		if (!trimmed) {
-			return;
-		}
-
-		try {
-			const chunk = JSON.parse(trimmed);
-			const thinkingDelta = chunk?.message?.thinking;
-			const textDelta = chunk?.message?.content;
-
-			if (typeof thinkingDelta === "string" && thinkingDelta.length > 0) {
-				thinking += thinkingDelta;
-				emit({ type: AiStreamEventType.Thinking, delta: thinkingDelta });
-			}
-
-			if (typeof textDelta === "string" && textDelta.length > 0) {
-				text += textDelta;
-				emit({ type: AiStreamEventType.Text, delta: textDelta });
-			}
-
-			if (chunk?.done === true) {
-				inputTokens =
-					typeof chunk.prompt_eval_count === "number"
-						? chunk.prompt_eval_count
-						: 0;
-				outputTokens =
-					typeof chunk.eval_count === "number" ? chunk.eval_count : 0;
-			}
-		} catch {
-			// Skip malformed stream lines.
-		}
-	});
-
-	return { text, thinking, inputTokens, outputTokens };
-};
-
-const connectClaude = async (
-	messages: AiHistoryMessage[],
-	systemPrompt: string,
-	apiKey: string,
-	model: string = defaultAnthropicModel
-): Promise<Response> => {
-	const thinking = resolveClaudeThinking(model);
-
-	const requestOnce = (withThinking: boolean): Promise<Response> =>
-		fetch("https://api.anthropic.com/v1/messages", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				"x-api-key": apiKey,
-				"anthropic-version": anthropicVersion,
-			},
-			body: JSON.stringify({
-				model,
-				max_tokens: claudeMaxOutputTokens,
-				stream: true,
-				system: systemPrompt,
-				messages,
-				...(withThinking && thinking ? { thinking } : {}),
-			}),
-		});
-
-	const firstResponse = await requestOnce(true);
-
-	if (firstResponse.ok) {
-		return firstResponse;
-	}
-
-	// Thinking support varies across model generations; retry without it.
-	const retryResponse = thinking ? await requestOnce(false) : firstResponse;
-
-	if (!retryResponse.ok) {
-		const errorData = await retryResponse.json().catch(() => ({}));
-
-		throw new Error(errorData?.error?.message || "Claude API request failed");
-	}
-
-	return retryResponse;
-};
-
-const pumpClaudeStream = async (
-	upstream: Response,
-	emit: AiStreamEmit
-): Promise<AiStreamOutcome> => {
-	let text = "";
-	let thinking = "";
-
-	await readLines(upstream, (line) => {
-		if (!line.startsWith(ssePrefix)) {
-			return;
-		}
-
-		const payload = line.slice(ssePrefix.length).trim();
-
-		if (!payload) {
-			return;
-		}
-
-		try {
-			const chunk = JSON.parse(payload);
-
-			if (chunk?.type !== claudeContentBlockDeltaEvent) {
-				return;
-			}
-
-			const delta = chunk?.delta;
-			const isThinkingDelta =
-				delta?.type === claudeThinkingDeltaType &&
-				typeof delta?.thinking === "string" &&
-				delta.thinking.length > 0;
-			const isTextDelta =
-				delta?.type === claudeTextDeltaType &&
-				typeof delta?.text === "string" &&
-				delta.text.length > 0;
-
-			if (isThinkingDelta) {
-				thinking += delta.thinking;
-				emit({ type: AiStreamEventType.Thinking, delta: delta.thinking });
-			}
-
-			if (isTextDelta) {
-				text += delta.text;
-				emit({ type: AiStreamEventType.Text, delta: delta.text });
-			}
-		} catch {
-			// Skip malformed stream lines.
-		}
-	});
-
-	return { text, thinking, inputTokens: 0, outputTokens: 0 };
-};
-
-const connectOpenAiCompatible = async (
-	baseUrl: string,
-	providerLabel: string,
-	messages: AiHistoryMessage[],
-	systemPrompt: string,
-	apiKey: string,
-	model: string
-): Promise<Response> => {
-	const response = await fetch(`${baseUrl}/chat/completions`, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Authorization: `Bearer ${apiKey}`,
-		},
-		body: JSON.stringify({
-			model,
-			max_tokens: maxOutputTokens,
-			stream: true,
-			messages: [{ role: UserRole.System, content: systemPrompt }, ...messages],
-		}),
-	});
-
-	if (!response.ok) {
-		const errorData = await response.json().catch(() => ({}));
-
-		throw new Error(
-			errorData?.error?.message || `${providerLabel} API request failed`
-		);
-	}
-
-	return response;
-};
-
-const pumpOpenAiCompatibleStream = async (
-	upstream: Response,
-	emit: AiStreamEmit
-): Promise<AiStreamOutcome> => {
-	let text = "";
-	let thinking = "";
-
-	await readLines(upstream, (line) => {
-		if (!line.startsWith(ssePrefix)) {
-			return;
-		}
-
-		const payload = line.slice(ssePrefix.length).trim();
-
-		if (!payload || payload === sseDoneSentinel) {
-			return;
-		}
-
-		try {
-			const chunk = JSON.parse(payload);
-			const delta = chunk?.choices?.[0]?.delta;
-			// Reasoning models on OpenAI-compatible hosts (e.g. NVIDIA) expose
-			// chain-of-thought through the non-standard reasoning_content field.
-			const reasoningDelta = delta?.reasoning_content;
-			const textDelta = delta?.content;
-
-			if (typeof reasoningDelta === "string" && reasoningDelta.length > 0) {
-				thinking += reasoningDelta;
-				emit({ type: AiStreamEventType.Thinking, delta: reasoningDelta });
-			}
-
-			if (typeof textDelta === "string" && textDelta.length > 0) {
-				text += textDelta;
-				emit({ type: AiStreamEventType.Text, delta: textDelta });
-			}
-		} catch {
-			// Skip malformed stream lines.
-		}
-	});
-
-	return { text, thinking, inputTokens: 0, outputTokens: 0 };
 };
 
 const buildAskSystemPrompt = (language: string, code: string): string => {
@@ -565,13 +205,17 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 			{ role: UserRole.User, content: prompt },
 		];
 		const metadata = user.user_metadata ?? {};
-		const aiProvider = (metadata.ai_provider as string) || "ollama";
+		const aiProvider = (metadata.ai_provider as string) || AiProviderId.Ollama;
 		const aiApiKey = (metadata.ai_api_key as string) || "";
 		const aiModel = (metadata.ai_model as string) || "";
 		const aiUrl = (metadata.ai_url as string) || "";
 
+		const upstreamAbort = new AbortController();
+
+		linkAbort(request.signal, upstreamAbort);
+
 		// OpenAI provider
-		if (aiProvider === "openai") {
+		if (aiProvider === AiProviderId.OpenAi) {
 			const openaiApiKey = aiApiKey || process.env.OPENAI_API_KEY || "";
 
 			if (!openaiApiKey) {
@@ -591,18 +235,19 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 				messages,
 				systemPrompt,
 				openaiApiKey,
-				openaiModel
+				openaiModel,
+				upstreamAbort.signal
 			);
 
-			return createStreamResponse(async (emit) => {
+			return createStreamResponse(upstreamAbort, async (emit) => {
 				const outcome = await pumpOpenAiCompatibleStream(upstream, emit);
 
-				emitDone(emit, outcome, stripFences, "openai", openaiModel);
+				emitDone(emit, outcome, stripFences, AiProviderId.OpenAi, openaiModel);
 			});
 		}
 
 		// NVIDIA provider (OpenAI-compatible)
-		if (aiProvider === "nvidia") {
+		if (aiProvider === AiProviderId.Nvidia) {
 			const nvidiaApiKey = aiApiKey || process.env.NVIDIA_API_KEY || "";
 
 			if (!nvidiaApiKey) {
@@ -622,18 +267,19 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 				messages,
 				systemPrompt,
 				nvidiaApiKey,
-				nvidiaModel
+				nvidiaModel,
+				upstreamAbort.signal
 			);
 
-			return createStreamResponse(async (emit) => {
+			return createStreamResponse(upstreamAbort, async (emit) => {
 				const outcome = await pumpOpenAiCompatibleStream(upstream, emit);
 
-				emitDone(emit, outcome, stripFences, "nvidia", nvidiaModel);
+				emitDone(emit, outcome, stripFences, AiProviderId.Nvidia, nvidiaModel);
 			});
 		}
 
 		// Claude provider (explicit)
-		if (aiProvider === "claude") {
+		if (aiProvider === AiProviderId.Claude) {
 			const claudeApiKey = aiApiKey || process.env.ANTHROPIC_API_KEY || "";
 
 			if (!claudeApiKey) {
@@ -651,18 +297,19 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 				messages,
 				systemPrompt,
 				claudeApiKey,
-				claudeModel
+				claudeModel,
+				upstreamAbort.signal
 			);
 
-			return createStreamResponse(async (emit) => {
+			return createStreamResponse(upstreamAbort, async (emit) => {
 				const outcome = await pumpClaudeStream(upstream, emit);
 
-				emitDone(emit, outcome, stripFences, "claude", claudeModel);
+				emitDone(emit, outcome, stripFences, AiProviderId.Claude, claudeModel);
 			});
 		}
 
 		// Ollama provider (default) with Claude fallback
-		const ollamaModel = aiModel || process.env.OLLAMA_MODEL || "codellama";
+		const ollamaModel = aiModel || defaultOllamaModel;
 
 		if (aiUrl && !isSafeRemoteUrl(aiUrl)) {
 			return NextResponse.json(
@@ -686,18 +333,20 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 				systemPrompt,
 				ollamaModel,
 				ollamaUrl,
-				ollamaApiKey
+				ollamaApiKey,
+				upstreamAbort.signal
 			);
 
-			return createStreamResponse(async (emit) => {
-				const outcome = await pumpOllamaStream(upstream, emit);
-				const contextWindow = await fetchOllamaContextWindow(
+			return createStreamResponse(upstreamAbort, async (emit) => {
+				const contextWindowPromise = fetchOllamaContextWindow(
 					ollamaUrl,
 					ollamaModel,
 					ollamaApiKey
 				);
+				const outcome = await pumpOllamaStream(upstream, emit);
+				const contextWindow = await contextWindowPromise;
 
-				emitDone(emit, outcome, stripFences, "ollama", ollamaModel, {
+				emitDone(emit, outcome, stripFences, AiProviderId.Ollama, ollamaModel, {
 					inputTokens: outcome.inputTokens,
 					outputTokens: outcome.outputTokens,
 					contextWindow,
@@ -705,7 +354,7 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 			});
 		} catch (ollamaError) {
 			attempts.push({
-				provider: "ollama",
+				provider: AiProviderId.Ollama,
 				error:
 					ollamaError instanceof Error ? ollamaError.message : "Unknown error",
 			});
@@ -719,26 +368,35 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 					systemPrompt,
 					ollamaModel,
 					ollamaCloudUrl,
-					ollamaApiKey
+					ollamaApiKey,
+					upstreamAbort.signal
 				);
 
-				return createStreamResponse(async (emit) => {
-					const outcome = await pumpOllamaStream(upstream, emit);
-					const contextWindow = await fetchOllamaContextWindow(
+				return createStreamResponse(upstreamAbort, async (emit) => {
+					const contextWindowPromise = fetchOllamaContextWindow(
 						ollamaCloudUrl,
 						ollamaModel,
 						ollamaApiKey
 					);
+					const outcome = await pumpOllamaStream(upstream, emit);
+					const contextWindow = await contextWindowPromise;
 
-					emitDone(emit, outcome, stripFences, "ollama-cloud", ollamaModel, {
-						inputTokens: outcome.inputTokens,
-						outputTokens: outcome.outputTokens,
-						contextWindow,
-					});
+					emitDone(
+						emit,
+						outcome,
+						stripFences,
+						AiProviderId.OllamaCloud,
+						ollamaModel,
+						{
+							inputTokens: outcome.inputTokens,
+							outputTokens: outcome.outputTokens,
+							contextWindow,
+						}
+					);
 				});
 			} catch (ollamaCloudError) {
 				attempts.push({
-					provider: "ollama-cloud",
+					provider: AiProviderId.OllamaCloud,
 					error:
 						ollamaCloudError instanceof Error
 							? ollamaCloudError.message
@@ -766,17 +424,25 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 			const upstream = await connectClaude(
 				messages,
 				systemPrompt,
-				fallbackApiKey
+				fallbackApiKey,
+				defaultAnthropicModel,
+				upstreamAbort.signal
 			);
 
-			return createStreamResponse(async (emit) => {
+			return createStreamResponse(upstreamAbort, async (emit) => {
 				const outcome = await pumpClaudeStream(upstream, emit);
 
-				emitDone(emit, outcome, stripFences, "claude", defaultAnthropicModel);
+				emitDone(
+					emit,
+					outcome,
+					stripFences,
+					AiProviderId.Claude,
+					defaultAnthropicModel
+				);
 			});
 		} catch (claudeError) {
 			attempts.push({
-				provider: "claude",
+				provider: AiProviderId.Claude,
 				error:
 					claudeError instanceof Error ? claudeError.message : "Unknown error",
 			});

--- a/app/components/AccountModal/AccountModal.tsx
+++ b/app/components/AccountModal/AccountModal.tsx
@@ -23,6 +23,7 @@ import {
 	aiProviders,
 	modalCloseDelay,
 } from "@/lib/constants/account";
+import { AiProviderId } from "@/lib/constants/ai";
 import { FormMessageTypes } from "@/lib/constants/form";
 
 /* Components */
@@ -117,15 +118,19 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 	}, [userData.theme]);
 
 	const refreshModels = async (provider?: AiProvider): Promise<void> => {
-		const activeProvider = provider ?? userData.aiProvider ?? "ollama";
+		const activeProvider =
+			provider ?? userData.aiProvider ?? AiProviderId.Ollama;
 
 		setModelsLoading(true);
 		resetMessages();
 
 		const { models, error } = await fetchAiModels(activeProvider, {
-			apiKey: activeProvider !== "ollama" ? userData.aiApiKey : undefined,
-			ollamaUrl: activeProvider === "ollama" ? userData.aiUrl : undefined,
-			ollamaApiKey: activeProvider === "ollama" ? userData.aiApiKey : undefined,
+			apiKey:
+				activeProvider !== AiProviderId.Ollama ? userData.aiApiKey : undefined,
+			ollamaUrl:
+				activeProvider === AiProviderId.Ollama ? userData.aiUrl : undefined,
+			ollamaApiKey:
+				activeProvider === AiProviderId.Ollama ? userData.aiApiKey : undefined,
 		});
 
 		if (error) {
@@ -141,7 +146,9 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 		setAiModels([]);
 
 		const hasCredentials =
-			provider === "ollama" || provider === "nvidia" || !!userData.aiApiKey;
+			provider === AiProviderId.Ollama ||
+			provider === AiProviderId.Nvidia ||
+			!!userData.aiApiKey;
 
 		if (hasCredentials) {
 			await refreshModels(provider);
@@ -198,7 +205,7 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 			avatar: userData.avatar,
 			theme: userData.theme,
 			auto_save: userData.autoSave ?? false,
-			ai_provider: userData.aiProvider ?? "ollama",
+			ai_provider: userData.aiProvider ?? AiProviderId.Ollama,
 			ai_api_key: userData.aiApiKey ?? "",
 			ai_model: userData.aiModel ?? "",
 			ai_url: userData.aiUrl ?? "",
@@ -272,10 +279,10 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 				updateUserStore();
 
 				if (
-					userData.aiProvider === "ollama" &&
+					userData.aiProvider === AiProviderId.Ollama &&
 					userData.aiUrl !== originalAiUrl
 				) {
-					await refreshModels("ollama");
+					await refreshModels(AiProviderId.Ollama);
 					setOriginalAiUrl(userData.aiUrl ?? "");
 				}
 
@@ -392,14 +399,20 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 				}
 
 				const activeProvider: AiProvider =
-					userMetadata?.ai_provider ?? "ollama";
+					userMetadata?.ai_provider ?? AiProviderId.Ollama;
 				const { models } = await fetchAiModels(activeProvider, {
 					apiKey:
-						activeProvider !== "ollama" ? userMetadata?.ai_api_key : undefined,
+						activeProvider !== AiProviderId.Ollama
+							? userMetadata?.ai_api_key
+							: undefined,
 					ollamaUrl:
-						activeProvider === "ollama" ? userMetadata?.ai_url : undefined,
+						activeProvider === AiProviderId.Ollama
+							? userMetadata?.ai_url
+							: undefined,
 					ollamaApiKey:
-						activeProvider === "ollama" ? userMetadata?.ai_api_key : undefined,
+						activeProvider === AiProviderId.Ollama
+							? userMetadata?.ai_api_key
+							: undefined,
 				});
 
 				if (!isMounted) return;
@@ -432,7 +445,7 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 			);
 		}
 
-		if (userData.aiProvider === "nvidia") {
+		if (userData.aiProvider === AiProviderId.Nvidia) {
 			return (
 				<div className={styles.modelLoadGroup}>
 					<small className={styles.helpText}>
@@ -640,7 +653,7 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 					<span className={styles.label}>AI Provider</span>
 					<select
 						className={styles.modelSelect}
-						value={userData.aiProvider ?? "ollama"}
+						value={userData.aiProvider ?? AiProviderId.Ollama}
 						onChange={(event) =>
 							handleProviderChange(event.target.value as AiProvider)
 						}
@@ -659,17 +672,17 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 				<h3 className={styles.sectionTitle}>
 					{
 						{
-							ollama: "Ollama",
-							"ollama-cloud": "Ollama Cloud",
-							claude: "Claude (Anthropic)",
-							openai: "OpenAI",
-							nvidia: "NVIDIA",
-						}[userData.aiProvider ?? "ollama"]
+							[AiProviderId.Ollama]: "Ollama",
+							[AiProviderId.OllamaCloud]: "Ollama Cloud",
+							[AiProviderId.Claude]: "Claude (Anthropic)",
+							[AiProviderId.OpenAi]: "OpenAI",
+							[AiProviderId.Nvidia]: "NVIDIA",
+						}[userData.aiProvider ?? AiProviderId.Ollama]
 					}
 				</h3>
 
 				{/* Endpoint URL — Ollama only */}
-				{userData.aiProvider === "ollama" && (
+				{userData.aiProvider === AiProviderId.Ollama && (
 					<div className={styles.inputGroup}>
 						<span className={styles.label}>Endpoint URL</span>
 						<Input
@@ -699,11 +712,11 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 						type="password"
 						name="aiApiKey"
 						placeholder={
-							userData.aiProvider === "claude"
+							userData.aiProvider === AiProviderId.Claude
 								? "sk-ant-..."
-								: userData.aiProvider === "openai"
+								: userData.aiProvider === AiProviderId.OpenAi
 									? "sk-..."
-									: userData.aiProvider === "nvidia"
+									: userData.aiProvider === AiProviderId.Nvidia
 										? "nvapi-..."
 										: "ollama-api-key..."
 						}
@@ -718,13 +731,13 @@ const AccountModal = ({ isOpen, onClose }: AccountModalProps): ReactElement => {
 						maxLength={255}
 					/>
 					<small className={styles.helpText}>
-						{userData.aiProvider === "claude" &&
+						{userData.aiProvider === AiProviderId.Claude &&
 							"Get your API key at console.anthropic.com"}
-						{userData.aiProvider === "openai" &&
+						{userData.aiProvider === AiProviderId.OpenAi &&
 							"Get your API key at platform.openai.com/api-keys"}
-						{userData.aiProvider === "nvidia" &&
+						{userData.aiProvider === AiProviderId.Nvidia &&
 							"Get your API key at build.nvidia.com"}
-						{userData.aiProvider === "ollama" &&
+						{userData.aiProvider === AiProviderId.Ollama &&
 							"Required only for ollama.com cloud models"}
 					</small>
 				</div>

--- a/app/components/Chat/AssistantMessage/AssistantMessage.tsx
+++ b/app/components/Chat/AssistantMessage/AssistantMessage.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { ReactElement } from "react";
+import { memo, ReactElement, useMemo } from "react";
+
+/* Lib */
+import { SegmentType } from "@/lib/constants/ai";
 
 /* Components */
 import CodeBlock from "@/components/Chat/CodeBlock/CodeBlock";
@@ -34,7 +37,7 @@ const AssistantMessage = ({
 	onCopyToSnippet,
 	onReplaceSnippet,
 }: AssistantMessageProps): ReactElement => {
-	const segments = parseAssistantSegments(content);
+	const segments = useMemo(() => parseAssistantSegments(content), [content]);
 	const showCopy = showActions && typeof onCopyToSnippet === "function";
 
 	return (
@@ -54,7 +57,7 @@ const AssistantMessage = ({
 
 			<div className={styles.assistantBody}>
 				{segments.map((segment, index) =>
-					segment.type === "code" ? (
+					segment.type === SegmentType.Code ? (
 						<CodeBlock
 							key={index}
 							body={segment.body}
@@ -87,4 +90,4 @@ const AssistantMessage = ({
 	);
 };
 
-export default AssistantMessage;
+export default memo(AssistantMessage);

--- a/app/components/ModelSelector/ModelSelector.tsx
+++ b/app/components/ModelSelector/ModelSelector.tsx
@@ -3,6 +3,7 @@
 import { ChangeEvent, ReactElement, useEffect, useState } from "react";
 
 /* Lib */
+import { AiProviderId } from "@/lib/constants/ai";
 import { ToastType } from "@/lib/constants/toast";
 import useChatStore from "@/lib/store/chat.store";
 import useToastStore from "@/lib/store/toast.store";
@@ -37,7 +38,8 @@ const ModelSelector = ({
 
 			const session = await getUserDataFromSession();
 			const metadata = session?.user?.user_metadata ?? {};
-			const activeProvider = (metadata.ai_provider as AiProvider) ?? "ollama";
+			const activeProvider =
+				(metadata.ai_provider as AiProvider) ?? AiProviderId.Ollama;
 
 			if (cancelled) return;
 
@@ -47,15 +49,15 @@ const ModelSelector = ({
 
 			const { models: fetched } = await fetchAiModels(activeProvider, {
 				apiKey:
-					activeProvider !== "ollama"
+					activeProvider !== AiProviderId.Ollama
 						? (metadata.ai_api_key as string | undefined)
 						: undefined,
 				ollamaUrl:
-					activeProvider === "ollama"
+					activeProvider === AiProviderId.Ollama
 						? (metadata.ai_url as string | undefined)
 						: undefined,
 				ollamaApiKey:
-					activeProvider === "ollama"
+					activeProvider === AiProviderId.Ollama
 						? (metadata.ai_api_key as string | undefined)
 						: undefined,
 			});

--- a/app/lib/ai/providers/claude.ts
+++ b/app/lib/ai/providers/claude.ts
@@ -1,0 +1,131 @@
+import {
+	AiStreamEventType,
+	anthropicVersion,
+	claudeAdaptivePattern,
+	claudeAdaptiveSummarizedPattern,
+	claudeContentBlockDeltaEvent,
+	claudeExtendedThinkingPattern,
+	claudeMaxOutputTokens,
+	claudeTextDeltaType,
+	claudeThinkingBudgetTokens,
+	claudeThinkingDeltaType,
+	defaultAnthropicModel,
+	ssePrefix,
+} from "@/lib/constants/ai";
+import { readResponseLines } from "@/lib/ai/streamLines";
+
+const resolveClaudeThinking = (
+	model: string
+): Record<string, unknown> | null => {
+	if (claudeAdaptiveSummarizedPattern.test(model)) {
+		return { type: "adaptive", display: "summarized" };
+	}
+
+	if (claudeAdaptivePattern.test(model)) {
+		return { type: "adaptive" };
+	}
+
+	if (claudeExtendedThinkingPattern.test(model)) {
+		return { type: "enabled", budget_tokens: claudeThinkingBudgetTokens };
+	}
+
+	return null;
+};
+
+export const connectClaude = async (
+	messages: AiHistoryMessage[],
+	systemPrompt: string,
+	apiKey: string,
+	model: string = defaultAnthropicModel,
+	abortSignal?: AbortSignal
+): Promise<Response> => {
+	const thinking = resolveClaudeThinking(model);
+
+	const requestOnce = (withThinking: boolean): Promise<Response> =>
+		fetch("https://api.anthropic.com/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-api-key": apiKey,
+				"anthropic-version": anthropicVersion,
+			},
+			body: JSON.stringify({
+				model,
+				max_tokens: claudeMaxOutputTokens,
+				stream: true,
+				system: systemPrompt,
+				messages,
+				...(withThinking && thinking ? { thinking } : {}),
+			}),
+			signal: abortSignal,
+		});
+
+	const firstResponse = await requestOnce(true);
+
+	if (firstResponse.ok) {
+		return firstResponse;
+	}
+
+	// Thinking support varies across model generations; retry without it.
+	const retryResponse = thinking ? await requestOnce(false) : firstResponse;
+
+	if (!retryResponse.ok) {
+		const errorData = await retryResponse.json().catch(() => ({}));
+
+		throw new Error(errorData?.error?.message || "Claude API request failed");
+	}
+
+	return retryResponse;
+};
+
+export const pumpClaudeStream = async (
+	upstream: Response,
+	emit: AiStreamEmit
+): Promise<AiStreamOutcome> => {
+	let text = "";
+	let thinking = "";
+
+	await readResponseLines(upstream, (line) => {
+		if (!line.startsWith(ssePrefix)) {
+			return;
+		}
+
+		const payload = line.slice(ssePrefix.length).trim();
+
+		if (!payload) {
+			return;
+		}
+
+		try {
+			const chunk = JSON.parse(payload);
+
+			if (chunk?.type !== claudeContentBlockDeltaEvent) {
+				return;
+			}
+
+			const delta = chunk?.delta;
+			const isThinkingDelta =
+				delta?.type === claudeThinkingDeltaType &&
+				typeof delta?.thinking === "string" &&
+				delta.thinking.length > 0;
+			const isTextDelta =
+				delta?.type === claudeTextDeltaType &&
+				typeof delta?.text === "string" &&
+				delta.text.length > 0;
+
+			if (isThinkingDelta) {
+				thinking += delta.thinking;
+				emit({ type: AiStreamEventType.Thinking, delta: delta.thinking });
+			}
+
+			if (isTextDelta) {
+				text += delta.text;
+				emit({ type: AiStreamEventType.Text, delta: delta.text });
+			}
+		} catch {
+			// Skip malformed stream lines.
+		}
+	});
+
+	return { text, thinking, inputTokens: 0, outputTokens: 0 };
+};

--- a/app/lib/ai/providers/ollama.ts
+++ b/app/lib/ai/providers/ollama.ts
@@ -1,0 +1,182 @@
+import {
+	AiStreamEventType,
+	ollamaContextWindowCache,
+	ollamaContextWindowCacheLimit,
+	ollamaTimeout,
+	UserRole,
+} from "@/lib/constants/ai";
+import { readResponseLines } from "@/lib/ai/streamLines";
+
+const rememberContextWindow = (cacheKey: string, value: number): void => {
+	if (value <= 0) {
+		return;
+	}
+
+	if (ollamaContextWindowCache.size >= ollamaContextWindowCacheLimit) {
+		const oldestKey = ollamaContextWindowCache.keys().next().value;
+
+		if (oldestKey !== undefined) {
+			ollamaContextWindowCache.delete(oldestKey);
+		}
+	}
+
+	ollamaContextWindowCache.set(cacheKey, value);
+};
+
+export const fetchOllamaContextWindow = async (
+	baseUrl: string,
+	model: string,
+	apiKey: string | undefined
+): Promise<number> => {
+	const cacheKey = `${baseUrl}::${model}`;
+	const cached = ollamaContextWindowCache.get(cacheKey);
+
+	if (typeof cached === "number") {
+		return cached;
+	}
+
+	try {
+		const headers: Record<string, string> = {
+			"Content-Type": "application/json",
+		};
+
+		if (apiKey) {
+			headers["Authorization"] = `Bearer ${apiKey}`;
+		}
+
+		const response = await fetch(`${baseUrl}/api/show`, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ name: model }),
+		});
+
+		if (!response.ok) {
+			return 0;
+		}
+
+		const data = await response.json();
+		const modelInfo = (data.model_info as Record<string, unknown>) ?? {};
+		const contextEntry = Object.entries(modelInfo).find(([key]) =>
+			key.endsWith(".context_length")
+		);
+		const contextLength =
+			typeof contextEntry?.[1] === "number" ? (contextEntry[1] as number) : 0;
+
+		rememberContextWindow(cacheKey, contextLength);
+
+		return contextLength;
+	} catch {
+		return 0;
+	}
+};
+
+export const connectOllama = async (
+	messages: AiHistoryMessage[],
+	systemPrompt: string,
+	model: string,
+	baseUrl: string,
+	apiKey: string | undefined,
+	abortSignal?: AbortSignal
+): Promise<Response> => {
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+	};
+
+	if (apiKey) {
+		headers["Authorization"] = `Bearer ${apiKey}`;
+	}
+
+	const requestOnce = async (withThinking: boolean): Promise<Response> => {
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort(), ollamaTimeout);
+		const handleAbort = (): void => controller.abort();
+
+		if (abortSignal?.aborted) {
+			controller.abort();
+		} else {
+			abortSignal?.addEventListener("abort", handleAbort, { once: true });
+		}
+
+		try {
+			return await fetch(`${baseUrl}/api/chat`, {
+				method: "POST",
+				headers,
+				body: JSON.stringify({
+					model,
+					messages: [
+						{ role: UserRole.System, content: systemPrompt },
+						...messages,
+					],
+					stream: true,
+					...(withThinking ? { think: true } : {}),
+				}),
+				signal: controller.signal,
+			});
+		} finally {
+			clearTimeout(timeoutId);
+			abortSignal?.removeEventListener("abort", handleAbort);
+		}
+	};
+
+	// Models without reasoning support reject `think`; retry once without it.
+	const thinkingResponse = await requestOnce(true);
+
+	if (thinkingResponse.ok) {
+		return thinkingResponse;
+	}
+
+	const plainResponse = await requestOnce(false);
+
+	if (!plainResponse.ok) {
+		throw new Error("Ollama request failed");
+	}
+
+	return plainResponse;
+};
+
+export const pumpOllamaStream = async (
+	upstream: Response,
+	emit: AiStreamEmit
+): Promise<AiStreamOutcome> => {
+	let text = "";
+	let thinking = "";
+	let inputTokens = 0;
+	let outputTokens = 0;
+
+	await readResponseLines(upstream, (line) => {
+		const trimmed = line.trim();
+
+		if (!trimmed) {
+			return;
+		}
+
+		try {
+			const chunk = JSON.parse(trimmed);
+			const thinkingDelta = chunk?.message?.thinking;
+			const textDelta = chunk?.message?.content;
+
+			if (typeof thinkingDelta === "string" && thinkingDelta.length > 0) {
+				thinking += thinkingDelta;
+				emit({ type: AiStreamEventType.Thinking, delta: thinkingDelta });
+			}
+
+			if (typeof textDelta === "string" && textDelta.length > 0) {
+				text += textDelta;
+				emit({ type: AiStreamEventType.Text, delta: textDelta });
+			}
+
+			if (chunk?.done === true) {
+				inputTokens =
+					typeof chunk.prompt_eval_count === "number"
+						? chunk.prompt_eval_count
+						: 0;
+				outputTokens =
+					typeof chunk.eval_count === "number" ? chunk.eval_count : 0;
+			}
+		} catch {
+			// Skip malformed stream lines.
+		}
+	});
+
+	return { text, thinking, inputTokens, outputTokens };
+};

--- a/app/lib/ai/providers/openAiCompatible.ts
+++ b/app/lib/ai/providers/openAiCompatible.ts
@@ -1,0 +1,86 @@
+import {
+	AiStreamEventType,
+	maxOutputTokens,
+	sseDoneSentinel,
+	ssePrefix,
+	UserRole,
+} from "@/lib/constants/ai";
+import { readResponseLines } from "@/lib/ai/streamLines";
+
+export const connectOpenAiCompatible = async (
+	baseUrl: string,
+	providerLabel: string,
+	messages: AiHistoryMessage[],
+	systemPrompt: string,
+	apiKey: string,
+	model: string,
+	abortSignal?: AbortSignal
+): Promise<Response> => {
+	const response = await fetch(`${baseUrl}/chat/completions`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${apiKey}`,
+		},
+		body: JSON.stringify({
+			model,
+			max_tokens: maxOutputTokens,
+			stream: true,
+			messages: [{ role: UserRole.System, content: systemPrompt }, ...messages],
+		}),
+		signal: abortSignal,
+	});
+
+	if (!response.ok) {
+		const errorData = await response.json().catch(() => ({}));
+
+		throw new Error(
+			errorData?.error?.message || `${providerLabel} API request failed`
+		);
+	}
+
+	return response;
+};
+
+export const pumpOpenAiCompatibleStream = async (
+	upstream: Response,
+	emit: AiStreamEmit
+): Promise<AiStreamOutcome> => {
+	let text = "";
+	let thinking = "";
+
+	await readResponseLines(upstream, (line) => {
+		if (!line.startsWith(ssePrefix)) {
+			return;
+		}
+
+		const payload = line.slice(ssePrefix.length).trim();
+
+		if (!payload || payload === sseDoneSentinel) {
+			return;
+		}
+
+		try {
+			const chunk = JSON.parse(payload);
+			const delta = chunk?.choices?.[0]?.delta;
+			// Reasoning models on OpenAI-compatible hosts (e.g. NVIDIA) expose
+			// chain-of-thought through the non-standard reasoning_content field.
+			const reasoningDelta = delta?.reasoning_content;
+			const textDelta = delta?.content;
+
+			if (typeof reasoningDelta === "string" && reasoningDelta.length > 0) {
+				thinking += reasoningDelta;
+				emit({ type: AiStreamEventType.Thinking, delta: reasoningDelta });
+			}
+
+			if (typeof textDelta === "string" && textDelta.length > 0) {
+				text += textDelta;
+				emit({ type: AiStreamEventType.Text, delta: textDelta });
+			}
+		} catch {
+			// Skip malformed stream lines.
+		}
+	});
+
+	return { text, thinking, inputTokens: 0, outputTokens: 0 };
+};

--- a/app/lib/ai/streamLines.ts
+++ b/app/lib/ai/streamLines.ts
@@ -1,0 +1,53 @@
+const readLines = async (
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	onLine: (line: string) => void,
+	shouldStop?: () => boolean
+): Promise<void> => {
+	const decoder = new TextDecoder();
+	let buffer = "";
+
+	try {
+		for (;;) {
+			if (shouldStop?.()) {
+				return;
+			}
+
+			const { done, value } = await reader.read();
+
+			if (done) {
+				break;
+			}
+
+			buffer += decoder.decode(value, { stream: true });
+
+			let newlineIndex = buffer.indexOf("\n");
+
+			while (newlineIndex !== -1) {
+				onLine(buffer.slice(0, newlineIndex));
+				buffer = buffer.slice(newlineIndex + 1);
+				newlineIndex = buffer.indexOf("\n");
+			}
+		}
+
+		if (buffer.trim().length > 0) {
+			onLine(buffer);
+		}
+	} finally {
+		await reader.cancel().catch(() => undefined);
+	}
+};
+
+const readResponseLines = async (
+	upstream: Response,
+	onLine: (line: string) => void
+): Promise<void> => {
+	const reader = upstream.body?.getReader();
+
+	if (!reader) {
+		throw new Error("AI provider returned an empty response stream");
+	}
+
+	await readLines(reader, onLine);
+};
+
+export { readLines, readResponseLines };

--- a/app/lib/config/shiki.ts
+++ b/app/lib/config/shiki.ts
@@ -1,6 +1,49 @@
-import { codeToHtml } from "shiki";
+import { createHighlighterCore, HighlighterCore } from "shiki/core";
+import { createOnigurumaEngine } from "shiki/engine/oniguruma";
 
 import { ThemeName, ThemeNames } from "./themes";
+
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+
+const getHighlighter = (): Promise<HighlighterCore> => {
+	if (!highlighterPromise) {
+		highlighterPromise = createHighlighterCore({
+			engine: createOnigurumaEngine(import("shiki/wasm")),
+			themes: [
+				import("@shikijs/themes/ayu-light"),
+				import("@shikijs/themes/catppuccin-latte"),
+				import("@shikijs/themes/dracula"),
+				import("@shikijs/themes/github-dark"),
+				import("@shikijs/themes/github-light"),
+				import("@shikijs/themes/material-theme-palenight"),
+			],
+			langs: [
+				import("@shikijs/langs/bash"),
+				import("@shikijs/langs/c"),
+				import("@shikijs/langs/cpp"),
+				import("@shikijs/langs/css"),
+				import("@shikijs/langs/dart"),
+				import("@shikijs/langs/go"),
+				import("@shikijs/langs/html"),
+				import("@shikijs/langs/java"),
+				import("@shikijs/langs/javascript"),
+				import("@shikijs/langs/json"),
+				import("@shikijs/langs/kotlin"),
+				import("@shikijs/langs/markdown"),
+				import("@shikijs/langs/php"),
+				import("@shikijs/langs/python"),
+				import("@shikijs/langs/ruby"),
+				import("@shikijs/langs/rust"),
+				import("@shikijs/langs/sql"),
+				import("@shikijs/langs/swift"),
+				import("@shikijs/langs/typescript"),
+				import("@shikijs/langs/yaml"),
+			],
+		});
+	}
+
+	return highlighterPromise;
+};
 
 const shikiThemeMap: Record<ThemeName, string> = {
 	[ThemeNames.AyuLight]: "ayu-light",
@@ -69,8 +112,9 @@ export const getHighlightedCode = async (
 ): Promise<string> => {
 	const shikiLanguage = shikiLanguageMap[language] ?? "plaintext";
 	const shikiTheme = shikiThemeMap[theme] ?? "dracula";
+	const highlighter = await getHighlighter();
 
-	return codeToHtml(code, {
+	return highlighter.codeToHtml(code, {
 		lang: shikiLanguage,
 		theme: shikiTheme,
 	});
@@ -90,7 +134,9 @@ export const getHighlightedFenceCode = async (
 	const shikiTheme = shikiThemeMap[theme] ?? "dracula";
 
 	try {
-		return await codeToHtml(code, {
+		const highlighter = await getHighlighter();
+
+		return highlighter.codeToHtml(code, {
 			lang: shikiLanguage,
 			theme: shikiTheme,
 		});

--- a/app/lib/constants/ai.ts
+++ b/app/lib/constants/ai.ts
@@ -67,6 +67,19 @@ export const enum AiPaneTab {
 	Code = "code",
 }
 
+export const enum AiProviderId {
+	Claude = "claude",
+	Nvidia = "nvidia",
+	Ollama = "ollama",
+	OllamaCloud = "ollama-cloud",
+	OpenAi = "openai",
+}
+
+export const enum SegmentType {
+	Code = "code",
+	Prose = "prose",
+}
+
 export const enum AiStreamEventType {
 	Done = "done",
 	Error = "error",
@@ -125,6 +138,7 @@ export const fencedCodeBlockPattern = /```([a-zA-Z0-9_+-]*)\n([\s\S]*?)```/g;
 
 export const aiChatModalMinWidthPx = 440;
 export const aiChatModalWidthStorageKey = "aiChatModal.width";
+export const ScrollPinThresholdPx = 80;
 
 export const maxHistoryMessages = 20;
 
@@ -132,6 +146,20 @@ export const ollamaTimeout = 55000;
 export const maxOutputTokens = 4096;
 export const claudeMaxOutputTokens = 8192;
 export const claudeThinkingBudgetTokens = 2048;
+
+export const anthropicVersion = process.env.ANTHROPIC_VERSION || "2023-06-01";
+export const defaultAnthropicModel =
+	process.env.ANTHROPIC_MODEL || "claude-sonnet-4-20250514";
+export const defaultOllamaUrl =
+	process.env.OLLAMA_URL || "http://localhost:11434";
+export const ollamaCloudUrl = "https://ollama.com";
+export const ollamaContextWindowCacheLimit = 64;
+export const ollamaContextWindowCache = new Map<string, number>();
+export const openAiBaseUrl = "https://api.openai.com/v1";
+export const nvidiaBaseUrl = "https://integrate.api.nvidia.com/v1";
+export const defaultOpenAIModel = process.env.OPENAI_MODEL || "gpt-4o";
+export const defaultNvidiaModel =
+	process.env.NVIDIA_MODEL || "meta/llama-3.1-70b-instruct";
 
 export const ssePrefix = "data:";
 export const sseDoneSentinel = "[DONE]";

--- a/app/lib/hooks/useAiChat.ts
+++ b/app/lib/hooks/useAiChat.ts
@@ -8,6 +8,7 @@ import {
 	aiActions,
 	ChatStatus,
 	codeActions,
+	ScrollPinThresholdPx,
 	UserRole,
 } from "@/lib/constants/ai";
 import { ToastType } from "@/lib/constants/toast";
@@ -83,8 +84,17 @@ const useAiChat = ({
 	};
 
 	useEffect(() => {
-		if (chatRef.current) {
-			chatRef.current.scrollTop = chatRef.current.scrollHeight;
+		const chat = chatRef.current;
+
+		if (!chat) {
+			return;
+		}
+
+		const distanceFromBottom =
+			chat.scrollHeight - chat.scrollTop - chat.clientHeight;
+
+		if (distanceFromBottom < ScrollPinThresholdPx) {
+			chat.scrollTop = chat.scrollHeight;
 		}
 	}, [history, revealedAnswer, thinkingText]);
 
@@ -166,10 +176,14 @@ const useAiChat = ({
 	};
 
 	const commitCurrentTurn = (): void => {
+		const turnAnswered = status === ChatStatus.Answered;
+		const turnStoppedWithAnswer =
+			status === ChatStatus.Stopped && revealedAnswer.length > 0;
+
 		if (
 			currentUserMessage &&
 			revealedAnswer &&
-			status === ChatStatus.Answered
+			(turnAnswered || turnStoppedWithAnswer)
 		) {
 			appendMessage({ role: UserRole.User, content: currentUserMessage });
 
@@ -185,6 +199,7 @@ const useAiChat = ({
 				userPrompt: currentUserPrompt || undefined,
 				thinking: thinkingText || undefined,
 				isReplaceCandidate,
+				stopped: turnStoppedWithAnswer || undefined,
 			});
 		}
 	};
@@ -250,6 +265,54 @@ const useAiChat = ({
 					}))
 				: [];
 
+		let streamedAnswer = "";
+		let pendingText = "";
+		let pendingThinking = "";
+		let flushHandle = 0;
+
+		const flushPending = (): void => {
+			flushHandle = 0;
+
+			if (controller.signal.aborted) {
+				pendingText = "";
+				pendingThinking = "";
+
+				return;
+			}
+
+			if (pendingText.length > 0) {
+				const chunk = pendingText;
+
+				pendingText = "";
+				setRevealedAnswer((previous) => previous + chunk);
+			}
+
+			if (pendingThinking.length > 0) {
+				const chunk = pendingThinking;
+
+				pendingThinking = "";
+				setThinkingText((previous) => previous + chunk);
+			}
+		};
+
+		const scheduleFlush = (): void => {
+			if (flushHandle !== 0) {
+				return;
+			}
+
+			flushHandle = requestAnimationFrame(flushPending);
+		};
+
+		const cancelFlush = (): void => {
+			if (flushHandle !== 0) {
+				cancelAnimationFrame(flushHandle);
+				flushHandle = 0;
+			}
+
+			pendingText = "";
+			pendingThinking = "";
+		};
+
 		try {
 			const response = await requestAiAction(
 				action,
@@ -259,12 +322,19 @@ const useAiChat = ({
 					userPrompt: effectivePrompt,
 					signal: controller.signal,
 					history: historyForRequest,
-					onThinkingDelta: (delta) =>
-						setThinkingText((previous) => previous + delta),
-					onTextDelta: (delta) =>
-						setRevealedAnswer((previous) => previous + delta),
+					onThinkingDelta: (delta) => {
+						pendingThinking += delta;
+						scheduleFlush();
+					},
+					onTextDelta: (delta) => {
+						streamedAnswer += delta;
+						pendingText += delta;
+						scheduleFlush();
+					},
 				}
 			);
+
+			cancelFlush();
 
 			if (controller.signal.aborted) {
 				return;
@@ -275,7 +345,16 @@ const useAiChat = ({
 			setThinkingText(response.thinking ?? "");
 			setStatus(ChatStatus.Answered);
 		} catch (requestError) {
+			cancelFlush();
+
 			if (controller.signal.aborted) {
+				return;
+			}
+
+			if (streamedAnswer.trim().length > 0) {
+				setRevealedAnswer(streamedAnswer);
+				setStatus(ChatStatus.Answered);
+
 				return;
 			}
 

--- a/app/utils/ai.utils.ts
+++ b/app/utils/ai.utils.ts
@@ -1,4 +1,6 @@
-import { AiStreamEventType } from "@/lib/constants/ai";
+import { aiActions, AiProviderId, AiStreamEventType } from "@/lib/constants/ai";
+import { readLines } from "@/lib/ai/streamLines";
+import { stripMarkdownCodeFences } from "@/utils/string.utils";
 
 export const fetchAiModels = async (
 	provider: AiProvider,
@@ -8,7 +10,7 @@ export const fetchAiModels = async (
 		const params = new URLSearchParams({ provider });
 		const headers: Record<string, string> = {};
 
-		if (provider === "claude" || provider === "openai") {
+		if (provider === AiProviderId.Claude || provider === AiProviderId.OpenAi) {
 			if (options.apiKey) {
 				headers["x-api-key"] = options.apiKey;
 			}
@@ -63,7 +65,10 @@ export const fetchOllamaModels = async (
 	ollamaUrl?: string,
 	ollamaApiKey?: string
 ): Promise<string[]> => {
-	const result = await fetchAiModels("ollama", { ollamaUrl, ollamaApiKey });
+	const result = await fetchAiModels(AiProviderId.Ollama, {
+		ollamaUrl,
+		ollamaApiKey,
+	});
 
 	return result.models;
 };
@@ -100,23 +105,37 @@ export const requestAiAction = async (
 	}
 
 	const reader = response.body.getReader();
-	const decoder = new TextDecoder();
-	let buffer = "";
+	let streamedText = "";
+	let streamedThinking = "";
 	let finalResponse: AiResponse | null = null;
 
-	const handleLine = (line: string): void => {
+	const parseLine = (line: string): AiStreamEvent | null => {
 		const trimmed = line.trim();
 
 		if (!trimmed) {
+			return null;
+		}
+
+		try {
+			// Each NDJSON line emitted by /api/ai is a serialized AiStreamEvent.
+			return JSON.parse(trimmed) as AiStreamEvent;
+		} catch {
+			return null;
+		}
+	};
+
+	const handleLine = (line: string): void => {
+		const event = parseLine(line);
+
+		if (!event) {
 			return;
 		}
 
-		// Each NDJSON line emitted by /api/ai is a serialized AiStreamEvent.
-		const event = JSON.parse(trimmed) as AiStreamEvent;
-
 		if (event.type === AiStreamEventType.Thinking) {
+			streamedThinking += event.delta;
 			onThinkingDelta?.(event.delta);
 		} else if (event.type === AiStreamEventType.Text) {
+			streamedText += event.delta;
 			onTextDelta?.(event.delta);
 		} else if (event.type === AiStreamEventType.Done) {
 			finalResponse = {
@@ -131,31 +150,21 @@ export const requestAiAction = async (
 		}
 	};
 
-	for (;;) {
-		const { done, value } = await reader.read();
+	await readLines(reader, handleLine, () => Boolean(signal?.aborted));
 
-		if (done) {
-			break;
-		}
-
-		buffer += decoder.decode(value, { stream: true });
-
-		let newlineIndex = buffer.indexOf("\n");
-
-		while (newlineIndex !== -1) {
-			handleLine(buffer.slice(0, newlineIndex));
-			buffer = buffer.slice(newlineIndex + 1);
-			newlineIndex = buffer.indexOf("\n");
-		}
+	if (finalResponse !== null) {
+		return finalResponse;
 	}
 
-	if (buffer.trim().length > 0) {
-		handleLine(buffer);
+	if (streamedText.trim().length > 0) {
+		return {
+			result:
+				action === aiActions.ask
+					? streamedText
+					: stripMarkdownCodeFences(streamedText),
+			thinking: streamedThinking || undefined,
+		};
 	}
 
-	if (finalResponse === null) {
-		throw new Error("AI stream ended without a result");
-	}
-
-	return finalResponse;
+	throw new Error("AI stream ended without a result");
 };

--- a/app/utils/chat.utils.ts
+++ b/app/utils/chat.utils.ts
@@ -2,6 +2,7 @@ import {
 	fencedCodeBlockPattern,
 	maxHistoryMessages,
 	replaceIntentPattern,
+	SegmentType,
 	UserRole,
 } from "@/lib/constants/ai";
 
@@ -50,13 +51,13 @@ const parseAssistantSegments = (content: string): AssistantSegment[] => {
 	while (match !== null) {
 		if (match.index > lastIndex) {
 			segments.push({
-				type: "prose",
+				type: SegmentType.Prose,
 				content: content.slice(lastIndex, match.index),
 			});
 		}
 
 		segments.push({
-			type: "code",
+			type: SegmentType.Code,
 			language: match[1] ?? "",
 			body: match[2] ?? "",
 		});
@@ -65,7 +66,10 @@ const parseAssistantSegments = (content: string): AssistantSegment[] => {
 	}
 
 	if (lastIndex < content.length) {
-		segments.push({ type: "prose", content: content.slice(lastIndex) });
+		segments.push({
+			type: SegmentType.Prose,
+			content: content.slice(lastIndex),
+		});
 	}
 
 	return segments;

--- a/app/utils/string.utils.ts
+++ b/app/utils/string.utils.ts
@@ -1,6 +1,15 @@
 const escapeHtml = (snippet: string): string =>
 	snippet.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
+const stripMarkdownCodeFences = (text: string): string => {
+	const trimmed = text.trim();
+	const codeBlockRegex = /^```[\w]*\n?([\s\S]*?)```\s*$/;
+	const match = trimmed.match(codeBlockRegex);
+	const fencedBody = match?.[1];
+
+	return fencedBody ? fencedBody.trim() : trimmed;
+};
+
 const normalizeRecoveryCode = (value: unknown): string => {
 	if (typeof value !== "string") {
 		return "";
@@ -23,6 +32,6 @@ const uuidv4 = (): UUID => {
 	}) as UUID;
 };
 
-export { escapeHtml, normalizeRecoveryCode };
+export { escapeHtml, normalizeRecoveryCode, stripMarkdownCodeFences };
 
 export default uuidv4;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
 		"@codemirror/lang-sql": "^6.10.0",
 		"@codemirror/lang-yaml": "^6.1.2",
 		"@codemirror/language": "^6.12.2",
+		"@shikijs/langs": "^4.0.2",
+		"@shikijs/themes": "^4.0.2",
 		"@supabase/ssr": "^0.9.0",
 		"@supabase/supabase-js": "^2.99.1",
 		"@uiw/codemirror-theme-dracula": "^4.25.8",

--- a/types/chat.d.ts
+++ b/types/chat.d.ts
@@ -9,6 +9,7 @@ declare global {
 		userPrompt?: string;
 		thinking?: string;
 		isReplaceCandidate?: boolean;
+		stopped?: boolean;
 	};
 
 	type AiStreamThinkingEvent = {

--- a/types/snippets.d.ts
+++ b/types/snippets.d.ts
@@ -126,8 +126,8 @@ declare global {
 	type AiResponse = {
 		result: string;
 		thinking?: string;
-		provider: AiProvider;
-		model: string;
+		provider?: AiProvider;
+		model?: string;
 		usage?: AiUsage;
 	};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,7 +1197,7 @@
     "@shikijs/types" "4.2.0"
     "@shikijs/vscode-textmate" "^10.0.2"
 
-"@shikijs/langs@4.2.0":
+"@shikijs/langs@4.2.0", "@shikijs/langs@^4.0.2":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@shikijs/langs/-/langs-4.2.0.tgz#084f832fda4e858738ff3070f8439e732131d709"
   integrity sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==
@@ -1213,7 +1213,7 @@
     "@shikijs/vscode-textmate" "^10.0.2"
     "@types/hast" "^3.0.4"
 
-"@shikijs/themes@4.2.0":
+"@shikijs/themes@4.2.0", "@shikijs/themes@^4.0.2":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@shikijs/themes/-/themes-4.2.0.tgz#3c56a59446775a312d1abaf198a1b18f449acf16"
   integrity sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==


### PR DESCRIPTION
## Summary

Major refactor of the AI chat system:

### Changes

- **Provider modularization**: Split AI provider logic into separate modules (`claude.ts`, `ollama.ts`, `openAiCompatible.ts`) under `app/lib/ai/providers/`
- **Shared streaming utility**: Added `streamLines.ts` with `readLines` and `readResponseLines` for consistent stream handling
- **Type-safe provider IDs**: Introduced `AiProviderId` enum (`Claude`, `Nvidia`, `Ollama`, `OllamaCloud`, `OpenAi`) replacing magic strings
- **Improved streaming**: RequestAnimationFrame-based batching for text/thinking deltas to reduce render thrashing
- **Scroll pin threshold**: Added `ScrollPinThresholdPx` (80px) to prevent auto-scroll while user is reading
- **Shiki modernization**: Migrated highlighter to core API with dynamic imports for better bundle size
- **Chat history enhancement**: Added `stopped` flag to track partially completed responses
- **Consistent provider references**: Updated `ModelSelector`, `AccountModal`, `AssistantMessage`, and API routes to use `AiProviderId` enum

### Files Changed

- 4 new provider modules in `app/lib/ai/providers/`
- 1 new utility in `app/lib/ai/streamLines.ts`
- Updated constants in `app/lib/constants/ai.ts`
- Updated hooks in `app/lib/hooks/useAiChat.ts`
- Updated utils in `app/utils/ai.utils.ts`, `app/utils/chat.utils.ts`, `app/utils/string.utils.ts`
- Updated components: `AccountModal`, `AssistantMessage`, `ModelSelector`
- Updated API route: `app/api/ai/route.ts`
- Updated Shiki config: `app/lib/config/shiki.ts`
- Updated types: `types/chat.d.ts`, `types/snippets.d.ts`
- Added `@shikijs/langs` and `@shikijs/themes` dependencies