### PR TITLE
feat(admin): add admin panel with role-based access control

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,33 @@
+import { ReactElement } from "react";
+import { redirect } from "next/navigation";
+
+/* Lib */
+import { AppRole, NonAdminRedirectPath } from "@/lib/constants/roles";
+import { resolveUserRole } from "@/lib/supabase/roles";
+import createSupabaseServerComponentClient from "@/lib/supabase/serverComponent";
+
+// Server-side authorization gate. This re-validates on the server even though
+// the proxy already guards /admin, so the page is safe if middleware is ever
+// bypassed or misconfigured (defense in depth).
+export default async function AdminLayout({
+	children,
+}: {
+	children: React.ReactNode;
+}): Promise<ReactElement> {
+	const supabase = await createSupabaseServerComponentClient();
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		redirect(NonAdminRedirectPath);
+	}
+
+	const role = await resolveUserRole(supabase, user.id);
+
+	if (role !== AppRole.Admin) {
+		redirect(NonAdminRedirectPath);
+	}
+
+	return <>{children}</>;
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,8 @@
+import { ReactElement } from "react";
+
+/* Components */
+import AdminDashboard from "@/components/admin/AdminDashboard/AdminDashboard";
+
+export default function Page(): ReactElement {
+	return <AdminDashboard />;
+}

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import { isAdminClientConfigured } from "@/lib/supabase/admin";
+import { requireAdmin } from "@/lib/supabase/adminGuard";
+import { computeSnippetAnalytics } from "@/lib/supabase/adminAnalytics";
+
+export const GET = async (request: NextRequest): Promise<NextResponse> => {
+	if (!isAdminClientConfigured()) {
+		return NextResponse.json(
+			{ error: "Admin features are not configured on the server" },
+			{ status: HttpStatusCode.ServiceUnavailable }
+		);
+	}
+
+	const guard = await requireAdmin(request);
+
+	if (guard.error) {
+		return guard.error;
+	}
+
+	const analytics = await computeSnippetAnalytics();
+
+	return NextResponse.json(analytics);
+};

--- a/app/api/admin/users/[userId]/disconnect/route.ts
+++ b/app/api/admin/users/[userId]/disconnect/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import { isAdminClientConfigured } from "@/lib/supabase/admin";
+import {
+	rejectDemoActor,
+	rejectDemoTarget,
+	requireAdmin,
+} from "@/lib/supabase/adminGuard";
+import {
+	getAdminUserEmail,
+	revokeUserSessions,
+} from "@/lib/supabase/adminUsers";
+
+// Force sign-out: revokes the target user's sessions so they must log in again.
+export const POST = async (
+	request: NextRequest,
+	context: { params: Promise<{ userId: string }> }
+): Promise<NextResponse> => {
+	if (!isAdminClientConfigured()) {
+		return NextResponse.json(
+			{ error: "Admin features are not configured on the server" },
+			{ status: HttpStatusCode.ServiceUnavailable }
+		);
+	}
+
+	const guard = await requireAdmin(request);
+
+	if (guard.error) {
+		return guard.error;
+	}
+
+	const demoActorBlock = rejectDemoActor(guard.user);
+
+	if (demoActorBlock) {
+		return demoActorBlock;
+	}
+
+	const { userId } = await context.params;
+	const targetEmail = await getAdminUserEmail(userId);
+	const demoTargetBlock = rejectDemoTarget(targetEmail);
+
+	if (demoTargetBlock) {
+		return demoTargetBlock;
+	}
+
+	const { error } = await revokeUserSessions(userId);
+
+	if (error) {
+		return NextResponse.json({ error }, { status: HttpStatusCode.BadRequest });
+	}
+
+	return NextResponse.json({ success: true });
+};

--- a/app/api/admin/users/[userId]/password/route.ts
+++ b/app/api/admin/users/[userId]/password/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { MinPasswordLength } from "@/lib/constants/admin.constants";
+import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import { isAdminClientConfigured } from "@/lib/supabase/admin";
+import {
+	rejectDemoActor,
+	rejectDemoTarget,
+	requireAdmin,
+} from "@/lib/supabase/adminGuard";
+import {
+	generatePasswordResetLink,
+	getAdminUserEmail,
+	setAdminUserPassword,
+} from "@/lib/supabase/adminUsers";
+
+const serviceUnavailable = (): NextResponse =>
+	NextResponse.json(
+		{ error: "Admin features are not configured on the server" },
+		{ status: HttpStatusCode.ServiceUnavailable }
+	);
+
+// With { newPassword } the password is set directly; without it, a recovery
+// link is generated and returned (useful when SMTP isn't configured locally).
+export const POST = async (
+	request: NextRequest,
+	context: { params: Promise<{ userId: string }> }
+): Promise<NextResponse> => {
+	if (!isAdminClientConfigured()) {
+		return serviceUnavailable();
+	}
+
+	const guard = await requireAdmin(request);
+
+	if (guard.error) {
+		return guard.error;
+	}
+
+	const demoActorBlock = rejectDemoActor(guard.user);
+
+	if (demoActorBlock) {
+		return demoActorBlock;
+	}
+
+	const { userId } = await context.params;
+	const targetEmail = await getAdminUserEmail(userId);
+
+	if (!targetEmail) {
+		return NextResponse.json(
+			{ error: "User not found" },
+			{ status: HttpStatusCode.NotFound }
+		);
+	}
+
+	const demoTargetBlock = rejectDemoTarget(targetEmail);
+
+	if (demoTargetBlock) {
+		return demoTargetBlock;
+	}
+
+	const body = (await request.json().catch(() => ({}))) as {
+		newPassword?: string;
+	};
+
+	if (body.newPassword) {
+		if (body.newPassword.length < MinPasswordLength) {
+			return NextResponse.json(
+				{ error: `Password must be at least ${MinPasswordLength} characters` },
+				{ status: HttpStatusCode.BadRequest }
+			);
+		}
+
+		const { error } = await setAdminUserPassword(userId, body.newPassword);
+
+		if (error) {
+			return NextResponse.json(
+				{ error },
+				{ status: HttpStatusCode.BadRequest }
+			);
+		}
+
+		return NextResponse.json({ success: true });
+	}
+
+	const { actionLink, error } = await generatePasswordResetLink(targetEmail);
+
+	if (error) {
+		return NextResponse.json({ error }, { status: HttpStatusCode.BadRequest });
+	}
+
+	return NextResponse.json({ actionLink, success: true });
+};

--- a/app/api/admin/users/[userId]/route.ts
+++ b/app/api/admin/users/[userId]/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { AppRole } from "@/lib/constants/roles";
+import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import { isAdminClientConfigured } from "@/lib/supabase/admin";
+import {
+	rejectDemoActor,
+	rejectDemoTarget,
+	requireAdmin,
+} from "@/lib/supabase/adminGuard";
+import {
+	deleteAdminUser,
+	getAdminUserEmail,
+	updateAdminUser,
+} from "@/lib/supabase/adminUsers";
+import { fetchRoleMap } from "@/lib/supabase/roles";
+
+const serviceUnavailable = (): NextResponse =>
+	NextResponse.json(
+		{ error: "Admin features are not configured on the server" },
+		{ status: HttpStatusCode.ServiceUnavailable }
+	);
+
+export const PATCH = async (
+	request: NextRequest,
+	context: { params: Promise<{ userId: string }> }
+): Promise<NextResponse> => {
+	if (!isAdminClientConfigured()) {
+		return serviceUnavailable();
+	}
+
+	const guard = await requireAdmin(request);
+
+	if (guard.error) {
+		return guard.error;
+	}
+
+	const demoActorBlock = rejectDemoActor(guard.user);
+
+	if (demoActorBlock) {
+		return demoActorBlock;
+	}
+
+	const { userId } = await context.params;
+	const targetEmail = await getAdminUserEmail(userId);
+	const demoTargetBlock = rejectDemoTarget(targetEmail);
+
+	if (demoTargetBlock) {
+		return demoTargetBlock;
+	}
+
+	const body = (await request
+		.json()
+		.catch(() => ({}))) as AdminUserUpdatePayload;
+	const payload: AdminUserUpdatePayload = {
+		...(body.email !== undefined ? { email: body.email } : {}),
+		...(body.username !== undefined ? { username: body.username } : {}),
+		...(body.theme !== undefined ? { theme: body.theme } : {}),
+		...(body.isDisabled !== undefined ? { isDisabled: body.isDisabled } : {}),
+		...(body.role !== undefined
+			? { role: body.role === AppRole.Admin ? AppRole.Admin : AppRole.User }
+			: {}),
+	};
+
+	// Don't let an admin strip their own admin role and lock themselves out.
+	if (payload.role === AppRole.User && guard.user.id === userId) {
+		return NextResponse.json(
+			{ error: "You cannot remove your own admin role" },
+			{ status: HttpStatusCode.BadRequest }
+		);
+	}
+
+	// Admin accounts can't be disabled — demote to user first.
+	if (payload.isDisabled === true) {
+		const roleMap = await fetchRoleMap([userId]);
+
+		if (roleMap[userId] === AppRole.Admin) {
+			return NextResponse.json(
+				{ error: "Admin users cannot be disabled" },
+				{ status: HttpStatusCode.Forbidden }
+			);
+		}
+	}
+
+	const { error } = await updateAdminUser(userId, payload);
+
+	if (error) {
+		return NextResponse.json({ error }, { status: HttpStatusCode.BadRequest });
+	}
+
+	return NextResponse.json({ success: true });
+};
+
+export const DELETE = async (
+	request: NextRequest,
+	context: { params: Promise<{ userId: string }> }
+): Promise<NextResponse> => {
+	if (!isAdminClientConfigured()) {
+		return serviceUnavailable();
+	}
+
+	const guard = await requireAdmin(request);
+
+	if (guard.error) {
+		return guard.error;
+	}
+
+	const demoActorBlock = rejectDemoActor(guard.user);
+
+	if (demoActorBlock) {
+		return demoActorBlock;
+	}
+
+	const { userId } = await context.params;
+
+	if (guard.user.id === userId) {
+		return NextResponse.json(
+			{ error: "You cannot delete your own account" },
+			{ status: HttpStatusCode.BadRequest }
+		);
+	}
+
+	const targetEmail = await getAdminUserEmail(userId);
+	const demoTargetBlock = rejectDemoTarget(targetEmail);
+
+	if (demoTargetBlock) {
+		return demoTargetBlock;
+	}
+
+	// Admin accounts are protected — demote to user before deleting.
+	const roleMap = await fetchRoleMap([userId]);
+
+	if (roleMap[userId] === AppRole.Admin) {
+		return NextResponse.json(
+			{ error: "Admin users cannot be deleted" },
+			{ status: HttpStatusCode.Forbidden }
+		);
+	}
+
+	const { error } = await deleteAdminUser(userId);
+
+	if (error) {
+		return NextResponse.json({ error }, { status: HttpStatusCode.BadRequest });
+	}
+
+	return NextResponse.json({ success: true });
+};

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { MinPasswordLength } from "@/lib/constants/admin.constants";
+import { AppRole } from "@/lib/constants/roles";
+import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import { isAdminClientConfigured } from "@/lib/supabase/admin";
+import { rejectDemoActor, requireAdmin } from "@/lib/supabase/adminGuard";
+import { createAdminUser, listAdminUsers } from "@/lib/supabase/adminUsers";
+
+const serviceUnavailable = (): NextResponse =>
+	NextResponse.json(
+		{ error: "Admin features are not configured on the server" },
+		{ status: HttpStatusCode.ServiceUnavailable }
+	);
+
+export const GET = async (request: NextRequest): Promise<NextResponse> => {
+	if (!isAdminClientConfigured()) {
+		return serviceUnavailable();
+	}
+
+	const guard = await requireAdmin(request);
+
+	if (guard.error) {
+		return guard.error;
+	}
+
+	const response = await listAdminUsers();
+
+	return NextResponse.json(response);
+};
+
+export const POST = async (request: NextRequest): Promise<NextResponse> => {
+	if (!isAdminClientConfigured()) {
+		return serviceUnavailable();
+	}
+
+	const guard = await requireAdmin(request);
+
+	if (guard.error) {
+		return guard.error;
+	}
+
+	const demoBlock = rejectDemoActor(guard.user);
+
+	if (demoBlock) {
+		return demoBlock;
+	}
+
+	const body = (await request
+		.json()
+		.catch(() => ({}))) as AdminUserCreatePayload;
+
+	if (!body.email || !body.password) {
+		return NextResponse.json(
+			{ error: "Email and password are required" },
+			{ status: HttpStatusCode.BadRequest }
+		);
+	}
+
+	if (body.password.length < MinPasswordLength) {
+		return NextResponse.json(
+			{ error: `Password must be at least ${MinPasswordLength} characters` },
+			{ status: HttpStatusCode.BadRequest }
+		);
+	}
+
+	const { error, userId } = await createAdminUser({
+		email: body.email,
+		password: body.password,
+		role: body.role === AppRole.Admin ? AppRole.Admin : AppRole.User,
+		...(body.theme ? { theme: body.theme } : {}),
+		...(body.username ? { username: body.username } : {}),
+	});
+
+	if (error) {
+		return NextResponse.json({ error }, { status: HttpStatusCode.BadRequest });
+	}
+
+	return NextResponse.json({ userId }, { status: HttpStatusCode.Ok });
+};

--- a/app/components/Aside/Aside.tsx
+++ b/app/components/Aside/Aside.tsx
@@ -32,6 +32,7 @@ import supabase from "@/lib/supabase/client";
 import useMenuStore from "@/lib/store/menu.store";
 import useViewPortStore from "@/lib/store/viewPort.store";
 import useUserStore from "@/lib/store/user.store";
+import useCurrentUser from "@/lib/hooks/useCurrentUser";
 import { getUserDataFromSession } from "@/lib/supabase/queries";
 import { isValidTheme, ThemeName, ThemeNames } from "@/lib/config/themes";
 import { setCookie } from "@/lib/cookies";
@@ -56,6 +57,7 @@ import CaretDown from "@/components/ui/icons/CaretDown";
 import Globe from "@/components/ui/icons/Globe";
 import Keyboard from "@/components/ui/icons/Keyboard";
 import Sparkle from "@/components/ui/icons/Sparkle";
+import ShieldCheck from "@/components/ui/icons/ShieldCheck";
 import ShortcutsModal from "@/components/ShortcutsModal/ShortcutsModal";
 
 /* Styles */
