### PR TITLE
fix(config): replace disableLogger with treeshake removeDebugLogging

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,5 +30,9 @@ export default withSentryConfig(nextConfig, {
 	project: "snippets",
 	silent: !process.env.CI,
 	widenClientFileUpload: true,
-	disableLogger: true,
+	webpack: {
+		treeshake: {
+			removeDebugLogging: true,
+		},
+	},
 });


### PR DESCRIPTION
Replaces deprecated `disableLogger` option in Sentry config with `webpack.treeshake.removeDebugLogging`.