@@ -140,6 +142,7 @@ const Aside = ({
 	const setUserData = useUserStore((state) => state.setUserData);
 	const setLoading = useUserStore((state) => state.setLoading);
 	const setTheme = useUserStore((state) => state.setTheme);
+	const { isAdmin } = useCurrentUser();
 
 	const signOut = async (): Promise<void> => {
 		setIsLoginOut(true);
@@ -591,6 +594,25 @@ const Aside = ({
 						</div>
 
 						<div className={styles.userMenuSep} />
+
+						{isAdmin && (
+							<button
+								className={styles.userMenuItem}
+								role="menuitem"
+								onClick={() => {
+									setIsUserMenuOpen(false);
+									closeMainMenu();
+									router.push("/admin");
+								}}
+							>
+								<ShieldCheck
+									className={styles.userMenuIco}
+									width={16}
+									height={16}
+								/>
+								<span className={styles.userMenuLabel}>Admin</span>
+							</button>
+						)}
 
 						{isOnAiAssistant ? (
 							<button

--- a/app/components/AuthForm/AuthForm.tsx
+++ b/app/components/AuthForm/AuthForm.tsx
@@ -10,7 +10,12 @@ import {
 import { useRouter } from "next/navigation";
 
 /* Lib */
-import { FormMessageTypes, regexPatterns } from "@/lib/constants/form";
+import {
+	BannedErrorFragment,
+	DisabledUserMessage,
+	FormMessageTypes,
+	regexPatterns,
+} from "@/lib/constants/form";
 import { AuthFormStep, MfaCodeLength } from "@/lib/constants/mfa";
 import supabase from "@/lib/supabase/client";
 import {
@@ -87,9 +92,17 @@ const AuthForm = (): ReactElement => {
 		});
 
 		if (error) {
+			const rawMessage =
+				error.message || "something went wrong!, try again later";
+			const friendlyMessage = rawMessage
+				.toLowerCase()
+				.includes(BannedErrorFragment)
+				? DisabledUserMessage
+				: rawMessage;
+
 			setFormData({
 				...formData,
-				text: error?.message ?? "something went wrong!, try again later",
+				text: friendlyMessage,
 				type: FormMessageTypes.Error,
 			});
 			setLoading(false);

--- a/app/components/CodeEditor/CodeEditorHeader.tsx
+++ b/app/components/CodeEditor/CodeEditorHeader.tsx
@@ -80,6 +80,7 @@ const CodeEditorHeader = ({
 				<Button
 					className={`${styles.saveButton} ${touched ? styles.touched : ""}`}
 					variant="secondary"
+					shape="pill"
 					disabled={isSaving}
 					aria-label="Save snippet"
 					onClick={onSave}

--- a/app/components/CodeEditor/codeEditor.module.css
+++ b/app/components/CodeEditor/codeEditor.module.css
@@ -147,7 +147,6 @@
 	gap: 0.375rem;
 	padding: 0 0.875rem;
 	border: 1px solid var(--border-color);
-	border-radius: 999px;
 	font-weight: 600;
 	transition:
 		background-color 0.2s ease,

--- a/app/components/admin/AdminDashboard/AdminDashboard.tsx
+++ b/app/components/admin/AdminDashboard/AdminDashboard.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { ReactElement, useState } from "react";
+import { useRouter } from "next/navigation";
+
+/* Constants */
+import { demoAccountData } from "@/lib/constants/account";
+import { AdminTab } from "@/lib/constants/admin.constants";
+
+/* Components */
+import SnippetAnalytics from "@/components/admin/SnippetAnalytics/SnippetAnalytics";
+import UserManagement from "@/components/admin/UserManagement/UserManagement";
+import Button from "@/components/ui/Button/Button";
+import Book from "@/components/ui/icons/Book";
+import ListChecks from "@/components/ui/icons/ListChecks";
+import ShieldCheck from "@/components/ui/icons/ShieldCheck";
+import User from "@/components/ui/icons/User";
+
+/* Lib */
+import useCurrentUser from "@/lib/hooks/useCurrentUser";
+
+/* Styles */
+import styles from "./adminDashboard.module.css";
+
+const AdminDashboard = (): ReactElement => {
+	const router = useRouter();
+	const { email } = useCurrentUser();
+	const [section, setSection] = useState<AdminTab>(AdminTab.Users);
+	const isReadOnly =
+		(email ?? "").toLowerCase() === demoAccountData.email.toLowerCase();
+	const navItems: { icon: ReactElement; label: string; value: AdminTab }[] = [
+		{
+			icon: <User width={18} height={18} />,
+			label: "Users",
+			value: AdminTab.Users,
+		},
+		{
+			icon: <ListChecks width={18} height={18} />,
+			label: "Analytics",
+			value: AdminTab.Analytics,
+		},
+	];
+
+	return (
+		<div className={styles.page}>
+			<aside className={styles.sidebar}>
+				<div className={styles.brand}>
+					<span className={styles.brandIcon}>
+						<ShieldCheck width={20} height={20} />
+					</span>
+					<span className={styles.brandTitle}>Admin</span>
+					{isReadOnly && <span className={styles.demoTag}>Demo</span>}
+				</div>
+
+				<nav className={styles.nav}>
+					{navItems.map((item) => (
+						<button
+							key={item.value}
+							type="button"
+							className={`${styles.navItem} ${section === item.value ? styles.navItemActive : ""}`}
+							aria-current={section === item.value}
+							onClick={() => setSection(item.value)}
+						>
+							<span className={styles.navIcon}>{item.icon}</span>
+							<span className={styles.navLabel}>{item.label}</span>
+						</button>
+					))}
+				</nav>
+
+				<Button
+					className={styles.backButton}
+					variant="secondary"
+					onClick={() => router.push("/snippets")}
+				>
+					<Book width={16} height={16} /> Back to app
+				</Button>
+			</aside>
+
+			<main className={styles.main}>
+				{section === AdminTab.Users ? (
+					<UserManagement isReadOnly={isReadOnly} />
+				) : (
+					<SnippetAnalytics />
+				)}
+			</main>
+		</div>
+	);
+};
+
+export default AdminDashboard;

--- a/app/components/admin/AdminDashboard/adminDashboard.module.css
+++ b/app/components/admin/AdminDashboard/adminDashboard.module.css
@@ -1,0 +1,151 @@
+.page {
+	display: flex;
+	width: 100%;
+	min-height: 100vh;
+}
+
+/* Every admin button: 30px tall with 0 15px padding. Table buttons keep a
+   compact icon padding (override below). */
+.page button {
+	min-height: 1.875rem;
+	padding: 0 0.9375rem;
+}
+
+.page td button {
+	padding: 0 0.5rem;
+}
+
+.sidebar {
+	/* border-box so padding stays inside the 100vh height (no global box-sizing
+	   reset exists) — otherwise the rail overflows the viewport and scrolls. */
+	box-sizing: border-box;
+	position: sticky;
+	top: 0;
+	align-self: flex-start;
+	flex: 0 0 15rem;
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+	height: 100vh;
+	padding: 1.5rem 1rem;
+	background: var(--bg-color-dark);
+	border-right: 1px solid var(--border-color);
+}
+
+.brand {
+	display: flex;
+	align-items: center;
+	gap: 0.625rem;
+}
+
+.brandIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border-radius: var(--border-radius-md);
+	color: var(--purple-color);
+	background: color-mix(in srgb, var(--purple-color) 14%, transparent);
+}
+
+.brandTitle {
+	font-size: var(--big-font-size);
+	font-weight: 700;
+	color: var(--foreground-color);
+}
+
+.demoTag {
+	margin-left: auto;
+	padding: 0.125rem 0.5rem;
+	border-radius: var(--border-radius-pill, 999px);
+	font-size: var(--tiny-font-size);
+	font-weight: 600;
+	color: var(--yellow-color);
+	background: color-mix(in srgb, var(--yellow-color) 16%, transparent);
+}
+
+.nav {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.navItem {
+	display: flex;
+	align-items: center;
+	gap: 0.625rem;
+	width: 100%;
+	border: none;
+	border-radius: var(--border-radius-md);
+	background: transparent;
+	color: var(--gray-color);
+	font-family: inherit;
+	font-size: var(--small-font-size);
+	text-align: left;
+	cursor: pointer;
+	transition:
+		background var(--duration-fast) var(--ease-fluid),
+		color var(--duration-fast) var(--ease-fluid);
+}
+
+.navItemActive {
+	color: var(--cyan-color);
+	background: color-mix(in srgb, var(--cyan-color) 12%, transparent);
+}
+
+.navItem:hover {
+	color: var(--foreground-color);
+	background: var(--current-line);
+}
+
+.navIcon {
+	display: inline-flex;
+	flex-shrink: 0;
+}
+
+.navLabel {
+	flex: 1;
+}
+
+.backButton {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.375rem;
+	margin-top: auto;
+}
+
+.main {
+	box-sizing: border-box;
+	flex: 1;
+	min-width: 0;
+	padding: 2rem;
+}
+
+@media (width <= 768px) {
+	.page {
+		flex-direction: column;
+	}
+
+	.sidebar {
+		position: static;
+		flex: none;
+		width: 100%;
+		height: auto;
+		border-right: none;
+		border-bottom: 1px solid var(--border-color);
+	}
+
+	.nav {
+		flex-flow: row wrap;
+	}
+
+	.backButton {
+		margin-top: 0;
+	}
+
+	.main {
+		padding: 1.25rem;
+	}
+}

--- a/app/components/admin/AnimatedCounter/AnimatedCounter.tsx
+++ b/app/components/admin/AnimatedCounter/AnimatedCounter.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { ReactElement, useEffect, useRef, useState } from "react";
+
+type AnimatedCounterProps = {
+	decimals?: number;
+	durationMs?: number;
+	value: number;
+};
+
+// Counts up from 0 to `value` with an ease-out curve on mount and whenever the
+// value changes. Honours prefers-reduced-motion by snapping to the final value.
+const AnimatedCounter = ({
+	decimals = 0,
+	durationMs = 900,
+	value,
+}: AnimatedCounterProps): ReactElement => {
+	const [display, setDisplay] = useState<number>(value);
+	const frameRef = useRef<number>(0);
+
+	useEffect(() => {
+		const prefersReduced = window.matchMedia(
+			"(prefers-reduced-motion: reduce)"
+		).matches;
+
+		if (prefersReduced) {
+			setDisplay(value);
+
+			return;
+		}
+
+		const start = performance.now();
+
+		const tick = (now: number): void => {
+			const progress = Math.min((now - start) / durationMs, 1);
+			const eased = 1 - Math.pow(1 - progress, 3);
+
+			setDisplay(value * eased);
+
+			if (progress < 1) {
+				frameRef.current = requestAnimationFrame(tick);
+			}
+		};
+
+		frameRef.current = requestAnimationFrame(tick);
+
+		return () => cancelAnimationFrame(frameRef.current);
+	}, [value, durationMs]);
+
+	return (
+		<>
+			{display.toLocaleString("en-US", {
+				maximumFractionDigits: decimals,
+				minimumFractionDigits: decimals,
+			})}
+		</>
+	);
+};
+
+export default AnimatedCounter;

--- a/app/components/admin/SnippetAnalytics/AnalyticsSkeleton.tsx
+++ b/app/components/admin/SnippetAnalytics/AnalyticsSkeleton.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { ReactElement } from "react";
+
+/* Components */
+import Card from "@/components/ui/Card/Card";
+import Skeleton from "@/components/ui/Skeleton/Skeleton";
+
+/* Styles */
+import styles from "./snippetAnalytics.module.css";
+
+// Loading placeholder mirroring the real analytics layout (stat cards + every
+// panel) so nothing shifts when data arrives.
+const AnalyticsSkeleton = (): ReactElement => {
+	return (
+		<div className={styles.container}>
+			<div className={styles.grid}>
+				{Array.from({ length: 11 }, (_, index) => (
+					<Skeleton
+						key={index}
+						height="7.5rem"
+						borderRadius="var(--border-radius-lg)"
+					/>
+				))}
+			</div>
+
+			<div className={styles.panelRow}>
+				<Card title="Creation trend" subtitle="Snippets created over time">
+					<Skeleton height="200px" borderRadius="var(--border-radius-md)" />
+				</Card>
+				<Card title="Language mix" subtitle="Distribution by language">
+					<Skeleton height="200px" borderRadius="var(--border-radius-md)" />
+				</Card>
+			</div>
+
+			<div className={styles.panelRow}>
+				<Card title="Top languages" subtitle="Snippets per language">
+					<Skeleton height="220px" borderRadius="var(--border-radius-md)" />
+				</Card>
+				<Card title="Top contributors" subtitle="Most active users">
+					<ul className={styles.rankList}>
+						{Array.from({ length: 5 }, (_, index) => (
+							<li className={styles.rankItem} key={index}>
+								<Skeleton height="0.75rem" />
+								<Skeleton height="0.5rem" />
+								<Skeleton width="1.5rem" height="0.75rem" />
+							</li>
+						))}
+					</ul>
+				</Card>
+			</div>
+
+			<div className={styles.panelRow}>
+				<Card title="Top folders" subtitle="Snippets per folder">
+					<ul className={styles.rankList}>
+						{Array.from({ length: 5 }, (_, index) => (
+							<li className={styles.rankItem} key={index}>
+								<Skeleton height="0.75rem" />
+								<Skeleton height="0.5rem" />
+								<Skeleton width="1.5rem" height="0.75rem" />
+							</li>
+						))}
+					</ul>
+				</Card>
+				<Card title="Saved searches" subtitle="Popular smart groups">
+					<ul className={styles.rankList}>
+						{Array.from({ length: 5 }, (_, index) => (
+							<li className={styles.rankItem} key={index}>
+								<Skeleton height="0.75rem" />
+								<Skeleton height="0.5rem" />
+								<Skeleton width="1.5rem" height="0.75rem" />
+							</li>
+						))}
+					</ul>
+				</Card>
+			</div>
+
+			<Card title="Top tags" subtitle="Most-used tags across snippets">
+				<Skeleton height="220px" borderRadius="var(--border-radius-md)" />
+			</Card>
+		</div>
+	);
+};
+
+export default AnalyticsSkeleton;

--- a/app/components/admin/SnippetAnalytics/SnippetAnalytics.tsx
+++ b/app/components/admin/SnippetAnalytics/SnippetAnalytics.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import { ReactElement, useCallback, useEffect, useState } from "react";
+
+/* Constants */
+import {
+	AdminApiPaths,
+	ChartPalette,
+	RequestStatus,
+	TrendPeriod,
+} from "@/lib/constants/admin.constants";
+import { ToastType } from "@/lib/constants/toast";
+
+/* Components */
+import AnalyticsSkeleton from "@/components/admin/SnippetAnalytics/AnalyticsSkeleton";
+import AreaChart from "@/components/admin/charts/AreaChart/AreaChart";
+import BarChart from "@/components/admin/charts/BarChart/BarChart";
+import DonutChart from "@/components/admin/charts/DonutChart/DonutChart";
+import StatCard from "@/components/admin/StatCard/StatCard";
+import Alert from "@/components/ui/Alert/Alert";
+import Button from "@/components/ui/Button/Button";
+import Card from "@/components/ui/Card/Card";
+import CodeBlock from "@/components/ui/icons/CodeBlock";
+import Floppy from "@/components/ui/icons/Floppy";
+import Folder from "@/components/ui/icons/Folder";
+import Globe from "@/components/ui/icons/Globe";
+import ListChecks from "@/components/ui/icons/ListChecks";
+import ListNumbers from "@/components/ui/icons/ListNumbers";
+import MagnifyingGlass from "@/components/ui/icons/MagnifyingGlass";
+import Sparkle from "@/components/ui/icons/Sparkle";
+import StarFilled from "@/components/ui/icons/StarFilled";
+import Tag from "@/components/ui/icons/Tag";
+import User from "@/components/ui/icons/User";
+
+/* Lib */
+import useToastStore from "@/lib/store/toast.store";
+
+/* Styles */
+import styles from "./snippetAnalytics.module.css";
+
+type StatCardConfig = {
+	accentVar: string;
+	decimals?: number;
+	footnote?: string;
+	footnoteTone?: "down" | "muted" | "up";
+	icon: ReactElement;
+	label: string;
+	value: number;
+};
+
+const SnippetAnalytics = (): ReactElement => {
+	const { addToast } = useToastStore();
+	const [analytics, setAnalytics] = useState<SnippetAnalytics | null>(null);
+	const [status, setStatus] = useState<RequestStatus>(RequestStatus.Loading);
+	const [period, setPeriod] = useState<TrendPeriod>(TrendPeriod.Daily);
+
+	const loadAnalytics = useCallback(async (): Promise<void> => {
+		setStatus(RequestStatus.Loading);
+
+		try {
+			const response = await fetch(AdminApiPaths.analytics);
+
+			if (!response.ok) {
+				throw new Error("Failed to load analytics");
+			}
+
+			const data = (await response.json()) as SnippetAnalytics;
+
+			setAnalytics(data);
+			setStatus(RequestStatus.Ready);
+		} catch {
+			setStatus(RequestStatus.Error);
+			addToast({ message: "Could not load analytics", type: ToastType.Error });
+		}
+	}, [addToast]);
+
+	useEffect(() => {
+		loadAnalytics();
+	}, [loadAnalytics]);
+
+	if (status === RequestStatus.Loading) {
+		return <AnalyticsSkeleton />;
+	}
+
+	if (status === RequestStatus.Error || !analytics) {
+		return (
+			<Alert severity="error">
+				<div className={styles.errorRow}>
+					<span>Could not load analytics.</span>
+					<Button variant="secondary" onClick={loadAnalytics}>
+						Retry
+					</Button>
+				</div>
+			</Alert>
+		);
+	}
+
+	const cards: StatCardConfig[] = [
+		{
+			accentVar: "--purple-color",
+			footnote: `${analytics.publicCount} public`,
+			icon: <CodeBlock width={18} height={18} />,
+			label: "Total snippets",
+			value: analytics.totalSnippets,
+		},
+		{
+			accentVar: "--cyan-color",
+			footnote:
+				analytics.newUsersLast30Days > 0
+					? `+${analytics.newUsersLast30Days} in 30d`
+					: "No new signups",
+			footnoteTone: analytics.newUsersLast30Days > 0 ? "up" : "muted",
+			icon: <User width={18} height={18} />,
+			label: "Total users",
+			value: analytics.totalUsers,
+		},
+		{
+			accentVar: "--green-color",
+			footnote: "with snippets",
+			icon: <ListChecks width={18} height={18} />,
+			label: "Active users",
+			value: analytics.activeUsers,
+		},
+		{
+			accentVar: "--yellow-color",
+			icon: <StarFilled width={18} height={18} />,
+			label: "Favorites",
+			value: analytics.favoriteCount,
+		},
+		{
+			accentVar: "--blue-color",
+			icon: <Globe width={18} height={18} />,
+			label: "Public snippets",
+			value: analytics.publicCount,
+		},
+		{
+			accentVar: "--orange-color",
+			decimals: 1,
+			footnote: "snippets / user",
+			icon: <ListNumbers width={18} height={18} />,
+			label: "Average per user",
+			value: analytics.averagePerUser,
+		},
+		{
+			accentVar: "--purple-color",
+			footnote: `${analytics.uncategorizedCount} untagged`,
+			icon: <Tag width={18} height={18} />,
+			label: "Tags in use",
+			value: analytics.uniqueTagCount,
+		},
+		{
+			accentVar: "--cyan-color",
+			icon: <Folder width={18} height={18} />,
+			label: "Folders",
+			value: analytics.folderCount,
+		},
+		{
+			accentVar: "--green-color",
+			icon: <MagnifyingGlass width={18} height={18} />,
+			label: "Saved searches",
+			value: analytics.savedSearchCount,
+		},
+		{
+			accentVar: "--orange-color",
+			footnote: "total edits",
+			icon: <Floppy width={18} height={18} />,
+			label: "Snippet versions",
+			value: analytics.totalVersions,
+		},
+		{
+			accentVar: "--comment-color",
+			footnote: "last 30 days",
+			footnoteTone: analytics.newUsersLast30Days > 0 ? "up" : "muted",
+			icon: <Sparkle width={18} height={18} />,
+			label: "New users",
+			value: analytics.newUsersLast30Days,
+		},
+	];
+	const languageData: ChartDatum[] = analytics.languageDistribution.map(
+		(item) => ({ label: item.language, value: item.count })
+	);
+	const tagData: ChartDatum[] = analytics.tagDistribution.map((item) => ({
+		label: item.tag,
+		value: item.count,
+	}));
+	const trendByPeriod: Record<TrendPeriod, SnippetTrendPoint[]> = {
+		[TrendPeriod.Daily]: analytics.dailyTrend,
+		[TrendPeriod.Monthly]: analytics.monthlyTrend,
+		[TrendPeriod.Weekly]: analytics.weeklyTrend,
+	};
+	const topContributorMax = analytics.topContributors[0]?.count ?? 1;
+	const folderMax = analytics.folderDistribution[0]?.count ?? 1;
+	const savedSearchMax = analytics.savedSearches[0]?.count ?? 1;
+	const trendPeriods: { label: string; value: TrendPeriod }[] = [
+		{ label: "Daily", value: TrendPeriod.Daily },
+		{ label: "Weekly", value: TrendPeriod.Weekly },
+		{ label: "Monthly", value: TrendPeriod.Monthly },
+	];
+
+	return (
+		<div className={styles.container}>
+			<div className={styles.grid}>
+				{cards.map((card, index) => (
+					<StatCard
+						key={card.label}
+						accentVar={card.accentVar}
+						decimals={card.decimals ?? 0}
+						delayMs={index * 60}
+						icon={card.icon}
+						label={card.label}
+						value={card.value}
+						{...(card.footnote ? { footnote: card.footnote } : {})}
+						{...(card.footnoteTone ? { footnoteTone: card.footnoteTone } : {})}
+					/>
+				))}
+			</div>
+
+			<div className={styles.panelRow}>
+				<Card
+					title="Creation trend"
+					subtitle="Snippets created over time"
+					actions={
+						<div className={styles.toggle} role="tablist">
+							{trendPeriods.map((option) => (
+								<Button
+									key={option.value}
+									variant={period === option.value ? "primary" : "secondary"}
+									role="tab"
+									aria-selected={period === option.value}
+									onClick={() => setPeriod(option.value)}
+								>
+									{option.label}
+								</Button>
+							))}
+						</div>
+					}
+				>
+					{analytics.totalSnippets > 0 ? (
+						<AreaChart data={trendByPeriod[period]} />
+					) : (
+						<p className={styles.emptyNote}>No activity recorded yet.</p>
+					)}
+				</Card>
+
+				<Card
+					title="Language mix"
+					subtitle={`Top: ${analytics.mostUsedLanguage ?? "—"}`}
+				>
+					{languageData.length > 0 ? (
+						<DonutChart
+							data={languageData}
+							centerValue={String(languageData.length)}
+							centerLabel="languages"
+						/>
+					) : (
+						<p className={styles.emptyNote}>No languages yet.</p>
+					)}
+				</Card>
+			</div>
+
+			<div className={styles.panelRow}>
+				<Card title="Top languages" subtitle="Snippets per language">
+					{languageData.length > 0 ? (
+						<BarChart data={languageData} />
+					) : (
+						<p className={styles.emptyNote}>No languages yet.</p>
+					)}
+				</Card>
+
+				<Card title="Top contributors" subtitle="Most active users">
+					{analytics.topContributors.length > 0 ? (
+						<ul className={styles.rankList}>
+							{analytics.topContributors.map((contributor, index) => {
+								const accentVar = ChartPalette[index % ChartPalette.length];
+								const widthPercent =
+									(contributor.count / Math.max(1, topContributorMax)) * 100;
+
+								return (
+									<li className={styles.rankItem} key={contributor.userId}>
+										<span
+											className={styles.rankLabel}
+											title={contributor.email}
+										>
+											{contributor.email}
+										</span>
+										<span className={styles.rankTrack}>
+											<span
+												className={styles.rankBar}
+												style={{
+													background: `var(${accentVar ?? "--purple-color"})`,
+													width: `${widthPercent}%`,
+												}}
+											/>
+										</span>
+										<span className={styles.rankValue}>
+											{contributor.count}
+										</span>
+									</li>
+								);
+							})}
+						</ul>
+					) : (
+						<p className={styles.emptyNote}>No contributors yet.</p>
+					)}
+				</Card>
+			</div>
+
+			<div className={styles.panelRow}>
+				<Card title="Top folders" subtitle="Snippets per folder">
+					{analytics.folderDistribution.length > 0 ? (
+						<ul className={styles.rankList}>
+							{analytics.folderDistribution.map((entry, index) => {
+								const accentVar = ChartPalette[index % ChartPalette.length];
+								const widthPercent =
+									(entry.count / Math.max(1, folderMax)) * 100;
+
+								return (
+									<li className={styles.rankItem} key={entry.folder}>
+										<span className={styles.rankLabel} title={entry.folder}>
+											{entry.folder}
+										</span>
+										<span className={styles.rankTrack}>
+											<span
+												className={styles.rankBar}
+												style={{
+													background: `var(${accentVar ?? "--purple-color"})`,
+													width: `${widthPercent}%`,
+												}}
+											/>
+										</span>
+										<span className={styles.rankValue}>{entry.count}</span>
+									</li>
+								);
+							})}
+						</ul>
+					) : (
+						<p className={styles.emptyNote}>No folders yet.</p>
+					)}
+				</Card>
+
+				<Card title="Saved searches" subtitle="Popular smart groups">
+					{analytics.savedSearches.length > 0 ? (
+						<ul className={styles.rankList}>
+							{analytics.savedSearches.map((entry, index) => {
+								const accentVar = ChartPalette[index % ChartPalette.length];
+								const widthPercent =
+									(entry.count / Math.max(1, savedSearchMax)) * 100;
+
+								return (
+									<li className={styles.rankItem} key={entry.name}>
+										<span className={styles.rankLabel} title={entry.name}>
+											{entry.name}
+										</span>
+										<span className={styles.rankTrack}>
+											<span
+												className={styles.rankBar}
+												style={{
+													background: `var(${accentVar ?? "--purple-color"})`,
+													width: `${widthPercent}%`,
+												}}
+											/>
+										</span>
+										<span className={styles.rankValue}>{entry.count}</span>
+									</li>
+								);
+							})}
+						</ul>
+					) : (
+						<p className={styles.emptyNote}>No saved searches yet.</p>
+					)}
+				</Card>
+			</div>
+
+			<Card title="Top tags" subtitle="Most-used tags across snippets">
+				{tagData.length > 0 ? (
+					<BarChart data={tagData} />
+				) : (
+					<p className={styles.emptyNote}>No tags yet.</p>
+				)}
+			</Card>
+		</div>
+	);
+};
+
+export default SnippetAnalytics;

--- a/app/components/admin/SnippetAnalytics/snippetAnalytics.module.css
+++ b/app/components/admin/SnippetAnalytics/snippetAnalytics.module.css
@@ -1,0 +1,83 @@
+.container {
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+}
+
+.grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+	gap: 1rem;
+}
+
+.panelRow {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 1.25rem;
+}
+
+.toggle {
+	display: inline-flex;
+	gap: 0.375rem;
+}
+
+.emptyNote {
+	padding: 2rem 0;
+	font-size: var(--small-font-size);
+	color: var(--gray-color);
+	text-align: center;
+}
+
+.errorRow {
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+	flex-wrap: wrap;
+}
+
+.rankList {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
+.rankItem {
+	display: grid;
+	grid-template-columns: minmax(6rem, 1fr) 2fr auto;
+	align-items: center;
+	gap: 0.75rem;
+}
+
+.rankLabel {
+	overflow: hidden;
+	font-size: var(--small-font-size);
+	color: var(--foreground-color);
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.rankTrack {
+	height: 0.5rem;
+	border-radius: var(--border-radius-md);
+	background: var(--current-line);
+	overflow: hidden;
+}
+
+.rankBar {
+	display: block;
+	height: 100%;
+	border-radius: var(--border-radius-md);
+	transition: width var(--duration-slow) var(--ease-fluid);
+}
+
+.rankValue {
+	font-size: var(--small-font-size);
+	font-variant-numeric: tabular-nums;
+	color: var(--gray-color);
+}
+
+@media (width <= 768px) {
+	.panelRow {
+		grid-template-columns: 1fr;
+	}
+}

--- a/app/components/admin/StatCard/StatCard.tsx
+++ b/app/components/admin/StatCard/StatCard.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { CSSProperties, ReactElement } from "react";
+
+/* Components */
+import AnimatedCounter from "@/components/admin/AnimatedCounter/AnimatedCounter";
+import Card from "@/components/ui/Card/Card";
+
+/* Styles */
+import styles from "./statCard.module.css";
+
+type StatCardProps = {
+	accentVar?: string;
+	decimals?: number;
+	delayMs?: number;
+	footnote?: string;
+	footnoteTone?: "down" | "muted" | "up";
+	icon: ReactElement;
+	label: string;
+	value: number;
+};
+
+const StatCard = ({
+	accentVar = "--purple-color",
+	decimals = 0,
+	delayMs = 0,
+	footnote,
+	footnoteTone = "muted",
+	icon,
+	label,
+	value,
+}: StatCardProps): ReactElement => {
+	// Custom properties aren't part of the typed CSSProperties surface.
+	const cardStyle = {
+		"--stat-accent": `var(${accentVar})`,
+		animationDelay: `${delayMs}ms`,
+	} as CSSProperties;
+
+	return (
+		<Card className={styles.statCard} style={cardStyle}>
+			<div className={styles.head}>
+				<span className={styles.label}>{label}</span>
+				<span className={styles.icon}>{icon}</span>
+			</div>
+
+			<div className={styles.value}>
+				<AnimatedCounter value={value} decimals={decimals} />
+			</div>
+
+			{footnote && (
+				<div className={`${styles.footnote} ${styles[footnoteTone]}`}>
+					{footnote}
+				</div>
+			)}
+		</Card>
+	);
+};
+
+export default StatCard;

--- a/app/components/admin/StatCard/statCard.module.css
+++ b/app/components/admin/StatCard/statCard.module.css
@@ -1,0 +1,74 @@
+.statCard {
+	gap: 0.75rem;
+	opacity: 0;
+	transform: translateY(0.75rem);
+	animation: stat-card-in var(--duration-slow) var(--ease-fluid) forwards;
+	transition:
+		transform var(--duration-base) var(--ease-fluid),
+		border-color var(--duration-base) var(--ease-fluid);
+}
+
+.statCard:hover {
+	transform: translateY(-2px);
+	border-color: var(--stat-accent);
+}
+
+.head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 0.5rem;
+}
+
+.label {
+	font-size: var(--tiny-font-size);
+	font-weight: 700;
+	letter-spacing: 0.05rem;
+	text-transform: uppercase;
+	color: var(--gray-color);
+}
+
+.icon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border-radius: var(--border-radius-md);
+	color: var(--stat-accent);
+	background: color-mix(in srgb, var(--stat-accent) 14%, transparent);
+}
+
+.value {
+	font-size: var(--large-font-size);
+	font-weight: 700;
+	line-height: 1.05;
+	letter-spacing: -0.02em;
+	color: var(--foreground-color);
+	font-variant-numeric: tabular-nums;
+}
+
+.footnote {
+	font-size: var(--tiny-font-size);
+	font-weight: 500;
+	color: var(--gray-color);
+}
+
+.up {
+	color: var(--green-color);
+}
+
+.down {
+	color: var(--red-color);
+}
+
+.muted {
+	color: var(--gray-color);
+}
+
+@keyframes stat-card-in {
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}

--- a/app/components/admin/UserFormModal/UserFormModal.tsx
+++ b/app/components/admin/UserFormModal/UserFormModal.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { ReactElement, useEffect, useState } from "react";
+
+/* Constants */
+import { AdminFormMode } from "@/lib/constants/admin.constants";
+import { AppRole } from "@/lib/constants/roles";
+import { ThemeNames, themeList } from "@/lib/config/themes";
+
+/* Components */
+import Alert from "@/components/ui/Alert/Alert";
+import Button from "@/components/ui/Button/Button";
+import Input from "@/components/ui/Input/Input";
+import Modal from "@/components/ui/Modal/Modal";
+import Select from "@/components/ui/Select/Select";
+import Switch from "@/components/ui/Switch/Switch";
+import Envelope from "@/components/ui/icons/Envelope";
+import Lock from "@/components/ui/icons/Lock";
+import User from "@/components/ui/icons/User";
+
+/* Styles */
+import styles from "./userFormModal.module.css";
+
+type UserFormModalProps = {
+	errorMessage: string | null;
+	isOpen: boolean;
+	isSubmitting: boolean;
+	mode: AdminFormMode;
+	onClose: () => void;
+	onSubmit: (values: AdminUserFormValues) => void;
+	user: AdminUser | null;
+};
+
+const UserFormModal = ({
+	errorMessage,
+	isOpen,
+	isSubmitting,
+	mode,
+	onClose,
+	onSubmit,
+	user,
+}: UserFormModalProps): ReactElement => {
+	const isEdit = mode === AdminFormMode.Edit;
+	const [email, setEmail] = useState<string>("");
+	const [username, setUsername] = useState<string>("");
+	const [password, setPassword] = useState<string>("");
+	const [role, setRole] = useState<AppRole>(AppRole.User);
+	const [theme, setTheme] = useState<string>(ThemeNames.ShadesOfPurple);
+	const [isDisabled, setIsDisabled] = useState<boolean>(false);
+
+	useEffect(() => {
+		if (!isOpen) {
+			return;
+		}
+
+		setEmail(user?.email ?? "");
+		setUsername(user?.username ?? "");
+		setPassword("");
+		setRole(user?.role ?? AppRole.User);
+		setTheme(user?.theme ?? ThemeNames.ShadesOfPurple);
+		setIsDisabled(user?.isDisabled ?? false);
+	}, [isOpen, user]);
+
+	const roleOptions: { label: string; value: AppRole }[] = [
+		{ label: "Admin", value: AppRole.Admin },
+		{ label: "User", value: AppRole.User },
+	];
+	const roleLabel =
+		roleOptions.find((option) => option.value === role)?.label ?? "User";
+	const themeLabel =
+		themeList.find((option) => option.name === theme)?.label ?? theme;
+
+	const handleRoleSelect = (label: string): void => {
+		const match = roleOptions.find((option) => option.label === label);
+
+		setRole(match?.value ?? AppRole.User);
+	};
+
+	const handleThemeSelect = (label: string): void => {
+		const match = themeList.find((option) => option.label === label);
+
+		setTheme(match?.name ?? ThemeNames.ShadesOfPurple);
+	};
+
+	const handleSubmit = (): void => {
+		onSubmit({ email, isDisabled, password, role, theme, username });
+	};
+
+	return (
+		<Modal
+			isOpen={isOpen}
+			onClose={onClose}
+			title={isEdit ? "Edit user" : "Create user"}
+			className={styles.userModal}
+		>
+			<div className={styles.container}>
+				<div className={styles.form}>
+					<div className={styles.section}>
+						<h3 className={styles.sectionTitle}>User information</h3>
+
+						<div className={styles.inputGroup}>
+							<span className={styles.label}>Email</span>
+							<Input
+								type="email"
+								value={email}
+								maxLength={120}
+								placeholder="name@example.com"
+								fat
+								disableMargin
+								Icon={<Envelope width={16} height={16} />}
+								className={styles.input}
+								onChange={(event) => setEmail(event.target.value)}
+							/>
+						</div>
+
+						<div className={styles.inputGroup}>
+							<span className={styles.label}>Username</span>
+							<Input
+								type="text"
+								value={username}
+								maxLength={60}
+								placeholder="Display name"
+								fat
+								disableMargin
+								Icon={<User width={16} height={16} />}
+								className={styles.input}
+								onChange={(event) => setUsername(event.target.value)}
+							/>
+						</div>
+
+						{!isEdit && (
+							<div className={styles.inputGroup}>
+								<span className={styles.label}>Password</span>
+								<Input
+									type="password"
+									value={password}
+									maxLength={72}
+									placeholder="Temporary password"
+									fat
+									disableMargin
+									Icon={<Lock width={16} height={16} />}
+									className={styles.input}
+									onChange={(event) => setPassword(event.target.value)}
+								/>
+							</div>
+						)}
+					</div>
+
+					<div className={styles.section}>
+						<h3 className={styles.sectionTitle}>Role &amp; theme</h3>
+
+						<div className={styles.row}>
+							<div className={styles.inputGroup}>
+								<span className={styles.label}>Role</span>
+								<Select
+									value={roleLabel}
+									items={roleOptions.map((option) => option.label)}
+									onSelect={handleRoleSelect}
+								/>
+							</div>
+
+							<div className={styles.inputGroup}>
+								<span className={styles.label}>Theme</span>
+								<Select
+									value={themeLabel}
+									items={themeList.map((option) => option.label)}
+									onSelect={handleThemeSelect}
+								/>
+							</div>
+						</div>
+					</div>
+
+					{isEdit && (
+						<div className={styles.section}>
+							<h3 className={styles.sectionTitle}>Status</h3>
+							<Switch
+								checked={!isDisabled}
+								label="Account enabled"
+								description="Disabled users cannot sign in."
+								onChange={(checked) => setIsDisabled(!checked)}
+							/>
+						</div>
+					)}
+
+					{errorMessage && (
+						<Alert severity="error" className={styles.alert}>
+							{errorMessage}
+						</Alert>
+					)}
+
+					<div className={styles.buttonContainer}>
+						<Button variant="secondary" onClick={onClose}>
+							Cancel
+						</Button>
+						<Button
+							variant="secondary"
+							onClick={handleSubmit}
+							disabled={isSubmitting}
+						>
+							{isSubmitting
+								? "Saving…"
+								: isEdit
+									? "Save changes"
+									: "Create user"}
+						</Button>
+					</div>
+				</div>
+			</div>
+		</Modal>
+	);
+};
+
+export default UserFormModal;

--- a/app/components/admin/UserFormModal/userFormModal.module.css
+++ b/app/components/admin/UserFormModal/userFormModal.module.css
@@ -1,0 +1,89 @@
+/* Mirrors the Account Settings modal design pattern. */
+.userModal {
+	--modal-max-width: 560px;
+	--modal-max-height: none;
+
+	width: 100%;
+}
+
+.container {
+	display: flex;
+	flex-direction: column;
+	gap: 1.5rem;
+}
+
+.form {
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+}
+
+.section {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	padding: 1.25rem;
+	background: var(--bg-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-lg);
+}
+
+.sectionTitle {
+	margin: 0;
+	font-size: var(--tiny-font-size);
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--purple-color);
+}
+
+.inputGroup {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.label {
+	margin-bottom: 0.5rem;
+	font-size: var(--small-font-size);
+	color: var(--green-color);
+}
+
+.input {
+	color: var(--gray-color);
+}
+
+.row {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 1rem;
+}
+
+.alert {
+	margin: 0;
+}
+
+.buttonContainer {
+	position: sticky;
+	bottom: -1.5rem;
+	z-index: 2;
+	display: flex;
+	gap: 0.75rem;
+	justify-content: flex-end;
+	margin: 0 -1.5rem -1.5rem;
+	padding: 1rem 1.5rem;
+	background: color-mix(in srgb, var(--bg-color-dark) 86%, transparent);
+	backdrop-filter: blur(8px);
+	border-top: 1px solid var(--border-color);
+}
+
+.buttonContainer button {
+	min-width: 7.5rem;
+	padding: 0.75rem 1.25rem;
+}
+
+@media (width <= 576px) {
+	.row {
+		grid-template-columns: 1fr;
+	}
+}

--- a/app/components/admin/UserManagement/UserManagement.tsx
+++ b/app/components/admin/UserManagement/UserManagement.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import { ReactElement, useCallback, useEffect, useState } from "react";
+
+/* Constants */
+import {
+	AdminApiPaths,
+	AdminFormMode,
+	AdminUserFilter,
+	JsonHeaders,
+	RequestStatus,
+} from "@/lib/constants/admin.constants";
+import { AppRole } from "@/lib/constants/roles";
+import { ToastType } from "@/lib/constants/toast";
+
+/* Components */
+import UserFormModal from "@/components/admin/UserFormModal/UserFormModal";
+import UsersTable from "@/components/admin/UsersTable/UsersTable";
+import Alert from "@/components/ui/Alert/Alert";
+import Button from "@/components/ui/Button/Button";
+import EmptyState from "@/components/ui/EmptyState/EmptyState";
+import Input from "@/components/ui/Input/Input";
+import Modal from "@/components/ui/Modal/Modal";
+import Select from "@/components/ui/Select/Select";
+import Skeleton from "@/components/ui/Skeleton/Skeleton";
+import MagnifyingGlass from "@/components/ui/icons/MagnifyingGlass";
+import Plus from "@/components/ui/icons/Plus";
+
+/* Lib */
+import useToastStore from "@/lib/store/toast.store";
+
+/* Styles */
+import styles from "./userManagement.module.css";
+
+type UserManagementProps = {
+	isReadOnly: boolean;
+};
+
+const UserManagement = ({ isReadOnly }: UserManagementProps): ReactElement => {
+	const { addToast } = useToastStore();
+	const [users, setUsers] = useState<AdminUser[]>([]);
+	const [status, setStatus] = useState<RequestStatus>(RequestStatus.Loading);
+	const [search, setSearch] = useState<string>("");
+	const [filter, setFilter] = useState<AdminUserFilter>(AdminUserFilter.All);
+	const [busyUserId, setBusyUserId] = useState<string | null>(null);
+	const [resetLink, setResetLink] = useState<string | null>(null);
+	const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+	const [formMode, setFormMode] = useState<AdminFormMode>(AdminFormMode.Create);
+	const [editingUser, setEditingUser] = useState<AdminUser | null>(null);
+	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+	const [formError, setFormError] = useState<string | null>(null);
+	const [confirmUser, setConfirmUser] = useState<AdminUser | null>(null);
+
+	const loadUsers = useCallback(async (): Promise<void> => {
+		setStatus(RequestStatus.Loading);
+
+		try {
+			const response = await fetch(AdminApiPaths.users);
+
+			if (!response.ok) {
+				throw new Error("Failed to load users");
+			}
+
+			const data = (await response.json()) as AdminUsersResponse;
+
+			setUsers(data.users);
+			setStatus(RequestStatus.Ready);
+		} catch {
+			setStatus(RequestStatus.Error);
+			addToast({ message: "Could not load users", type: ToastType.Error });
+		}
+	}, [addToast]);
+
+	useEffect(() => {
+		loadUsers();
+	}, [loadUsers]);
+
+	const filterOptions: { label: string; value: AdminUserFilter }[] = [
+		{ label: "All users", value: AdminUserFilter.All },
+		{ label: "Admins", value: AdminUserFilter.Admins },
+		{ label: "Users", value: AdminUserFilter.Users },
+		{ label: "Disabled", value: AdminUserFilter.Disabled },
+	];
+	const filterLabel =
+		filterOptions.find((option) => option.value === filter)?.label ??
+		"All users";
+	const normalizedSearch = search.trim().toLowerCase();
+	const filteredUsers = users.filter((user) => {
+		const matchesSearch =
+			normalizedSearch.length === 0 ||
+			user.email.toLowerCase().includes(normalizedSearch) ||
+			user.username.toLowerCase().includes(normalizedSearch);
+		const matchesFilter =
+			filter === AdminUserFilter.All ||
+			(filter === AdminUserFilter.Admins && user.role === AppRole.Admin) ||
+			(filter === AdminUserFilter.Users && user.role === AppRole.User) ||
+			(filter === AdminUserFilter.Disabled && user.isDisabled);
+
+		return matchesSearch && matchesFilter;
+	});
+
+	const applyMutation = async (
+		response: Response,
+		successMessage: string
+	): Promise<void> => {
+		// Error responses are shaped as { error }.
+		const body = (await response.json().catch(() => ({}))) as {
+			error?: string;
+		};
+
+		if (!response.ok) {
+			addToast({
+				message: body.error ?? "Action failed",
+				type: ToastType.Error,
+			});
+
+			return;
+		}
+
+		addToast({ message: successMessage, type: ToastType.Success });
+		await loadUsers();
+	};
+
+	const handleFilterSelect = (label: string): void => {
+		const match = filterOptions.find((option) => option.label === label);
+
+		setFilter(match?.value ?? AdminUserFilter.All);
+	};
+
+	const openCreate = (): void => {
+		setFormMode(AdminFormMode.Create);
+		setEditingUser(null);
+		setFormError(null);
+		setIsModalOpen(true);
+	};
+
+	const openEdit = (user: AdminUser): void => {
+		setFormMode(AdminFormMode.Edit);
+		setEditingUser(user);
+		setFormError(null);
+		setIsModalOpen(true);
+	};
+
+	const handleSave = async (values: AdminUserFormValues): Promise<void> => {
+		setIsSubmitting(true);
+		setFormError(null);
+
+		const isEdit = formMode === AdminFormMode.Edit && editingUser !== null;
+		const url = isEdit
+			? `${AdminApiPaths.users}/${editingUser?.id}`
+			: AdminApiPaths.users;
+		const payload = isEdit
+			? {
+					email: values.email,
+					isDisabled: values.isDisabled,
+					role: values.role,
+					theme: values.theme,
+					username: values.username,
+				}
+			: {
+					email: values.email,
+					password: values.password,
+					role: values.role,
+					theme: values.theme,
+					username: values.username,
+				};
+		const response = await fetch(url, {
+			body: JSON.stringify(payload),
+			headers: JsonHeaders,
+			method: isEdit ? "PATCH" : "POST",
+		});
+		const body = (await response.json().catch(() => ({}))) as {
+			error?: string;
+		};
+
+		setIsSubmitting(false);
+
+		if (!response.ok) {
+			const message = body.error ?? "Could not save user";
+
+			setFormError(message);
+			addToast({ message, type: ToastType.Error });
+
+			return;
+		}
+
+		setIsModalOpen(false);
+		addToast({
+			message: isEdit ? "User updated" : "User created",
+			type: ToastType.Success,
+		});
+		await loadUsers();
+	};
+
+	const handleToggleDisabled = async (user: AdminUser): Promise<void> => {
+		setBusyUserId(user.id);
+
+		const response = await fetch(`${AdminApiPaths.users}/${user.id}`, {
+			body: JSON.stringify({ isDisabled: !user.isDisabled }),
+			headers: JsonHeaders,
+			method: "PATCH",
+		});
+
+		await applyMutation(
+			response,
+			user.isDisabled ? "User enabled" : "User disabled"
+		);
+		setBusyUserId(null);
+	};
+
+	const handleResetPassword = async (user: AdminUser): Promise<void> => {
+		setBusyUserId(user.id);
+		setResetLink(null);
+
+		const response = await fetch(`${AdminApiPaths.users}/${user.id}/password`, {
+			body: JSON.stringify({}),
+			headers: JsonHeaders,
+			method: "POST",
+		});
+		const body = (await response.json().catch(() => ({}))) as {
+			actionLink?: string;
+			error?: string;
+		};
+
+		if (!response.ok) {
+			addToast({
+				message: body.error ?? "Could not reset password",
+				type: ToastType.Error,
+			});
+		} else {
+			addToast({
+				message: `Recovery link generated for ${user.email}`,
+				type: ToastType.Success,
+			});
+			setResetLink(body.actionLink ?? null);
+		}
+
+		setBusyUserId(null);
+	};
+
+	const handleConfirmDelete = async (): Promise<void> => {
+		if (!confirmUser) {
+			return;
+		}
+
+		const target = confirmUser;
+
+		setConfirmUser(null);
+		setBusyUserId(target.id);
+
+		const response = await fetch(`${AdminApiPaths.users}/${target.id}`, {
+			method: "DELETE",
+		});
+
+		await applyMutation(response, `${target.email} deleted`);
+		setBusyUserId(null);
+	};
+
+	const handleDisconnect = async (user: AdminUser): Promise<void> => {
+		setBusyUserId(user.id);
+
+		const response = await fetch(
+			`${AdminApiPaths.users}/${user.id}/disconnect`,
+			{ method: "POST" }
+		);
+		const body = (await response.json().catch(() => ({}))) as {
+			error?: string;
+		};
+
+		if (!response.ok) {
+			addToast({
+				message: body.error ?? "Could not disconnect user",
+				type: ToastType.Error,
+			});
+		} else {
+			addToast({
+				message: `${user.email} has been signed out`,
+				type: ToastType.Success,
+			});
+		}
+
+		setBusyUserId(null);
+	};
+
+	return (
+		<div className={styles.container}>
+			{isReadOnly && (
+				<Alert severity="warning">
+					You are signed in as the demo administrator. The user directory is
+					read-only — create, edit, and delete are disabled.
+				</Alert>
+			)}
+
+			{resetLink && (
+				<Alert severity="info">
+					<div className={styles.notice}>
+						<span>Recovery link generated.</span>
+						<a
+							className={styles.resetLink}
+							href={resetLink}
+							target="_blank"
+							rel="noreferrer"
+						>
+							Open recovery link
+						</a>
+					</div>
+				</Alert>
+			)}
+
+			<div className={styles.toolbar}>
+				<div className={styles.search}>
+					<Input
+						type="text"
+						value={search}
+						placeholder="Search by email or name"
+						maxLength={80}
+						disableMargin
+						Icon={<MagnifyingGlass width={16} height={16} />}
+						onChange={(event) => setSearch(event.target.value)}
+					/>
+				</div>
+
+				<div className={styles.filter}>
+					<Select
+						value={filterLabel}
+						items={filterOptions.map((option) => option.label)}
+						onSelect={handleFilterSelect}
+					/>
+				</div>
+
+				<Button
+					className={styles.iconButton}
+					variant="secondary"
+					shape="pill"
+					onClick={openCreate}
+					disabled={isReadOnly}
+				>
+					<Plus width={16} height={16} /> New user
+				</Button>
+			</div>
+
+			{status === RequestStatus.Loading && (
+				<div className={styles.skeletons}>
+					{Array.from({ length: 5 }, (_, index) => (
+						<Skeleton key={index} height="3.25rem" />
+					))}
+				</div>
+			)}
+
+			{status === RequestStatus.Error && (
+				<Alert severity="error">
+					<div className={styles.notice}>
+						<span>Could not load users.</span>
+						<Button variant="secondary" onClick={loadUsers}>
+							Retry
+						</Button>
+					</div>
+				</Alert>
+			)}
+
+			{status === RequestStatus.Ready &&
+				(filteredUsers.length > 0 ? (
+					<UsersTable
+						busyUserId={busyUserId}
+						isReadOnly={isReadOnly}
+						users={filteredUsers}
+						onDelete={(user) => setConfirmUser(user)}
+						onDisconnect={handleDisconnect}
+						onEdit={openEdit}
+						onResetPassword={handleResetPassword}
+						onToggleDisabled={handleToggleDisabled}
+					/>
+				) : (
+					<EmptyState
+						illustration="search"
+						title="No users found"
+						description="Try a different search or filter."
+					/>
+				))}
+
+			<UserFormModal
+				errorMessage={formError}
+				isOpen={isModalOpen}
+				isSubmitting={isSubmitting}
+				mode={formMode}
+				user={editingUser}
+				onClose={() => setIsModalOpen(false)}
+				onSubmit={handleSave}
+			/>
+
+			<Modal
+				isOpen={confirmUser !== null}
+				onClose={() => setConfirmUser(null)}
+				title="Delete user"
+				className={styles.confirmModal}
+			>
+				<div className={styles.confirm}>
+					<p className={styles.confirmText}>
+						Permanently delete <strong>{confirmUser?.email}</strong> and all
+						their snippets? This action cannot be undone.
+					</p>
+					<div className={styles.buttonContainer}>
+						<Button variant="secondary" onClick={() => setConfirmUser(null)}>
+							Cancel
+						</Button>
+						<Button variant="secondary" onClick={handleConfirmDelete}>
+							Delete user
+						</Button>
+					</div>
+				</div>
+			</Modal>
+		</div>
+	);
+};
+
+export default UserManagement;

--- a/app/components/admin/UserManagement/userManagement.module.css
+++ b/app/components/admin/UserManagement/userManagement.module.css
@@ -1,0 +1,86 @@
+.container {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.toolbar {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	flex-wrap: wrap;
+}
+
+.iconButton {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+}
+
+.search {
+	flex: 1 1 16rem;
+	min-width: 12rem;
+}
+
+.filter {
+	flex: 0 0 auto;
+	min-width: 9rem;
+}
+
+.skeletons {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.notice {
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+	flex-wrap: wrap;
+}
+
+.resetLink {
+	color: var(--cyan-color);
+	text-decoration: underline;
+	font-size: var(--small-font-size);
+	word-break: break-all;
+}
+
+.confirmModal {
+	--modal-max-width: 460px;
+	--modal-max-height: none;
+
+	width: 100%;
+}
+
+.confirm {
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+}
+
+.confirmText {
+	font-size: var(--small-font-size);
+	line-height: 1.5;
+	color: var(--foreground-color);
+}
+
+.buttonContainer {
+	position: sticky;
+	bottom: -1.5rem;
+	z-index: 2;
+	display: flex;
+	gap: 0.75rem;
+	justify-content: flex-end;
+	margin: 0 -1.5rem -1.5rem;
+	padding: 1rem 1.5rem;
+	background: color-mix(in srgb, var(--bg-color-dark) 86%, transparent);
+	backdrop-filter: blur(8px);
+	border-top: 1px solid var(--border-color);
+}
+
+.buttonContainer button {
+	min-width: 7.5rem;
+	padding: 0.75rem 1.25rem;
+}

--- a/app/components/admin/UsersTable/UsersTable.tsx
+++ b/app/components/admin/UsersTable/UsersTable.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { ReactElement } from "react";
+
+/* Constants */
+import { AppRole } from "@/lib/constants/roles";
+
+/* Components */
+import Menu from "@/components/ui/Menu/Menu";
+import Table from "@/components/ui/Table/Table";
+import EyeClosed from "@/components/ui/icons/EyeClosed";
+import EyeOpen from "@/components/ui/icons/EyeOpen";
+import Lock from "@/components/ui/icons/Lock";
+import Settings from "@/components/ui/icons/Settings";
+import SignOut from "@/components/ui/icons/SignOut";
+import Trash from "@/components/ui/icons/Trash";
+
+/* Styles */
+import styles from "./usersTable.module.css";
+
+type UsersTableProps = {
+	busyUserId: string | null;
+	isReadOnly: boolean;
+	onDelete: (user: AdminUser) => void;
+	onDisconnect: (user: AdminUser) => void;
+	onEdit: (user: AdminUser) => void;
+	onResetPassword: (user: AdminUser) => void;
+	onToggleDisabled: (user: AdminUser) => void;
+	users: AdminUser[];
+};
+
+const UsersTable = ({
+	busyUserId,
+	isReadOnly,
+	onDelete,
+	onDisconnect,
+	onEdit,
+	onResetPassword,
+	onToggleDisabled,
+	users,
+}: UsersTableProps): ReactElement => {
+	const columns: TableColumn[] = [
+		{ label: "User" },
+		{ label: "Role" },
+		{ label: "Status" },
+		{ label: "Theme" },
+		{ label: "Created" },
+		{ label: "Last sign-in" },
+		{ align: "right", label: "Actions" },
+	];
+	const formatDate = (value: string | null): string => {
+		if (!value) {
+			return "Never";
+		}
+
+		return new Date(value).toLocaleDateString("en-US", {
+			day: "numeric",
+			month: "short",
+			year: "numeric",
+		});
+	};
+
+	return (
+		<Table columns={columns}>
+			{users.map((user) => {
+				const locked = isReadOnly || user.isDemo;
+				const isBusy = busyUserId === user.id;
+				const isAdminUser = user.role === AppRole.Admin;
+				const cannotDisable = isAdminUser && !user.isDisabled;
+				const menuItems: MenuItem[] = [
+					{
+						disabled: isBusy,
+						icon: <Settings width={16} height={16} />,
+						label: "Edit user",
+						onSelect: () => onEdit(user),
+					},
+					{
+						disabled: isBusy || cannotDisable,
+						icon: user.isDisabled ? (
+							<EyeOpen width={16} height={16} />
+						) : (
+							<EyeClosed width={16} height={16} />
+						),
+						label: cannotDisable
+							? "Admins can't be disabled"
+							: user.isDisabled
+								? "Enable user"
+								: "Disable user",
+						onSelect: () => onToggleDisabled(user),
+					},
+					{
+						disabled: isBusy,
+						icon: <SignOut width={16} height={16} />,
+						label: "Force sign-out",
+						onSelect: () => onDisconnect(user),
+					},
+					{
+						disabled: isBusy,
+						icon: <Lock width={16} height={16} />,
+						label: "Reset password",
+						onSelect: () => onResetPassword(user),
+					},
+					{
+						danger: true,
+						disabled: isBusy || isAdminUser,
+						icon: <Trash width={16} height={16} />,
+						label: isAdminUser ? "Admins can't be deleted" : "Delete user",
+						onSelect: () => onDelete(user),
+					},
+				];
+
+				return (
+					<tr key={user.id} className={user.isDemo ? styles.demoRow : ""}>
+						<td>
+							<div className={styles.userCell}>
+								<span className={styles.userName}>{user.username}</span>
+								<span className={styles.userEmail}>{user.email}</span>
+							</div>
+						</td>
+						<td>
+							<span
+								className={`${styles.badge} ${user.role === AppRole.Admin ? styles.badgeAdmin : styles.badgeUser}`}
+							>
+								{user.role === AppRole.Admin ? "Admin" : "User"}
+							</span>
+						</td>
+						<td>
+							<span
+								className={`${styles.badge} ${user.isDisabled ? styles.badgeDisabled : styles.badgeActive}`}
+							>
+								{user.isDisabled ? "Disabled" : "Active"}
+							</span>
+						</td>
+						<td>
+							<span className={styles.theme}>{user.theme}</span>
+						</td>
+						<td className={styles.muted}>{formatDate(user.createdAt)}</td>
+						<td className={styles.muted}>{formatDate(user.lastSignInAt)}</td>
+						<td className={styles.actionsCell}>
+							{locked ? (
+								<span className={styles.lockNote}>
+									<Lock width={14} height={14} /> Read-only
+								</span>
+							) : (
+								<Menu items={menuItems} ariaLabel="User actions" />
+							)}
+						</td>
+					</tr>
+				);
+			})}
+		</Table>
+	);
+};
+
+export default UsersTable;

--- a/app/components/admin/UsersTable/usersTable.module.css
+++ b/app/components/admin/UsersTable/usersTable.module.css
@@ -1,0 +1,81 @@
+.demoRow {
+	background: color-mix(in srgb, var(--yellow-color) 7%, transparent);
+}
+
+.userCell {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+}
+
+.userName {
+	font-weight: 600;
+	color: var(--foreground-color);
+}
+
+.userEmail {
+	font-size: var(--tiny-font-size);
+	color: var(--gray-color);
+}
+
+.badge {
+	display: inline-flex;
+	align-items: center;
+	padding: 0.188rem 0.5rem;
+	border-radius: var(--border-radius-pill, 999px);
+	font-size: var(--tiny-font-size);
+	font-weight: 600;
+	text-transform: capitalize;
+}
+
+.badgeAdmin {
+	color: var(--purple-color);
+	background: color-mix(in srgb, var(--purple-color) 16%, transparent);
+}
+
+.badgeUser {
+	color: var(--gray-color);
+	background: color-mix(in srgb, var(--gray-color) 16%, transparent);
+}
+
+.badgeActive {
+	color: var(--green-color);
+	background: color-mix(in srgb, var(--green-color) 16%, transparent);
+}
+
+.badgeDisabled {
+	color: var(--red-color);
+	background: color-mix(in srgb, var(--red-color) 16%, transparent);
+}
+
+.theme {
+	font-size: var(--tiny-font-size);
+	color: var(--cyan-color);
+}
+
+.muted {
+	color: var(--gray-color);
+	white-space: nowrap;
+}
+
+.actionsCell {
+	text-align: right;
+}
+
+.actions {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 0.375rem;
+	flex-wrap: wrap;
+}
+
+.lockNote {
+	display: inline-flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 0.375rem;
+	width: 100%;
+	font-size: var(--tiny-font-size);
+	color: var(--gray-color);
+}

--- a/app/components/admin/charts/AreaChart/AreaChart.tsx
+++ b/app/components/admin/charts/AreaChart/AreaChart.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { ReactElement } from "react";
+
+/* Styles */
+import styles from "./areaChart.module.css";
+
+type AreaChartProps = {
+	accentVar?: string;
+	data: SnippetTrendPoint[];
+};
+
+const AreaChart = ({
+	accentVar = "--cyan-color",
+	data,
+}: AreaChartProps): ReactElement => {
+	const viewWidth = 600;
+	const viewHeight = 200;
+	const verticalPadding = 12;
+	const max = Math.max(1, ...data.map((point) => point.count));
+	const stepX = data.length > 1 ? viewWidth / (data.length - 1) : viewWidth;
+	const points = data.map((point, index) => {
+		const usableHeight = viewHeight - verticalPadding * 2;
+		const x = index * stepX;
+		const y = viewHeight - verticalPadding - (point.count / max) * usableHeight;
+
+		return { x, y };
+	});
+	const linePath = points
+		.map(
+			(point, index) =>
+				`${index === 0 ? "M" : "L"} ${point.x.toFixed(1)} ${point.y.toFixed(1)}`
+		)
+		.join(" ");
+	const areaPath = points.length
+		? `${linePath} L ${viewWidth} ${viewHeight} L 0 ${viewHeight} Z`
+		: "";
+	const labelStep = Math.max(1, Math.ceil(data.length / 6));
+	const isVisibleLabel = (index: number): boolean =>
+		index === 0 || index === data.length - 1 || index % labelStep === 0;
+
+	return (
+		<div className={styles.chart}>
+			<svg
+				className={styles.svg}
+				viewBox={`0 0 ${viewWidth} ${viewHeight}`}
+				preserveAspectRatio="none"
+				role="img"
+				aria-label="Snippet creation trend"
+			>
+				<defs>
+					<linearGradient id="areaChartFill" x1="0" y1="0" x2="0" y2="1">
+						<stop
+							offset="0%"
+							stopColor={`var(${accentVar})`}
+							stopOpacity="0.32"
+						/>
+						<stop
+							offset="100%"
+							stopColor={`var(${accentVar})`}
+							stopOpacity="0"
+						/>
+					</linearGradient>
+				</defs>
+
+				<path className={styles.area} d={areaPath} fill="url(#areaChartFill)" />
+
+				<path
+					className={styles.line}
+					d={linePath}
+					fill="none"
+					stroke={`var(${accentVar})`}
+					strokeWidth="2.5"
+					strokeLinejoin="round"
+					strokeLinecap="round"
+					vectorEffect="non-scaling-stroke"
+					pathLength={1}
+				/>
+			</svg>
+
+			<div className={styles.axis}>
+				{data.map((point, index) => (
+					<span className={styles.axisLabel} key={`${point.label}-${index}`}>
+						{isVisibleLabel(index) ? point.label : ""}
+					</span>
+				))}
+			</div>
+		</div>
+	);
+};
+
+export default AreaChart;

--- a/app/components/admin/charts/AreaChart/areaChart.module.css
+++ b/app/components/admin/charts/AreaChart/areaChart.module.css
@@ -1,0 +1,50 @@
+.chart {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	width: 100%;
+}
+
+.svg {
+	width: 100%;
+	height: 200px;
+	overflow: visible;
+}
+
+.line {
+	stroke-dasharray: 1;
+	stroke-dashoffset: 1;
+	animation: area-line-draw var(--duration-slow) var(--ease-fluid) forwards;
+}
+
+.area {
+	opacity: 0;
+	animation: area-fade-in var(--duration-slow) var(--ease-fluid) 120ms forwards;
+}
+
+.axis {
+	display: flex;
+	width: 100%;
+}
+
+.axisLabel {
+	flex: 1 1 0;
+	min-width: 0;
+	overflow: hidden;
+	font-size: var(--tiny-font-size);
+	color: var(--gray-color);
+	text-align: center;
+	white-space: nowrap;
+}
+
+@keyframes area-line-draw {
+	to {
+		stroke-dashoffset: 0;
+	}
+}
+
+@keyframes area-fade-in {
+	to {
+		opacity: 1;
+	}
+}

--- a/app/components/admin/charts/BarChart/BarChart.tsx
+++ b/app/components/admin/charts/BarChart/BarChart.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ReactElement, useEffect, useState } from "react";
+
+/* Constants */
+import { ChartPalette } from "@/lib/constants/admin.constants";
+
+/* Styles */
+import styles from "./barChart.module.css";
+
+type BarChartProps = {
+	data: ChartDatum[];
+};
+
+const BarChart = ({ data }: BarChartProps): ReactElement => {
+	const [mounted, setMounted] = useState<boolean>(false);
+	const max = Math.max(1, ...data.map((datum) => datum.value));
+
+	useEffect(() => {
+		const frame = requestAnimationFrame(() => setMounted(true));
+
+		return () => cancelAnimationFrame(frame);
+	}, []);
+
+	return (
+		<div className={styles.chart}>
+			{data.map((datum, index) => {
+				const accentVar = ChartPalette[index % ChartPalette.length];
+				const accent = datum.color ?? `var(${accentVar ?? "--purple-color"})`;
+				const heightPercent = mounted ? (datum.value / max) * 100 : 0;
+
+				return (
+					<div className={styles.column} key={datum.label}>
+						<div className={styles.track}>
+							<span className={styles.value}>{datum.value}</span>
+							<div
+								className={styles.bar}
+								style={{ background: accent, height: `${heightPercent}%` }}
+								title={`${datum.label}: ${datum.value}`}
+							/>
+						</div>
+						<span className={styles.label} title={datum.label}>
+							{datum.label}
+						</span>
+					</div>
+				);
+			})}
+		</div>
+	);
+};
+
+export default BarChart;

--- a/app/components/admin/charts/BarChart/barChart.module.css
+++ b/app/components/admin/charts/BarChart/barChart.module.css
@@ -1,0 +1,52 @@
+.chart {
+	display: flex;
+	align-items: flex-end;
+	gap: 0.5rem;
+	width: 100%;
+	height: 220px;
+	padding-top: 1rem;
+}
+
+.column {
+	display: flex;
+	flex: 1 1 0;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.5rem;
+	min-width: 0;
+	height: 100%;
+}
+
+.track {
+	position: relative;
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	justify-content: flex-end;
+	align-items: center;
+	width: 100%;
+}
+
+.bar {
+	width: 70%;
+	max-width: 2.5rem;
+	min-height: 2px;
+	border-radius: var(--border-radius) var(--border-radius) 0 0;
+	transition: height var(--duration-slow) var(--ease-spring);
+}
+
+.value {
+	font-size: var(--tiny-font-size);
+	font-variant-numeric: tabular-nums;
+	color: var(--gray-color);
+	margin-bottom: 0.25rem;
+}
+
+.label {
+	max-width: 100%;
+	overflow: hidden;
+	font-size: var(--tiny-font-size);
+	color: var(--gray-color);
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}

--- a/app/components/admin/charts/DonutChart/DonutChart.tsx
+++ b/app/components/admin/charts/DonutChart/DonutChart.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { ReactElement, useEffect, useState } from "react";
+
+/* Constants */
+import { ChartPalette } from "@/lib/constants/admin.constants";
+
+/* Styles */
+import styles from "./donutChart.module.css";
+
+type DonutChartProps = {
+	centerLabel?: string;
+	centerValue?: string;
+	data: ChartDatum[];
+};
+
+const DonutChart = ({
+	centerLabel,
+	centerValue,
+	data,
+}: DonutChartProps): ReactElement => {
+	const [mounted, setMounted] = useState<boolean>(false);
+	const radius = 60;
+	const strokeWidth = 22;
+	const circumference = 2 * Math.PI * radius;
+	const total = Math.max(
+		1,
+		data.reduce((sum, datum) => sum + datum.value, 0)
+	);
+	const segments = data.map((datum, index) => {
+		const accentVar = ChartPalette[index % ChartPalette.length];
+		const priorTotal = data
+			.slice(0, index)
+			.reduce((sum, prior) => sum + prior.value, 0);
+
+		return {
+			color: datum.color ?? `var(${accentVar ?? "--purple-color"})`,
+			fraction: datum.value / total,
+			label: datum.label,
+			priorFraction: priorTotal / total,
+			value: datum.value,
+		};
+	});
+
+	useEffect(() => {
+		const frame = requestAnimationFrame(() => setMounted(true));
+
+		return () => cancelAnimationFrame(frame);
+	}, []);
+
+	return (
+		<div className={styles.donut}>
+			<div className={styles.ring}>
+				<svg
+					viewBox="0 0 160 160"
+					className={styles.svg}
+					role="img"
+					aria-label="Distribution"
+				>
+					<g transform="rotate(-90 80 80)">
+						<circle
+							cx="80"
+							cy="80"
+							r={radius}
+							fill="none"
+							stroke="var(--current-line)"
+							strokeWidth={strokeWidth}
+						/>
+						{segments.map((segment) => {
+							const dash = mounted ? segment.fraction * circumference : 0;
+
+							return (
+								<circle
+									key={segment.label}
+									className={styles.segment}
+									cx="80"
+									cy="80"
+									r={radius}
+									fill="none"
+									stroke={segment.color}
+									strokeWidth={strokeWidth}
+									strokeDasharray={`${dash} ${circumference - dash}`}
+									strokeDashoffset={-segment.priorFraction * circumference}
+								>
+									<title>{`${segment.label}: ${segment.value}`}</title>
+								</circle>
+							);
+						})}
+					</g>
+				</svg>
+
+				{(centerValue || centerLabel) && (
+					<div className={styles.center}>
+						{centerValue && (
+							<div className={styles.centerValue}>{centerValue}</div>
+						)}
+						{centerLabel && (
+							<div className={styles.centerLabel}>{centerLabel}</div>
+						)}
+					</div>
+				)}
+			</div>
+
+			<ul className={styles.legend}>
+				{segments.map((segment) => (
+					<li className={styles.legendItem} key={`legend-${segment.label}`}>
+						<span
+							className={styles.legendDot}
+							style={{ background: segment.color }}
+						/>
+						<span className={styles.legendLabel} title={segment.label}>
+							{segment.label}
+						</span>
+						<span className={styles.legendValue}>{segment.value}</span>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+};
+
+export default DonutChart;

--- a/app/components/admin/charts/DonutChart/donutChart.module.css
+++ b/app/components/admin/charts/DonutChart/donutChart.module.css
@@ -1,0 +1,82 @@
+.donut {
+	display: flex;
+	align-items: center;
+	gap: 1.5rem;
+	flex-wrap: wrap;
+}
+
+.ring {
+	position: relative;
+	flex-shrink: 0;
+	width: 160px;
+	height: 160px;
+}
+
+.svg {
+	width: 100%;
+	height: 100%;
+}
+
+.segment {
+	transition: stroke-dasharray var(--duration-slow) var(--ease-fluid);
+}
+
+.center {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.125rem;
+	pointer-events: none;
+}
+
+.centerValue {
+	font-size: var(--big-font-size);
+	font-weight: 700;
+	color: var(--foreground-color);
+	font-variant-numeric: tabular-nums;
+}
+
+.centerLabel {
+	font-size: var(--tiny-font-size);
+	color: var(--gray-color);
+	text-transform: uppercase;
+	letter-spacing: 0.05rem;
+}
+
+.legend {
+	display: flex;
+	flex: 1 1 8rem;
+	flex-direction: column;
+	gap: 0.5rem;
+	min-width: 8rem;
+}
+
+.legendItem {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: var(--small-font-size);
+}
+
+.legendDot {
+	flex-shrink: 0;
+	width: 0.625rem;
+	height: 0.625rem;
+	border-radius: 50%;
+}
+
+.legendLabel {
+	flex: 1;
+	overflow: hidden;
+	color: var(--foreground-color);
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.legendValue {
+	font-variant-numeric: tabular-nums;
+	color: var(--gray-color);
+}

--- a/app/components/landing/FeatureCard/FeatureCard.tsx
+++ b/app/components/landing/FeatureCard/FeatureCard.tsx
@@ -1,5 +1,9 @@
-import { ReactElement } from "react";
+import { CSSProperties, ReactElement } from "react";
 
+/* Components */
+import Card from "@/components/ui/Card/Card";
+
+/* Styles */
 import styles from "./featureCard.module.css";
 
 type FeatureCardProps = {
@@ -8,12 +12,15 @@ type FeatureCardProps = {
 
 const FeatureCard = ({ feature }: FeatureCardProps): ReactElement => {
 	const FeatureIcon = feature.icon;
+	// Accent token derived from the feature's palette key (e.g. var(--cyan-color)).
+	const cardStyle = {
+		"--feature-accent": `var(--${feature.accent}-color)`,
+	} as CSSProperties;
 
 	return (
-		<article
-			className={styles.card}
-			data-accent={feature.accent}
-			data-size={feature.size}
+		<Card
+			className={`${styles.card} ${styles[feature.size] ?? ""}`}
+			style={cardStyle}
 		>
 			<h3 className={styles.title}>
 				<span className={styles.iconWrap}>
@@ -35,7 +42,7 @@ const FeatureCard = ({ feature }: FeatureCardProps): ReactElement => {
 			) : null}
 
 			<span className={styles.detail}>{feature.detail}</span>
-		</article>
+		</Card>
 	);
 };
 

--- a/app/components/landing/FeatureCard/featureCard.module.css
+++ b/app/components/landing/FeatureCard/featureCard.module.css
@@ -1,44 +1,23 @@
+/* Built on the shared <Card> primitive; these rules layer the landing's glass
+   surface + accent on top (featureCard styles import after Card, so they win). */
 .card {
 	--feature-accent: var(--purple-color);
 
-	display: flex;
-	flex-flow: column nowrap;
 	align-items: flex-start;
 	gap: 0.65rem;
 	background: var(--glass-bg);
 	border: 1px solid var(--glass-border);
-	border-radius: var(--border-radius-lg);
 	padding: 1.5rem;
 	backdrop-filter: blur(8px);
 	overflow: hidden;
 }
 
-.card[data-accent="blue"] {
-	--feature-accent: var(--blue-color);
+.large {
+	min-height: 16rem;
 }
 
-.card[data-accent="cyan"] {
-	--feature-accent: var(--cyan-color);
-}
-
-.card[data-accent="green"] {
-	--feature-accent: var(--green-color);
-}
-
-.card[data-accent="orange"] {
-	--feature-accent: var(--orange-color);
-}
-
-.card[data-accent="purple"] {
-	--feature-accent: var(--purple-color);
-}
-
-.card[data-accent="red"] {
-	--feature-accent: var(--red-color);
-}
-
-.card[data-accent="yellow"] {
-	--feature-accent: var(--yellow-color);
+.medium {
+	min-height: 11rem;
 }
 
 .iconWrap {
@@ -87,12 +66,4 @@
 	font-family: monospace;
 	color: var(--feature-accent);
 	padding-top: 0.5rem;
-}
-
-.card[data-size="large"] {
-	min-height: 16rem;
-}
-
-.card[data-size="medium"] {
-	min-height: 11rem;
 }

--- a/app/components/ui/Alert/alert.module.css
+++ b/app/components/ui/Alert/alert.module.css
@@ -23,26 +23,28 @@
 	word-break: break-word;
 }
 
+/* Severity colors derive from the active theme's palette (color-mix tint over
+   the current surface) so alerts track every [data-theme], dark or light. */
 .success {
-	background-color: var(--success-color);
-	color: var(--dark-green-color);
-	border-color: var(--dark-green-color);
+	background-color: color-mix(in srgb, var(--green-color) 14%, transparent);
+	color: var(--green-color);
+	border: 1px solid color-mix(in srgb, var(--green-color) 45%, transparent);
 }
 
 .warning {
-	background-color: var(--warning-color);
-	color: var(--dark-orange-color);
-	border-color: var(--dark-orange-color);
+	background-color: color-mix(in srgb, var(--yellow-color) 14%, transparent);
+	color: var(--yellow-color);
+	border: 1px solid color-mix(in srgb, var(--yellow-color) 45%, transparent);
 }
 
 .error {
-	background-color: var(--error-color);
-	color: var(--dark-red-color);
-	border: 2px solid var(--dark-red-color);
+	background-color: color-mix(in srgb, var(--red-color) 14%, transparent);
+	color: var(--red-color);
+	border: 1px solid color-mix(in srgb, var(--red-color) 45%, transparent);
 }
 
 .info {
-	background-color: var(--info-color);
-	color: var(--blue-color);
-	border-color: var(--blue-color);
+	background-color: color-mix(in srgb, var(--cyan-color) 14%, transparent);
+	color: var(--cyan-color);
+	border: 1px solid color-mix(in srgb, var(--cyan-color) 45%, transparent);
 }

--- a/app/components/ui/Button/Button.tsx
+++ b/app/components/ui/Button/Button.tsx
@@ -6,6 +6,7 @@ import styles from "./button.module.css";
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 	children: Children;
 	className?: string;
+	shape?: "default" | "pill";
 	variant?: Variants;
 	onClick?: () => void;
 }
@@ -13,6 +14,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 const Button = ({
 	children,
 	className = "",
+	shape = "default",
 	variant = "primary",
 	onClick,
 	...props
@@ -20,11 +22,12 @@ const Button = ({
 	return (
 		<button
 			className={`
-			  ${styles.button} 
-			  ${variant === "primary" && styles.primary} 
-			  ${variant === "secondary" && styles.secondary} 
+			  ${styles.button}
+			  ${variant === "primary" && styles.primary}
+			  ${variant === "secondary" && styles.secondary}
 			  ${variant === "tertiary" && styles.tertiary}
 			  ${variant === "cta" && styles.cta}
+			  ${shape === "pill" ? styles.pill : ""}
 			  ${className}`}
 			{...props}
 			onClick={onClick}

--- a/app/components/ui/Button/button.module.css
+++ b/app/components/ui/Button/button.module.css
@@ -13,6 +13,10 @@
 		transform var(--duration-fast) var(--ease-fluid);
 }
 
+.pill {
+	border-radius: 999px;
+}
+
 .primary {
 	background: var(--button-bg);
 	color: var(--foreground-color);

--- a/app/components/ui/Card/Card.tsx
+++ b/app/components/ui/Card/Card.tsx
@@ -1,0 +1,41 @@
+import { CSSProperties, ReactElement, ReactNode } from "react";
+
+/* Styles */
+import styles from "./card.module.css";
+
+type CardProps = {
+	actions?: ReactNode;
+	children: ReactNode;
+	className?: string;
+	style?: CSSProperties;
+	subtitle?: string;
+	title?: string;
+};
+
+const Card = ({
+	actions,
+	children,
+	className = "",
+	style,
+	subtitle,
+	title,
+}: CardProps): ReactElement => {
+	return (
+		<section className={`${styles.card} ${className}`} style={style}>
+			{(title || actions) && (
+				<header className={styles.header}>
+					{(title || subtitle) && (
+						<div className={styles.heading}>
+							{title && <h3 className={styles.title}>{title}</h3>}
+							{subtitle && <p className={styles.subtitle}>{subtitle}</p>}
+						</div>
+					)}
+					{actions && <div className={styles.actions}>{actions}</div>}
+				</header>
+			)}
+			{children}
+		</section>
+	);
+};
+
+export default Card;

--- a/app/components/ui/Card/card.module.css
+++ b/app/components/ui/Card/card.module.css
@@ -1,0 +1,37 @@
+.card {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	padding: 1.25rem;
+	background: var(--bg-color-dark);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-lg);
+}
+
+.header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.heading {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+}
+
+.title {
+	font-size: var(--big-font-size);
+	font-weight: 600;
+	color: var(--foreground-color);
+}
+
+.subtitle {
+	font-size: var(--tiny-font-size);
+	color: var(--gray-color);
+}
+
+.actions {
+	flex-shrink: 0;
+}

--- a/app/components/ui/Menu/Menu.tsx
+++ b/app/components/ui/Menu/Menu.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { ReactElement, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+/* Components */
+import DotsThreeVertical from "@/components/ui/icons/DotsThreeVertical";
+
+/* Styles */
+import styles from "./menu.module.css";
+
+type MenuProps = {
+	ariaLabel?: string;
+	items: MenuItem[];
+};
+
+// Kebab (⋮) overflow menu. The dropdown is portaled to the body and positioned
+// next to the trigger so it never clips inside scrollable containers (tables).
+const Menu = ({
+	ariaLabel = "More options",
+	items,
+}: MenuProps): ReactElement => {
+	const [isOpen, setIsOpen] = useState<boolean>(false);
+	const [coords, setCoords] = useState<{ left: number; top: number }>({
+		left: 0,
+		top: 0,
+	});
+	const triggerRef = useRef<HTMLButtonElement | null>(null);
+	const menuRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		if (!isOpen) {
+			return;
+		}
+
+		const handlePointer = (event: MouseEvent): void => {
+			// event.target is an EventTarget; narrow to Node for contains().
+			const target = event.target as Node;
+
+			if (
+				!menuRef.current?.contains(target) &&
+				!triggerRef.current?.contains(target)
+			) {
+				setIsOpen(false);
+			}
+		};
+		const handleKey = (event: KeyboardEvent): void => {
+			if (event.key === "Escape") {
+				setIsOpen(false);
+			}
+		};
+		const handleScroll = (): void => setIsOpen(false);
+
+		document.addEventListener("mousedown", handlePointer);
+		document.addEventListener("keydown", handleKey);
+		window.addEventListener("scroll", handleScroll, true);
+
+		return () => {
+			document.removeEventListener("mousedown", handlePointer);
+			document.removeEventListener("keydown", handleKey);
+			window.removeEventListener("scroll", handleScroll, true);
+		};
+	}, [isOpen]);
+
+	const toggleMenu = (): void => {
+		const trigger = triggerRef.current;
+
+		if (!trigger) {
+			return;
+		}
+
+		const rect = trigger.getBoundingClientRect();
+
+		setCoords({ left: rect.right, top: rect.bottom + 4 });
+		setIsOpen((current) => !current);
+	};
+
+	const handleSelect = (item: MenuItem): void => {
+		if (item.disabled) {
+			return;
+		}
+
+		setIsOpen(false);
+		item.onSelect();
+	};
+
+	return (
+		<div className={styles.container}>
+			<button
+				ref={triggerRef}
+				type="button"
+				className={styles.trigger}
+				aria-label={ariaLabel}
+				aria-haspopup="menu"
+				aria-expanded={isOpen}
+				onClick={toggleMenu}
+			>
+				<DotsThreeVertical width={18} height={18} />
+			</button>
+
+			{isOpen &&
+				createPortal(
+					<div
+						ref={menuRef}
+						className={styles.menu}
+						role="menu"
+						style={{ left: coords.left, top: coords.top }}
+					>
+						{items.map((item) => (
+							<button
+								key={item.label}
+								type="button"
+								role="menuitem"
+								disabled={item.disabled}
+								className={`${styles.item} ${item.danger ? styles.danger : ""}`}
+								onClick={() => handleSelect(item)}
+							>
+								{item.icon && (
+									<span className={styles.itemIcon}>{item.icon}</span>
+								)}
+								<span className={styles.itemLabel}>{item.label}</span>
+							</button>
+						))}
+					</div>,
+					document.body
+				)}
+		</div>
+	);
+};
+
+export default Menu;

--- a/app/components/ui/Menu/menu.module.css
+++ b/app/components/ui/Menu/menu.module.css
@@ -1,0 +1,76 @@
+.container {
+	display: inline-flex;
+}
+
+.trigger {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: var(--button-bg);
+	color: var(--gray-color);
+	cursor: pointer;
+	transition:
+		color var(--duration-fast) var(--ease-fluid),
+		border-color var(--duration-fast) var(--ease-fluid);
+}
+
+.trigger:hover {
+	color: var(--cyan-color);
+	border-color: var(--cyan-color);
+}
+
+.menu {
+	position: fixed;
+	z-index: 1100;
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	min-width: 11rem;
+	padding: 0.375rem;
+	transform: translateX(-100%);
+	background: var(--bg-color-dark);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+}
+
+.item {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	width: 100%;
+	min-height: 2rem;
+	padding: 0.375rem 0.625rem;
+	border: none;
+	border-radius: var(--border-radius);
+	background: transparent;
+	color: var(--foreground-color);
+	font-family: inherit;
+	font-size: var(--small-font-size);
+	text-align: left;
+	cursor: pointer;
+	transition: background var(--duration-fast) var(--ease-fluid);
+}
+
+.danger {
+	color: var(--red-color);
+}
+
+.itemIcon {
+	display: inline-flex;
+	flex-shrink: 0;
+}
+
+.itemLabel {
+	flex: 1;
+}
+
+.item:disabled {
+	opacity: 0.45;
+	cursor: not-allowed;
+}
+
+.item:hover:not(:disabled) {
+	background: var(--current-line);
+}

--- a/app/components/ui/Table/Table.tsx
+++ b/app/components/ui/Table/Table.tsx
@@ -1,0 +1,35 @@
+import { ReactElement, ReactNode } from "react";
+
+/* Styles */
+import styles from "./table.module.css";
+
+type TableProps = {
+	children: ReactNode;
+	columns: TableColumn[];
+};
+
+// Styled table shell. The consumer supplies the `<tr>` rows as children; the
+// primitive owns the wrapper, header, and cell chrome.
+const Table = ({ children, columns }: TableProps): ReactElement => {
+	return (
+		<div className={styles.wrap}>
+			<table className={styles.table}>
+				<thead>
+					<tr>
+						{columns.map((column) => (
+							<th
+								key={column.label}
+								className={column.align === "right" ? styles.right : ""}
+							>
+								{column.label}
+							</th>
+						))}
+					</tr>
+				</thead>
+				<tbody>{children}</tbody>
+			</table>
+		</div>
+	);
+};
+
+export default Table;

--- a/app/components/ui/Table/table.module.css
+++ b/app/components/ui/Table/table.module.css
@@ -1,0 +1,48 @@
+.wrap {
+	width: 100%;
+	overflow-x: auto;
+	background: var(--bg-color-dark);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-lg);
+}
+
+.table {
+	width: 100%;
+	min-width: 720px;
+	border-collapse: collapse;
+}
+
+.table th {
+	padding: 0.75rem 1rem;
+	font-size: var(--tiny-font-size);
+	font-weight: 700;
+	letter-spacing: 0.05rem;
+	text-transform: uppercase;
+	text-align: left;
+	color: var(--gray-color);
+	border-bottom: 1px solid var(--border-color);
+	white-space: nowrap;
+}
+
+.right {
+	text-align: right;
+}
+
+.table td {
+	padding: 0.75rem 1rem;
+	font-size: var(--small-font-size);
+	border-bottom: 1px solid var(--border-color);
+	vertical-align: middle;
+}
+
+.table tbody tr {
+	transition: background var(--duration-fast) var(--ease-fluid);
+}
+
+.table tbody tr:hover {
+	background: color-mix(in srgb, var(--cyan-color) 9%, transparent);
+}
+
+.table tbody tr:last-child td {
+	border-bottom: none;
+}

--- a/app/components/ui/Tooltip/Tooltip.tsx
+++ b/app/components/ui/Tooltip/Tooltip.tsx
@@ -1,0 +1,24 @@
+import { ReactElement, ReactNode } from "react";
+
+/* Styles */
+import styles from "./tooltip.module.css";
+
+type TooltipProps = {
+	children: ReactNode;
+	label: string;
+};
+
+// Hover/focus tooltip shown above the wrapped control, matching the editor
+// action-button tooltip pattern.
+const Tooltip = ({ children, label }: TooltipProps): ReactElement => {
+	return (
+		<span className={styles.wrapper}>
+			{children}
+			<span className={styles.tooltip} role="tooltip">
+				{label}
+			</span>
+		</span>
+	);
+};
+
+export default Tooltip;

--- a/app/components/ui/Tooltip/tooltip.module.css
+++ b/app/components/ui/Tooltip/tooltip.module.css
@@ -1,0 +1,27 @@
+.wrapper {
+	position: relative;
+	display: inline-flex;
+}
+
+.tooltip {
+	position: absolute;
+	bottom: calc(100% + 0.375rem);
+	left: 50%;
+	z-index: 5;
+	transform: translateX(-50%);
+	padding: 0.25rem 0.5rem;
+	background: var(--bg-color-dark);
+	color: var(--foreground-color);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	font-size: var(--tiny-font-size);
+	white-space: nowrap;
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity var(--duration-fast) var(--ease-fluid);
+}
+
+.wrapper:hover .tooltip,
+.wrapper:focus-within .tooltip {
+	opacity: 1;
+}

--- a/app/components/ui/icons/DotsThreeVertical.tsx
+++ b/app/components/ui/icons/DotsThreeVertical.tsx
@@ -1,0 +1,24 @@
+import { ReactElement } from "react";
+
+const DotsThreeVertical = ({
+	className = "",
+	width = 16,
+	height = 16,
+}: Icon): ReactElement => {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			className={className}
+			width={width}
+			height={height}
+			viewBox="0 0 256 256"
+			fill="currentColor"
+		>
+			<circle cx="128" cy="60" r="16" />
+			<circle cx="128" cy="128" r="16" />
+			<circle cx="128" cy="196" r="16" />
+		</svg>
+	);
+};
+
+export default DotsThreeVertical;

--- a/app/components/ui/icons/ShieldCheck.tsx
+++ b/app/components/ui/icons/ShieldCheck.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from "react";
+
+import IconContainer from "@/components/ui/icons/Icon";
+
+const ShieldCheck = (props: Icon): ReactElement => {
+	return (
+		<IconContainer {...props} viewBox="0 0 256 256">
+			<path d="M208,40H48A16,16,0,0,0,32,56v58.77c0,89.61,75.82,119.34,91,124.39a15.53,15.53,0,0,0,10,0c15.2-5.05,91-34.78,91-124.39V56A16,16,0,0,0,208,40Zm0,74.79c0,78.42-66.35,104.62-80,109.18-13.53-4.51-80-30.69-80-109.18V56H208ZM82.34,141.66a8,8,0,0,1,11.32-11.32L112,148.68l50.34-50.34a8,8,0,0,1,11.32,11.32l-56,56a8,8,0,0,1-11.32,0Z"></path>
+		</IconContainer>
+	);
+};
+
+export default ShieldCheck;

--- a/app/lib/constants/admin.constants.ts
+++ b/app/lib/constants/admin.constants.ts
@@ -1,0 +1,80 @@
+// Constants for the admin panel: API paths, GoTrue ban durations, analytics
+// window sizes, and UI tab/filter identifiers.
+
+export const enum AdminTab {
+	Analytics = "analytics",
+	Users = "users",
+}
+
+export const enum AdminFormMode {
+	Create = "create",
+	Edit = "edit",
+}
+
+export const JsonHeaders = { "Content-Type": "application/json" } as const;
+
+export const enum AdminUserFilter {
+	Admins = "admins",
+	All = "all",
+	Disabled = "disabled",
+	Users = "users",
+}
+
+export const enum RequestStatus {
+	Error = "error",
+	Loading = "loading",
+	Ready = "ready",
+}
+
+export const enum TrendPeriod {
+	Daily = "daily",
+	Monthly = "monthly",
+	Weekly = "weekly",
+}
+
+// GoTrue treats a far-future ban as an indefinite disable; "none" lifts it.
+export const BanDuration = "876000h";
+
+export const UnbanDuration = "none";
+
+// listUsers caps page size; one page is plenty for this app's scale.
+export const UsersPerPage = 1000;
+
+// Bound the analytics scan so a runaway table can't blow up the request.
+export const AnalyticsSnippetLimit = 5000;
+
+export const TrendDays = 30;
+
+export const TrendWeeks = 12;
+
+export const TrendMonths = 12;
+
+export const TopContributorsLimit = 5;
+
+export const LanguageDistributionLimit = 8;
+
+export const TopTagsLimit = 10;
+
+export const TopFoldersLimit = 8;
+
+export const TopSavedSearchesLimit = 8;
+
+export const MinPasswordLength = 6;
+
+export const AdminApiPaths = {
+	analytics: "/api/admin/analytics",
+	users: "/api/admin/users",
+} as const;
+
+// CSS custom-property names cycled through by the charts so every series tracks
+// the active theme. Authored as token names, applied via var(--token).
+export const ChartPalette = [
+	"--purple-color",
+	"--cyan-color",
+	"--green-color",
+	"--orange-color",
+	"--blue-color",
+	"--yellow-color",
+	"--red-color",
+	"--comment-color",
+] as const;

--- a/app/lib/constants/date.constants.ts
+++ b/app/lib/constants/date.constants.ts
@@ -1,0 +1,18 @@
+// Shared date/time literals.
+
+export const MillisecondsPerDay = 24 * 60 * 60 * 1000;
+
+export const ShortMonthNames = [
+	"Jan",
+	"Feb",
+	"Mar",
+	"Apr",
+	"May",
+	"Jun",
+	"Jul",
+	"Aug",
+	"Sep",
+	"Oct",
+	"Nov",
+	"Dec",
+] as const;

--- a/app/lib/constants/form.ts
+++ b/app/lib/constants/form.ts
@@ -10,3 +10,8 @@ export const regexPatterns = {
 	email: /^[^\s@]+@[^\s@]+.[^\s@]+$/,
 	password: /^(?!\s*$).+/,
 };
+
+// GoTrue reports a disabled account as "banned"; surface the app's wording.
+export const BannedErrorFragment = "banned";
+
+export const DisabledUserMessage = "User is disabled";

--- a/app/lib/constants/roles.ts
+++ b/app/lib/constants/roles.ts
@@ -1,0 +1,19 @@
+// Authorization roles and the wiring that exposes them to middleware.
+// Mirrors the `app_role` enum and `user_roles` table created in
+// supabase/migrations/20260621090000_create_user_roles.sql.
+
+export const enum AppRole {
+	Admin = "admin",
+	User = "user",
+}
+
+// JWT claim injected by the custom access token hook
+// (supabase/migrations/20260621090100_create_custom_access_token_hook.sql).
+export const RoleClaimKey = "user_role";
+
+export const RolesTableName = "user_roles";
+
+export const AdminRoutePath = "/admin";
+
+// Where non-admins are sent when they hit an admin-only surface.
+export const NonAdminRedirectPath = "/snippets";

--- a/app/lib/hooks/useCurrentUser.ts
+++ b/app/lib/hooks/useCurrentUser.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+
+/* Constants */
+import { AppRole } from "@/lib/constants/roles";
+
+/* Lib */
+import useUserStore from "@/lib/store/user.store";
+import {
+	getCurrentUserRole,
+	getUserEmailBySession,
+} from "@/lib/supabase/queries";
+
+type CurrentUser = {
+	email: string | null;
+	isAdmin: boolean;
+};
+
+// Loads the signed-in user's role and email into the user store and returns
+// them. Centralizes the role/identity wiring so the sidebar menu and the admin
+// dashboard don't each fetch it inline.
+const useCurrentUser = (): CurrentUser => {
+	const email = useUserStore((state) => state.email);
+	const isAdmin = useUserStore((state) => state.isAdmin);
+	const setEmail = useUserStore((state) => state.setEmail);
+	const setIsAdmin = useUserStore((state) => state.setIsAdmin);
+
+	useEffect(() => {
+		getCurrentUserRole().then((role) => {
+			setIsAdmin(role === AppRole.Admin);
+		});
+	}, [setIsAdmin]);
+
+	useEffect(() => {
+		if (email) {
+			return;
+		}
+
+		getUserEmailBySession().then((value) => {
+			if (value) {
+				setEmail(value);
+			}
+		});
+	}, [email, setEmail]);
+
+	return { email, isAdmin };
+};
+
+export default useCurrentUser;

--- a/app/lib/store/user.store.tsx
+++ b/app/lib/store/user.store.tsx
@@ -11,6 +11,7 @@ type UserState = {
 	theme: string;
 	aiApiKey: string;
 	autoSave: boolean;
+	isAdmin: boolean;
 	isLoading: boolean;
 	setUserName: (userName: string | null) => void;
 	setUserAvatar: (avatar: string) => void;
@@ -18,6 +19,7 @@ type UserState = {
 	setTheme: (theme: string) => void;
 	setAiApiKey: (aiApiKey: string) => void;
 	setAutoSave: (autoSave: boolean) => void;
+	setIsAdmin: (isAdmin: boolean) => void;
 	setUserData: (userData: {
 		userName?: string | null;
 		userAvatar?: string;
@@ -25,6 +27,7 @@ type UserState = {
 		theme?: string;
 		aiApiKey?: string;
 		autoSave?: boolean;
+		isAdmin?: boolean;
 	}) => void;
 	setLoading: (loading: boolean) => void;
 	clearUser: () => void;
@@ -37,6 +40,7 @@ const useUserStore = create<UserState>((set) => ({
 	theme: ThemeNames.ShadesOfPurple,
 	aiApiKey: "",
 	autoSave: false,
+	isAdmin: false,
 	isLoading: true,
 	setUserName: (userName) => set({ userName }),
 	setUserAvatar: (userAvatar) => set({ userAvatar }),
@@ -44,6 +48,7 @@ const useUserStore = create<UserState>((set) => ({
 	setTheme: (theme) => set({ theme }),
 	setAiApiKey: (aiApiKey) => set({ aiApiKey }),
 	setAutoSave: (autoSave) => set({ autoSave }),
+	setIsAdmin: (isAdmin) => set({ isAdmin }),
 	setUserData: (userData) =>
 		set((state) => ({
 			...state,
@@ -58,6 +63,7 @@ const useUserStore = create<UserState>((set) => ({
 			theme: ThemeNames.ShadesOfPurple,
 			aiApiKey: "",
 			autoSave: false,
+			isAdmin: false,
 			isLoading: false,
 		}),
 }));

--- a/app/lib/supabase/adminAnalytics.ts
+++ b/app/lib/supabase/adminAnalytics.ts
@@ -1,0 +1,253 @@
+import {
+	AnalyticsSnippetLimit,
+	LanguageDistributionLimit,
+	TopContributorsLimit,
+	TopFoldersLimit,
+	TopSavedSearchesLimit,
+	TopTagsLimit,
+	TrendDays,
+	TrendMonths,
+	TrendWeeks,
+	UsersPerPage,
+} from "@/lib/constants/admin.constants";
+import { SnippetState } from "@/lib/constants/core";
+import {
+	MillisecondsPerDay,
+	ShortMonthNames,
+} from "@/lib/constants/date.constants";
+import createSupabaseAdminClient from "@/lib/supabase/admin";
+
+import { dayKey } from "@/utils/date.utils";
+
+const countBy = <Item>(
+	items: Item[],
+	keyOf: (item: Item) => string
+): Map<string, number> => {
+	const counts = new Map<string, number>();
+
+	items.forEach((item) => {
+		const key = keyOf(item);
+
+		counts.set(key, (counts.get(key) ?? 0) + 1);
+	});
+
+	return counts;
+};
+
+const buildDailyTrend = (
+	snippets: AnalyticsSnippetRow[]
+): SnippetTrendPoint[] => {
+	const counts = countBy(snippets, (snippet) => dayKey(snippet.created_at));
+
+	return Array.from({ length: TrendDays }, (_, index) => {
+		const date = new Date();
+
+		date.setDate(date.getDate() - (TrendDays - 1 - index));
+
+		const key = date.toISOString().slice(0, 10);
+		const month = Number(key.slice(5, 7)) - 1;
+		const day = Number(key.slice(8, 10));
+
+		return {
+			count: counts.get(key) ?? 0,
+			label: `${ShortMonthNames[month] ?? ""} ${day}`,
+		};
+	});
+};
+
+const buildWeeklyTrend = (
+	snippets: AnalyticsSnippetRow[]
+): SnippetTrendPoint[] => {
+	const now = Date.now();
+
+	return Array.from({ length: TrendWeeks }, (_, index) => {
+		const weeksAgo = TrendWeeks - 1 - index;
+		const windowStart = now - (weeksAgo + 1) * 7 * MillisecondsPerDay;
+		const windowEnd = now - weeksAgo * 7 * MillisecondsPerDay;
+		const count = snippets.filter((snippet) => {
+			const created = new Date(snippet.created_at).getTime();
+
+			return created >= windowStart && created < windowEnd;
+		}).length;
+		const startDate = new Date(windowStart);
+
+		return {
+			count,
+			label: `${ShortMonthNames[startDate.getMonth()] ?? ""} ${startDate.getDate()}`,
+		};
+	});
+};
+
+const buildMonthlyTrend = (
+	snippets: AnalyticsSnippetRow[]
+): SnippetTrendPoint[] => {
+	return Array.from({ length: TrendMonths }, (_, index) => {
+		const monthsAgo = TrendMonths - 1 - index;
+		const cursor = new Date();
+
+		cursor.setDate(1);
+		cursor.setMonth(cursor.getMonth() - monthsAgo);
+
+		const year = cursor.getFullYear();
+		const month = cursor.getMonth();
+		const count = snippets.filter((snippet) => {
+			const created = new Date(snippet.created_at);
+
+			return created.getFullYear() === year && created.getMonth() === month;
+		}).length;
+
+		return { count, label: ShortMonthNames[month] ?? "" };
+	});
+};
+
+const splitTags = (tags: string | null): string[] =>
+	(tags ?? "")
+		.split(",")
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+
+// Aggregates snippet + user data into the dashboard analytics payload. Runs with
+// the service-role client so it sees every user's data (bypassing RLS). Done in
+// memory over a bounded fetch — fine at this app's scale; a SQL view/RPC would
+// be the move if the table grows into the millions.
+export const computeSnippetAnalytics = async (): Promise<SnippetAnalytics> => {
+	const admin = createSupabaseAdminClient();
+	const { data: snippetRows } = await admin
+		.from("snippet")
+		.select("user_id, language, state, created_at, is_public, tags, folder")
+		.order("created_at", { ascending: false })
+		.limit(AnalyticsSnippetLimit);
+	// Supabase rows are loosely typed; we know the selected projection.
+	const allSnippets = (snippetRows ?? []) as AnalyticsSnippetRow[];
+	const liveSnippets = allSnippets.filter(
+		(snippet) => snippet.state !== SnippetState.Inactive
+	);
+
+	const { data: usersData } = await admin.auth.admin.listUsers({
+		page: 1,
+		perPage: UsersPerPage,
+	});
+	const allUsers = usersData?.users ?? [];
+	const emailById = new Map(
+		allUsers.map((user) => [user.id, user.email ?? "unknown"])
+	);
+
+	const { count: versionCount } = await admin
+		.from("snippet_version")
+		.select("version_id", { count: "exact", head: true });
+
+	const totalSnippets = liveSnippets.length;
+	const totalUsers = allUsers.length;
+	const favoriteCount = liveSnippets.filter(
+		(snippet) => snippet.state === SnippetState.Favorite
+	).length;
+	const publicCount = liveSnippets.filter(
+		(snippet) => snippet.is_public
+	).length;
+
+	const languageCounts = countBy(
+		liveSnippets,
+		(snippet) => snippet.language || "unknown"
+	);
+	const languageDistribution: LanguageDatum[] = Array.from(
+		languageCounts.entries()
+	)
+		.map(([language, count]) => ({ count, language }))
+		.sort((first, second) => second.count - first.count)
+		.slice(0, LanguageDistributionLimit);
+
+	const perUserCounts = countBy(liveSnippets, (snippet) => snippet.user_id);
+	const topContributors: ContributorDatum[] = Array.from(
+		perUserCounts.entries()
+	)
+		.map(([userId, count]) => ({
+			count,
+			email: emailById.get(userId) ?? "unknown",
+			userId,
+		}))
+		.sort((first, second) => second.count - first.count)
+		.slice(0, TopContributorsLimit);
+
+	const tagCounts = new Map<string, number>();
+
+	liveSnippets.forEach((snippet) => {
+		splitTags(snippet.tags).forEach((tag) =>
+			tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1)
+		);
+	});
+
+	const tagDistribution: TagDatum[] = Array.from(tagCounts.entries())
+		.map(([tag, count]) => ({ count, tag }))
+		.sort((first, second) => second.count - first.count)
+		.slice(0, TopTagsLimit);
+	const uncategorizedCount = liveSnippets.filter(
+		(snippet) => splitTags(snippet.tags).length === 0
+	).length;
+
+	const folderCounts = countBy(
+		liveSnippets.filter((snippet) => (snippet.folder ?? "").trim().length > 0),
+		(snippet) => (snippet.folder ?? "").trim()
+	);
+	const folderDistribution: FolderDatum[] = Array.from(folderCounts.entries())
+		.map(([folder, count]) => ({ count, folder }))
+		.sort((first, second) => second.count - first.count)
+		.slice(0, TopFoldersLimit);
+
+	// Saved searches live on each user's metadata as `smart_groups`.
+	const savedSearchNames = allUsers.flatMap((user) => {
+		// user_metadata is loosely typed by GoTrue.
+		const metadata = (user.user_metadata ?? {}) as Record<string, unknown>;
+		const groups = metadata.smart_groups;
+
+		if (!Array.isArray(groups)) {
+			return [];
+		}
+
+		return groups
+			.filter(
+				(group): group is SmartGroup =>
+					Boolean(group) &&
+					typeof group === "object" &&
+					typeof (group as SmartGroup).name === "string"
+			)
+			.map((group) => group.name);
+	});
+	const savedSearchCounts = countBy(savedSearchNames, (name) => name);
+	const savedSearches: SavedSearchDatum[] = Array.from(
+		savedSearchCounts.entries()
+	)
+		.map(([name, count]) => ({ count, name }))
+		.sort((first, second) => second.count - first.count)
+		.slice(0, TopSavedSearchesLimit);
+
+	const thirtyDaysAgo = Date.now() - 30 * MillisecondsPerDay;
+	const newUsersLast30Days = allUsers.filter(
+		(user) => new Date(user.created_at).getTime() >= thirtyDaysAgo
+	).length;
+
+	return {
+		activeUsers: perUserCounts.size,
+		averagePerUser:
+			totalUsers > 0 ? Math.round((totalSnippets / totalUsers) * 10) / 10 : 0,
+		dailyTrend: buildDailyTrend(liveSnippets),
+		favoriteCount,
+		folderCount: folderCounts.size,
+		folderDistribution,
+		generatedAt: new Date().toISOString(),
+		languageDistribution,
+		monthlyTrend: buildMonthlyTrend(liveSnippets),
+		mostUsedLanguage: languageDistribution[0]?.language ?? null,
+		newUsersLast30Days,
+		publicCount,
+		savedSearchCount: savedSearchNames.length,
+		savedSearches,
+		tagDistribution,
+		topContributors,
+		totalSnippets,
+		totalUsers,
+		totalVersions: versionCount ?? 0,
+		uncategorizedCount,
+		uniqueTagCount: tagCounts.size,
+		weeklyTrend: buildWeeklyTrend(liveSnippets),
+	};
+};

--- a/app/lib/supabase/adminGuard.ts
+++ b/app/lib/supabase/adminGuard.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { NextRequest } from "next/server";
+import { User } from "@supabase/supabase-js";
+
+import { demoAccountData } from "@/lib/constants/account";
+import { AppRole } from "@/lib/constants/roles";
+import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import { resolveUserRole } from "@/lib/supabase/roles";
+import createSupabaseServerClient from "@/lib/supabase/server";
+
+// True when the email belongs to the protected, read-only demo account.
+export const isDemoAccount = (email: string | null | undefined): boolean =>
+	(email ?? "").toLowerCase() === demoAccountData.email.toLowerCase();
+
+// Server-side authorization gate for admin API routes. Returns either a denial
+// response to send back immediately, or the verified admin `user`. This is the
+// authoritative check — never trust the client to assert its own role.
+export const requireAdmin = async (
+	request: NextRequest
+): Promise<
+	{ error: NextResponse; user: null } | { error: null; user: User }
+> => {
+	const { supabase } = await createSupabaseServerClient(request);
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		return {
+			error: NextResponse.json(
+				{ error: "Unauthorized" },
+				{ status: HttpStatusCode.Unauthorized }
+			),
+			user: null,
+		};
+	}
+
+	const role = await resolveUserRole(supabase, user.id);
+
+	if (role !== AppRole.Admin) {
+		return {
+			error: NextResponse.json(
+				{ error: "Forbidden" },
+				{ status: HttpStatusCode.Forbidden }
+			),
+			user: null,
+		};
+	}
+
+	return { error: null, user };
+};
+
+// Blocks mutations when the acting admin is the demo account (read-only demo).
+// Returns a 403 response to send back, or null when the caller may mutate.
+export const rejectDemoActor = (user: User): NextResponse | null => {
+	if (isDemoAccount(user.email)) {
+		return NextResponse.json(
+			{ error: "The demo administrator is read-only" },
+			{ status: HttpStatusCode.Forbidden }
+		);
+	}
+
+	return null;
+};
+
+// Blocks mutations that target the protected demo account, regardless of who is
+// acting. Returns a 403 response to send back, or null when the target is fine.
+export const rejectDemoTarget = (
+	email: string | null | undefined
+): NextResponse | null => {
+	if (isDemoAccount(email)) {
+		return NextResponse.json(
+			{ error: "The demo account cannot be modified" },
+			{ status: HttpStatusCode.Forbidden }
+		);
+	}
+
+	return null;
+};

--- a/app/lib/supabase/adminUsers.ts
+++ b/app/lib/supabase/adminUsers.ts
@@ -1,0 +1,199 @@
+import { AdminUserAttributes, User } from "@supabase/supabase-js";
+
+import {
+	BanDuration,
+	UnbanDuration,
+	UsersPerPage,
+} from "@/lib/constants/admin.constants";
+import { AppRole } from "@/lib/constants/roles";
+import { ThemeNames } from "@/lib/config/themes";
+import createSupabaseAdminClient from "@/lib/supabase/admin";
+import { isDemoAccount } from "@/lib/supabase/adminGuard";
+import { fetchRoleMap, setUserRole } from "@/lib/supabase/roles";
+
+const readMetaString = (
+	metadata: Record<string, unknown>,
+	key: string
+): string | undefined => {
+	const value = metadata[key];
+
+	return typeof value === "string" ? value : undefined;
+};
+
+const isUserBanned = (user: User): boolean => {
+	// banned_until isn't on the base User type but GoTrue returns it to admins.
+	const bannedUntil = (user as { banned_until?: string | null }).banned_until;
+
+	if (!bannedUntil) {
+		return false;
+	}
+
+	return new Date(bannedUntil).getTime() > Date.now();
+};
+
+const toAdminUser = (user: User, role: AppRole): AdminUser => {
+	const metadata = (user.user_metadata ?? {}) as Record<string, unknown>;
+	const email = user.email ?? "";
+	const usernameFromEmail = email.split("@")[0] ?? "";
+
+	return {
+		createdAt: user.created_at,
+		email,
+		id: user.id,
+		isDemo: isDemoAccount(email),
+		isDisabled: isUserBanned(user),
+		lastSignInAt: user.last_sign_in_at ?? null,
+		role,
+		theme: readMetaString(metadata, "theme") ?? ThemeNames.ShadesOfPurple,
+		username: readMetaString(metadata, "username") ?? usernameFromEmail,
+	};
+};
+
+export const listAdminUsers = async (): Promise<AdminUsersResponse> => {
+	const admin = createSupabaseAdminClient();
+	const { data, error } = await admin.auth.admin.listUsers({
+		page: 1,
+		perPage: UsersPerPage,
+	});
+
+	if (error || !data) {
+		return { total: 0, users: [] };
+	}
+
+	const roleMap = await fetchRoleMap(data.users.map((user) => user.id));
+	const users = data.users
+		.map((user) => toAdminUser(user, roleMap[user.id] ?? AppRole.User))
+		.sort((first, second) => second.createdAt.localeCompare(first.createdAt));
+
+	return { total: users.length, users };
+};
+
+export const getAdminUserEmail = async (
+	userId: string
+): Promise<string | null> => {
+	const admin = createSupabaseAdminClient();
+	const { data } = await admin.auth.admin.getUserById(userId);
+
+	return data?.user?.email ?? null;
+};
+
+export const createAdminUser = async (
+	payload: AdminUserCreatePayload
+): Promise<{ error: string | null; userId: string | null }> => {
+	const admin = createSupabaseAdminClient();
+	const { data, error } = await admin.auth.admin.createUser({
+		email: payload.email,
+		email_confirm: true,
+		password: payload.password,
+		user_metadata: {
+			...(payload.username ? { username: payload.username } : {}),
+			...(payload.theme ? { theme: payload.theme } : {}),
+		},
+	});
+
+	if (error || !data?.user) {
+		return { error: error?.message ?? "Could not create user", userId: null };
+	}
+
+	// The signup trigger seeds a default role; this guarantees the requested one.
+	const { error: roleError } = await setUserRole(
+		data.user.id,
+		payload.role ?? AppRole.User
+	);
+
+	if (roleError) {
+		return { error: roleError, userId: data.user.id };
+	}
+
+	return { error: null, userId: data.user.id };
+};
+
+export const updateAdminUser = async (
+	userId: string,
+	payload: AdminUserUpdatePayload
+): Promise<{ error: string | null }> => {
+	const admin = createSupabaseAdminClient();
+	const wantsMetadata =
+		payload.username !== undefined || payload.theme !== undefined;
+	// Merge into existing metadata so unrelated keys (avatar, ai_*) survive.
+	const existingMetadata = wantsMetadata
+		? (((await admin.auth.admin.getUserById(userId)).data?.user
+				?.user_metadata ?? {}) as Record<string, unknown>)
+		: {};
+	const mergedMetadata = {
+		...existingMetadata,
+		...(payload.username !== undefined ? { username: payload.username } : {}),
+		...(payload.theme !== undefined ? { theme: payload.theme } : {}),
+	};
+	const attributes: AdminUserAttributes = {
+		...(payload.email !== undefined ? { email: payload.email } : {}),
+		...(payload.isDisabled !== undefined
+			? { ban_duration: payload.isDisabled ? BanDuration : UnbanDuration }
+			: {}),
+		...(wantsMetadata ? { user_metadata: mergedMetadata } : {}),
+	};
+
+	if (Object.keys(attributes).length > 0) {
+		const { error } = await admin.auth.admin.updateUserById(userId, attributes);
+
+		if (error) {
+			return { error: error.message };
+		}
+	}
+
+	if (payload.role !== undefined) {
+		const { error } = await setUserRole(userId, payload.role);
+
+		if (error) {
+			return { error };
+		}
+	}
+
+	return { error: null };
+};
+
+export const deleteAdminUser = async (
+	userId: string
+): Promise<{ error: string | null }> => {
+	const admin = createSupabaseAdminClient();
+	const { error } = await admin.auth.admin.deleteUser(userId);
+
+	return { error: error?.message ?? null };
+};
+
+export const setAdminUserPassword = async (
+	userId: string,
+	password: string
+): Promise<{ error: string | null }> => {
+	const admin = createSupabaseAdminClient();
+	const { error } = await admin.auth.admin.updateUserById(userId, { password });
+
+	return { error: error?.message ?? null };
+};
+
+// Forces a user to re-authenticate by revoking their active sessions.
+export const revokeUserSessions = async (
+	userId: string
+): Promise<{ error: string | null }> => {
+	const admin = createSupabaseAdminClient();
+	const { error } = await admin.rpc("admin_revoke_user_sessions", {
+		target_user: userId,
+	});
+
+	return { error: error?.message ?? null };
+};
+
+export const generatePasswordResetLink = async (
+	email: string
+): Promise<{ actionLink: string | null; error: string | null }> => {
+	const admin = createSupabaseAdminClient();
+	const { data, error } = await admin.auth.admin.generateLink({
+		email,
+		type: "recovery",
+	});
+
+	return {
+		actionLink: data?.properties?.action_link ?? null,
+		error: error?.message ?? null,
+	};
+};

--- a/app/lib/supabase/queries.ts
+++ b/app/lib/supabase/queries.ts
@@ -7,6 +7,7 @@ import {
 	MfaFactorType,
 	MfaFriendlyName,
 } from "@/lib/constants/mfa";
+import { AppRole, RoleClaimKey, RolesTableName } from "@/lib/constants/roles";
 import { HttpStatusCode } from "@/lib/constants/ui.constants";
 import { AuthError, UserAttributes, UserResponse } from "@supabase/supabase-js";
 
@@ -50,6 +51,31 @@ export const getUserEmailBySession = async (): Promise<
 	const userFromServer = await getUserDataFromServer();
 
 	return userFromServer?.email ?? null;
+};
+
+export const getCurrentUserRole = async (): Promise<AppRole> => {
+	const { data } = await supabase.auth.getClaims();
+	// The access-token hook injects `user_role`; the typed JwtPayload omits it.
+	const claims = data?.claims as Record<string, unknown> | undefined;
+	const claimed = claims?.[RoleClaimKey];
+
+	if (claimed === AppRole.Admin || claimed === AppRole.User) {
+		return claimed;
+	}
+
+	const userId = await getUserIdBySession();
+
+	if (!userId) {
+		return AppRole.User;
+	}
+
+	const { data: roleRow } = await supabase
+		.from(RolesTableName)
+		.select("role")
+		.eq("user_id", userId)
+		.maybeSingle();
+
+	return roleRow?.role === AppRole.Admin ? AppRole.Admin : AppRole.User;
 };
 
 export const getAllSnippets = async (): Promise<Snippet[]> => {

--- a/app/lib/supabase/roles.ts
+++ b/app/lib/supabase/roles.ts
@@ -1,0 +1,91 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+
+import { AppRole, RoleClaimKey, RolesTableName } from "@/lib/constants/roles";
+import createSupabaseAdminClient from "@/lib/supabase/admin";
+
+// Coerces any stored/claimed value into a known role, defaulting to User.
+export const normalizeRole = (value: unknown): AppRole =>
+	value === AppRole.Admin ? AppRole.Admin : AppRole.User;
+
+export const isAdminRole = (role: AppRole): boolean => role === AppRole.Admin;
+
+// Reads the role from the JWT (zero database round-trip) when the custom access
+// token hook is registered. Returns null when the claim is absent.
+const readRoleFromClaims = async (
+	client: SupabaseClient
+): Promise<AppRole | null> => {
+	const { data } = await client.auth.getClaims();
+	// The hook injects `user_role`; the typed JwtPayload doesn't know about it.
+	const claims = data?.claims as Record<string, unknown> | undefined;
+	const claimed = claims?.[RoleClaimKey];
+
+	if (claimed === AppRole.Admin || claimed === AppRole.User) {
+		return claimed;
+	}
+
+	return null;
+};
+
+// Resolves the role for the *current* session client: JWT claim first, then a
+// direct read of the user's own row (allowed by RLS) as a fallback. Works in
+// both the proxy and Server Components.
+export const resolveUserRole = async (
+	client: SupabaseClient,
+	userId: string
+): Promise<AppRole> => {
+	const claimRole = await readRoleFromClaims(client);
+
+	if (claimRole) {
+		return claimRole;
+	}
+
+	const { data } = await client
+		.from(RolesTableName)
+		.select("role")
+		.eq("user_id", userId)
+		.maybeSingle();
+
+	return normalizeRole(data?.role);
+};
+
+// Bulk role lookup for arbitrary users via the service-role client (bypasses
+// RLS). Used by the admin user list. Missing users default to User.
+export const fetchRoleMap = async (
+	userIds: string[]
+): Promise<Record<string, AppRole>> => {
+	if (userIds.length === 0) {
+		return {};
+	}
+
+	const admin = createSupabaseAdminClient();
+	const { data } = await admin
+		.from(RolesTableName)
+		.select("user_id, role")
+		.in("user_id", userIds);
+
+	const map: Record<string, AppRole> = {};
+
+	(data ?? []).forEach((row: { user_id: string; role: string }) => {
+		map[row.user_id] = normalizeRole(row.role);
+	});
+
+	return map;
+};
+
+// Sets (upserts) a user's role via the service-role client. Note: the change
+// only reaches an existing session's JWT after its next token refresh; the
+// admin UI reflects the DB value immediately because it re-reads the table.
+export const setUserRole = async (
+	userId: string,
+	role: AppRole
+): Promise<{ error: string | null }> => {
+	const admin = createSupabaseAdminClient();
+	const { error } = await admin
+		.from(RolesTableName)
+		.upsert(
+			{ user_id: userId, role, updated_at: new Date().toISOString() },
+			{ onConflict: "user_id" }
+		);
+
+	return { error: error?.message ?? null };
+};

--- a/app/lib/supabase/serverComponent.ts
+++ b/app/lib/supabase/serverComponent.ts
@@ -1,0 +1,42 @@
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
+import { SupabaseClient } from "@supabase/supabase-js";
+
+// Supabase client for React Server Components / server-side route guards.
+// Unlike server.ts (which is request/response based for the proxy), this reads
+// the session from next/headers cookies. Cookie writes are a no-op because RSCs
+// cannot mutate cookies — the proxy refreshes the session on navigation.
+const createSupabaseServerComponentClient =
+	async (): Promise<SupabaseClient> => {
+		const cookieStore = await cookies();
+
+		return createServerClient(
+			process.env.NEXT_PUBLIC_SUPABASE_URL!,
+			process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+			{
+				cookies: {
+					getAll() {
+						return cookieStore.getAll();
+					},
+					setAll(
+						cookiesToSet: {
+							name: string;
+							value: string;
+							options: Record<string, unknown>;
+						}[]
+					) {
+						try {
+							cookiesToSet.forEach(({ name, value, options }) =>
+								cookieStore.set(name, value, options)
+							);
+						} catch {
+							// Mutating cookies from a Server Component throws; the proxy
+							// handles session refresh, so swallowing this is safe.
+						}
+					},
+				},
+			}
+		);
+	};
+
+export default createSupabaseServerComponentClient;

--- a/app/utils/date.utils.ts
+++ b/app/utils/date.utils.ts
@@ -18,4 +18,7 @@ const formatDateToDDMMYYYY = (dateString: string): string => {
 	return "";
 };
 
+// ISO timestamp → YYYY-MM-DD day bucket key.
+export const dayKey = (isoDate: string): string => isoDate.slice(0, 10);
+
 export default formatDateToDDMMYYYY;

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,12 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import createSupabaseServerClient from "@/lib/supabase/server";
 import { MfaAssuranceLevel } from "@/lib/constants/mfa";
+import {
+	AdminRoutePath,
+	AppRole,
+	NonAdminRedirectPath,
+} from "@/lib/constants/roles";
+import { resolveUserRole } from "@/lib/supabase/roles";
 
 export async function proxy(
 	request: NextRequest
@@ -16,6 +22,9 @@ export async function proxy(
 		request.nextUrl.pathname === "/snippets" ||
 		request.nextUrl.pathname.startsWith("/ai-assistant");
 	const isLoginPath = request.nextUrl.pathname === "/login";
+	const isAdminPath =
+		request.nextUrl.pathname === AdminRoutePath ||
+		request.nextUrl.pathname.startsWith(`${AdminRoutePath}/`);
 
 	// A session that still needs to step up to aal2 has not finished the MFA
 	// challenge yet. It must stay on /login to complete verification and must
@@ -35,6 +44,21 @@ export async function proxy(
 		);
 	})();
 
+	// Admin route guard. The role is read from the JWT claim (set by the custom
+	// access token hook) with a database fallback — see resolveUserRole. Any
+	// non-admin, unauthenticated, or MFA-pending request is bounced to /snippets.
+	if (isAdminPath) {
+		if (!user || isMfaPending) {
+			return NextResponse.redirect(new URL(NonAdminRedirectPath, request.url));
+		}
+
+		const role = await resolveUserRole(supabase, user.id);
+
+		if (role !== AppRole.Admin) {
+			return NextResponse.redirect(new URL(NonAdminRedirectPath, request.url));
+		}
+	}
+
 	// if user is fully signed in and the current path is /login redirect to /snippets
 	if (user && isLoginPath && !isMfaPending) {
 		return NextResponse.redirect(new URL("/snippets", request.url));
@@ -53,5 +77,12 @@ export async function proxy(
 
 // See "Matching Paths" below to learn more
 export const config = {
-	matcher: ["/", "/snippets", "/ai-assistant/:path*", "/login"],
+	matcher: [
+		"/",
+		"/snippets",
+		"/ai-assistant/:path*",
+		"/admin",
+		"/admin/:path*",
+		"/login",
+	],
 };

--- a/supabase/migrations/20260621090000_create_user_roles.sql
+++ b/supabase/migrations/20260621090000_create_user_roles.sql
@@ -1,0 +1,127 @@
+-- Migration: Role-Based Access Control (RBAC) foundation
+-- Creates the `app_role` enum, the `user_roles` table, supporting helpers,
+-- Row Level Security, a signup trigger, backfill, and the initial admin seed.
+--
+-- This migration is IDEMPOTENT: every statement guards against re-running so it
+-- can be applied safely against a database that already has part of it.
+
+-- ───────────────────────────── 1. app_role enum ─────────────────────────────
+-- Two-role model. New roles can be appended later with `alter type ... add value`.
+do $$
+begin
+	if not exists (select 1 from pg_type where typname = 'app_role') then
+		create type public.app_role as enum ('admin', 'user');
+	end if;
+end
+$$;
+
+-- ──────────────────────────── 2. user_roles table ───────────────────────────
+-- One row per user, keyed to auth.users. Deleting a user cascades the role away.
+create table if not exists public.user_roles (
+	user_id uuid primary key references auth.users (id) on delete cascade,
+	role public.app_role not null default 'user',
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now()
+);
+
+comment on table public.user_roles is
+	'Application authorization role for each auth user. One row per user; defaults to ''user''.';
+
+-- Keep updated_at fresh on every change.
+create or replace function public.set_user_roles_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+	new.updated_at = now();
+
+	return new;
+end;
+$$;
+
+drop trigger if exists trg_user_roles_updated_at on public.user_roles;
+create trigger trg_user_roles_updated_at
+	before update on public.user_roles
+	for each row execute function public.set_user_roles_updated_at();
+
+-- ───────────────────────────── 3. is_admin() helper ─────────────────────────
+-- SECURITY DEFINER so it can read user_roles without tripping the table's own
+-- RLS (which itself calls is_admin()), avoiding infinite recursion. search_path
+-- is pinned to '' to prevent search-path hijacking.
+create or replace function public.is_admin(check_user_id uuid default auth.uid())
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+	select exists (
+		select 1
+		from public.user_roles
+		where user_id = check_user_id
+			and role = 'admin'
+	);
+$$;
+
+-- ──────────────────────────────── 4. RLS ────────────────────────────────────
+alter table public.user_roles enable row level security;
+
+-- A user may read their own role; an admin may read every role.
+drop policy if exists "Read own role or admin reads all" on public.user_roles;
+create policy "Read own role or admin reads all"
+	on public.user_roles
+	for select
+	to authenticated
+	using (user_id = auth.uid() or public.is_admin());
+
+-- Only admins may write roles. This is the privilege-escalation guard: a normal
+-- client can never insert/update/delete a row to promote itself.
+drop policy if exists "Admins manage roles" on public.user_roles;
+create policy "Admins manage roles"
+	on public.user_roles
+	for all
+	to authenticated
+	using (public.is_admin())
+	with check (public.is_admin());
+
+-- ─────────────────────── 5. auto-assign role on signup ──────────────────────
+-- Every new auth user gets a 'user' row automatically.
+create or replace function public.handle_new_user_role()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+	insert into public.user_roles (user_id, role)
+	values (new.id, 'user')
+	on conflict (user_id) do nothing;
+
+	return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created_assign_role on auth.users;
+create trigger on_auth_user_created_assign_role
+	after insert on auth.users
+	for each row execute function public.handle_new_user_role();
+
+-- ─────────────────────────── 6. backfill existing ───────────────────────────
+-- Give every pre-existing user a default role so nobody is left without one.
+insert into public.user_roles (user_id, role)
+select id, 'user'
+from auth.users
+on conflict (user_id) do nothing;
+
+-- ───────────────────────────── 7. seed the admin ────────────────────────────
+-- Promote the designated administrator. Runs whether or not the account exists
+-- yet (no-op if it doesn't); re-running keeps the role at 'admin'.
+insert into public.user_roles (user_id, role)
+select id, 'admin'
+from auth.users
+where email = 'user@domain.com'
+on conflict (user_id) do update set role = 'admin', updated_at = now();
+
+-- ──────────────────────────────── 8. grants ─────────────────────────────────
+grant select on public.user_roles to authenticated;
+grant execute on function public.is_admin(uuid) to authenticated;

--- a/supabase/migrations/20260621090100_create_custom_access_token_hook.sql
+++ b/supabase/migrations/20260621090100_create_custom_access_token_hook.sql
@@ -1,0 +1,71 @@
+-- Migration: Custom Access Token (JWT) Hook
+-- Injects the user's application role as a `user_role` claim into every issued
+-- access token. This lets Next.js middleware authorize requests by reading the
+-- JWT claim with NO database round-trip.
+--
+-- IMPORTANT — the hook function alone does nothing until it is REGISTERED:
+--   • Hosted project: Dashboard → Authentication → Hooks →
+--     "Customize Access Token (JWT) Claims" → select
+--     `public.custom_access_token_hook`, then Save. New claims appear on the
+--     next token issue/refresh.
+--   • Local dev (supabase start): add to supabase/config.toml:
+--         [auth.hook.custom_access_token]
+--         enabled = true
+--         uri = "pg-functions://postgres/public/custom_access_token_hook"
+--
+-- The application reads the claim with a database fallback, so it behaves
+-- correctly whether or not the hook is registered (the fallback just costs one
+-- extra query until registration is done).
+--
+-- This migration is IDEMPOTENT.
+
+create or replace function public.custom_access_token_hook(event jsonb)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+	claims jsonb;
+	resolved_role public.app_role;
+begin
+	select role
+	into resolved_role
+	from public.user_roles
+	where user_id = (event->>'user_id')::uuid;
+
+	claims := coalesce(event->'claims', '{}'::jsonb);
+
+	if resolved_role is not null then
+		claims := jsonb_set(claims, '{user_role}', to_jsonb(resolved_role));
+	else
+		-- Anyone without an explicit row is treated as a plain user.
+		claims := jsonb_set(claims, '{user_role}', to_jsonb('user'::text));
+	end if;
+
+	event := jsonb_set(event, '{claims}', claims);
+
+	return event;
+end;
+$$;
+
+-- ─────────────────────────── permissions for the hook ───────────────────────
+-- The GoTrue auth server runs the hook as `supabase_auth_admin`; it needs to
+-- execute the function and read the roles table. Everyone else is locked out of
+-- executing the hook directly.
+grant usage on schema public to supabase_auth_admin;
+grant execute on function public.custom_access_token_hook(jsonb) to supabase_auth_admin;
+revoke execute on function public.custom_access_token_hook(jsonb) from authenticated, anon, public;
+
+grant select on table public.user_roles to supabase_auth_admin;
+
+-- Allow the auth admin to read roles from inside the hook (RLS bypass for this
+-- specific principal only).
+drop policy if exists "Auth admin reads roles for token hook" on public.user_roles;
+create policy "Auth admin reads roles for token hook"
+	on public.user_roles
+	as permissive
+	for select
+	to supabase_auth_admin
+	using (true);

--- a/supabase/migrations/20260622090000_admin_revoke_sessions.sql
+++ b/supabase/migrations/20260622090000_admin_revoke_sessions.sql
@@ -1,0 +1,30 @@
+-- Migration: force sign-out (disconnect) support
+-- Lets an admin revoke a user's active auth sessions, forcing them to log in
+-- again with their email + password. Exposed as an RPC callable by the
+-- service-role client only (the admin API route).
+--
+-- Deleting the user's rows from auth.sessions invalidates their sessions:
+-- supabase.auth.getUser() (called by the proxy on every protected request)
+-- then fails server-side and the user is redirected to /login. Linked
+-- refresh tokens cascade from the sessions table.
+--
+-- IDEMPOTENT.
+
+create or replace function public.admin_revoke_user_sessions(target_user uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+	delete from auth.sessions where user_id = target_user;
+end;
+$$;
+
+revoke execute on function public.admin_revoke_user_sessions(uuid)
+	from authenticated, anon, public;
+grant execute on function public.admin_revoke_user_sessions(uuid) to service_role;
+
+-- Refresh PostgREST's schema cache so the RPC is callable immediately (otherwise
+-- the API returns "Could not find the function ... in the schema cache").
+notify pgrst, 'reload schema';

--- a/types/admin.d.ts
+++ b/types/admin.d.ts
@@ -1,0 +1,124 @@
+import { AppRole } from "@/lib/constants/roles";
+
+declare global {
+	// A user as presented in the admin dashboard. Assembled server-side from the
+	// Supabase Admin API (auth.users) + the user_roles table.
+	interface AdminUser {
+		createdAt: string;
+		email: string;
+		id: string;
+		isDemo: boolean;
+		isDisabled: boolean;
+		lastSignInAt: string | null;
+		role: AppRole;
+		theme: string;
+		username: string;
+	}
+
+	type AdminUsersResponse = {
+		total: number;
+		users: AdminUser[];
+	};
+
+	type AdminUserCreatePayload = {
+		email: string;
+		password: string;
+		role?: AppRole;
+		theme?: string;
+		username?: string;
+	};
+
+	type AdminUserUpdatePayload = {
+		email?: string;
+		isDisabled?: boolean;
+		role?: AppRole;
+		theme?: string;
+		username?: string;
+	};
+
+	// Flat form state shared between the user form modal and its container.
+	type AdminUserFormValues = {
+		email: string;
+		isDisabled: boolean;
+		password: string;
+		role: AppRole;
+		theme: string;
+		username: string;
+	};
+
+	// Generic shape consumed by the chart primitives.
+	type ChartDatum = {
+		color?: string;
+		label: string;
+		value: number;
+	};
+
+	// Projection of the `snippet` table used by the analytics aggregator.
+	type AnalyticsSnippetRow = {
+		created_at: string;
+		folder: string | null;
+		is_public: boolean;
+		language: string;
+		state: string;
+		tags: string | null;
+		user_id: string;
+	};
+
+	type LanguageDatum = {
+		count: number;
+		language: string;
+	};
+
+	type ContributorDatum = {
+		count: number;
+		email: string;
+		userId: string;
+	};
+
+	type SnippetTrendPoint = {
+		count: number;
+		label: string;
+	};
+
+	type TagDatum = {
+		count: number;
+		tag: string;
+	};
+
+	type FolderDatum = {
+		count: number;
+		folder: string;
+	};
+
+	type SavedSearchDatum = {
+		count: number;
+		name: string;
+	};
+
+	interface SnippetAnalytics {
+		activeUsers: number;
+		averagePerUser: number;
+		dailyTrend: SnippetTrendPoint[];
+		favoriteCount: number;
+		folderCount: number;
+		folderDistribution: FolderDatum[];
+		generatedAt: string;
+		languageDistribution: LanguageDatum[];
+		monthlyTrend: SnippetTrendPoint[];
+		mostUsedLanguage: string | null;
+		newUsersLast30Days: number;
+		publicCount: number;
+		savedSearchCount: number;
+		savedSearches: SavedSearchDatum[];
+		tagDistribution: TagDatum[];
+		topContributors: ContributorDatum[];
+		totalSnippets: number;
+		totalUsers: number;
+		totalVersions: number;
+		uncategorizedCount: number;
+		uniqueTagCount: number;
+		weeklyTrend: SnippetTrendPoint[];
+	}
+}
+
+export {};

--- a/types/ui.d.ts
+++ b/types/ui.d.ts
@@ -5,6 +5,19 @@ declare global {
 
 	type Severity = "error" | "warning" | "info" | "success";
 	type SnapshotPadding = "lg" | "md" | "sm" | "xl";
+
+	type TableColumn = {
+		align?: "right";
+		label: string;
+	};
+
+	type MenuItem = {
+		danger?: boolean;
+		disabled?: boolean;
+		icon?: ReactNode;
+		label: string;
+		onSelect: () => void;
+	};
 	type Variants =
 		| "primary"
 		| "secondary"


### PR DESCRIPTION
## Summary

Adds a full admin panel with role-based access control to the snippets app.

### New features
- **Admin dashboard** (`/admin`) with user management, snippet analytics, and session control
- **Role-based access control** via Supabase custom access token hook — admin role injected into JWT claims
- **Admin route guard** in proxy middleware — non-admins redirected to `/snippets`
- **User management** — list users, reset passwords, revoke sessions, toggle ban status
- **Snippet analytics** — area/bar/donut charts for snippet creation trends and language breakdown
- **Disabled user handling** — friendly error message on login for banned accounts

### New UI primitives
- `Card`, `Menu`, `Table`, `Tooltip` components
- `ShieldCheck`, `DotsThreeVertical` icons
- Button `pill` shape variant

### Improvements
- Alert severity colors now track the active theme via `color-mix`
- FeatureCard refactored to use shared `Card` primitive
- Added `dayKey` date utility

### Database migrations
- `20260621090000_create_user_roles.sql` — user_roles table
- `20260621090100_create_custom_access_token_hook.sql` — JWT claim injection
- `20260622090000_admin_revoke_sessions.sql` — session revocation RPC