### PR TITLE
feat(editor): add HTML preview and code console renderer

### DIFF
--- a/app/components/CodeConsole/CodeConsole.tsx
+++ b/app/components/CodeConsole/CodeConsole.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { ReactElement, useEffect, useRef, useState } from "react";
+
+/* Lib */
+import SupportedLanguages from "@/lib/config/languages";
+import { prepareConsoleCode } from "@/lib/consoleRunner";
+import {
+	ConsoleEntryLevels,
+	ConsoleMessageLevel,
+	ConsoleMessageSource,
+	ConsoleRunMessageSource,
+	ConsoleRunTimeoutMs,
+	ConsoleSandboxDocument,
+} from "@/lib/constants/preview.constants";
+
+/* Components */
+import Play from "@/components/ui/icons/Play";
+import Trash from "@/components/ui/icons/Trash";
+
+/* Styles */
+import styles from "./codeConsole.module.css";
+
+type CodeConsoleProps = {
+	code: string;
+	height: string;
+	language: SupportedLanguages;
+};
+
+const CodeConsole = ({
+	code,
+	height,
+	language,
+}: CodeConsoleProps): ReactElement => {
+	const [entries, setEntries] = useState<ConsoleEntry[]>([]);
+	const [isRunning, setIsRunning] = useState(false);
+	const [sandboxGeneration, setSandboxGeneration] = useState(0);
+	const iframeRef = useRef<HTMLIFrameElement | null>(null);
+	const nextEntryIdRef = useRef(0);
+	const pendingCodeRef = useRef<string | null>(null);
+	const timeoutRef = useRef<number | null>(null);
+
+	const appendEntry = (level: ConsoleMessageLevel, text: string): void => {
+		nextEntryIdRef.current += 1;
+
+		const entry: ConsoleEntry = { id: nextEntryIdRef.current, level, text };
+
+		setEntries((previousEntries) => [...previousEntries, entry]);
+	};
+
+	const clearRunTimeout = (): void => {
+		if (timeoutRef.current !== null) {
+			window.clearTimeout(timeoutRef.current);
+			timeoutRef.current = null;
+		}
+	};
+
+	useEffect(() => {
+		const handleSandboxMessage = (event: MessageEvent): void => {
+			// Only trust messages coming from our own sandbox frame
+			if (event.source !== iframeRef.current?.contentWindow) {
+				return;
+			}
+
+			// Shape assumed for field access only — every field the frame sends
+			// is attacker-controlled and re-validated below before use
+			const data = event.data as ConsoleSandboxMessage;
+
+			if (!data || data.source !== ConsoleMessageSource) {
+				return;
+			}
+
+			if (data.level === ConsoleMessageLevel.Done) {
+				clearRunTimeout();
+				setIsRunning(false);
+
+				return;
+			}
+
+			if (
+				!ConsoleEntryLevels.includes(data.level) ||
+				typeof data.text !== "string"
+			) {
+				return;
+			}
+
+			appendEntry(data.level, data.text);
+		};
+
+		window.addEventListener("message", handleSandboxMessage);
+
+		return () => {
+			window.removeEventListener("message", handleSandboxMessage);
+		};
+	}, []);
+
+	useEffect(() => clearRunTimeout, []);
+
+	const runHandler = async (): Promise<void> => {
+		if (isRunning) {
+			return;
+		}
+
+		setEntries([]);
+		setIsRunning(true);
+
+		try {
+			pendingCodeRef.current = await prepareConsoleCode(code, language);
+
+			// Remount the frame so timers and promises left over from the
+			// previous run die before this run starts; handleFrameLoad posts
+			// the pending code once the fresh frame is ready.
+			setSandboxGeneration((generation) => generation + 1);
+		} catch (transpileError) {
+			appendEntry(
+				ConsoleMessageLevel.Error,
+				transpileError instanceof Error
+					? transpileError.message
+					: String(transpileError)
+			);
+			setIsRunning(false);
+		}
+	};
+
+	const handleFrameLoad = (): void => {
+		const sandboxWindow = iframeRef.current?.contentWindow;
+		const pendingCode = pendingCodeRef.current;
+
+		if (!sandboxWindow || pendingCode === null) {
+			return;
+		}
+
+		pendingCodeRef.current = null;
+
+		timeoutRef.current = window.setTimeout(() => {
+			timeoutRef.current = null;
+			appendEntry(ConsoleMessageLevel.Error, "Execution timed out");
+			setIsRunning(false);
+
+			// Remount the frame to tear down whatever is still running in it
+			setSandboxGeneration((generation) => generation + 1);
+		}, ConsoleRunTimeoutMs);
+
+		// An opaque sandbox origin can only be targeted with "*"
+		sandboxWindow.postMessage(
+			{ code: pendingCode, source: ConsoleRunMessageSource },
+			"*"
+		);
+	};
+
+	return (
+		<div className={styles.consoleContainer} style={{ height }}>
+			<div className={styles.consoleHeader}>
+				<span className={styles.consoleTitle}>Console</span>
+				<div className={styles.consoleActions}>
+					<button
+						aria-label="Run code"
+						className={styles.consoleButton}
+						disabled={isRunning}
+						onClick={runHandler}
+						title="Run code"
+						type="button"
+					>
+						<Play height={14} width={14} />
+					</button>
+					<button
+						aria-label="Clear console"
+						className={styles.consoleButton}
+						onClick={() => setEntries([])}
+						title="Clear console"
+						type="button"
+					>
+						<Trash height={14} width={14} />
+					</button>
+				</div>
+			</div>
+			<div className={styles.consoleOutput}>
+				{entries.length === 0 ? (
+					<span className={styles.consoleEmpty}>
+						{isRunning ? "Running…" : "Press run to execute the snippet"}
+					</span>
+				) : (
+					entries.map((entry) => (
+						<div
+							className={`${styles.consoleEntry} ${styles[entry.level] ?? ""}`}
+							key={entry.id}
+						>
+							{entry.text}
+						</div>
+					))
+				)}
+			</div>
+			{/* allow-scripts only: opaque origin, no cookies/storage/parent DOM;
+			    the document's CSP additionally denies all network access */}
+			<iframe
+				className={styles.sandboxFrame}
+				key={sandboxGeneration}
+				onLoad={handleFrameLoad}
+				ref={iframeRef}
+				sandbox="allow-scripts"
+				srcDoc={ConsoleSandboxDocument}
+				title="Code execution sandbox"
+			/>
+		</div>
+	);
+};
+
+export default CodeConsole;

--- a/app/components/CodeConsole/codeConsole.module.css
+++ b/app/components/CodeConsole/codeConsole.module.css
@@ -1,0 +1,122 @@
+.consoleContainer {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	border-left: 1px solid var(--border-color);
+	background: var(--bg-color-dark);
+}
+
+.consoleHeader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	height: 2rem;
+	padding: 0 0.75rem;
+	background: var(--bg-color-dark);
+	border-bottom: 1px solid var(--border-color);
+	flex-shrink: 0;
+}
+
+.consoleTitle {
+	font-size: var(--smaller-font-size);
+	color: var(--gray-color);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.consoleActions {
+	display: flex;
+	align-items: center;
+	gap: 0.25rem;
+}
+
+.consoleButton {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0.25rem;
+	background: transparent;
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	color: var(--gray-color);
+	transition:
+		color 0.2s ease,
+		background-color 0.2s ease,
+		transform 0.15s ease;
+}
+
+.consoleButton:hover {
+	background: var(--bg-color);
+	color: var(--cyan-color);
+}
+
+.consoleButton:active {
+	transform: scale(0.95);
+}
+
+.consoleButton:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 2px var(--cyan-color);
+}
+
+.consoleButton:disabled {
+	opacity: 0.4;
+	cursor: default;
+}
+
+.consoleOutput {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 0.75rem 1rem;
+	color: var(--foreground-color);
+	font-family: monospace;
+	font-size: var(--smaller-font-size);
+	line-height: 1.5;
+}
+
+.consoleEmpty {
+	color: var(--gray-color);
+}
+
+.consoleEntry {
+	padding: 0.125rem 0;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.warn {
+	color: var(--yellow-color);
+}
+
+.error {
+	color: var(--red-color);
+}
+
+.sandboxFrame {
+	display: none;
+}
+
+.consoleOutput::-webkit-scrollbar {
+	width: 10px;
+}
+
+.consoleOutput::-webkit-scrollbar-track {
+	background: var(--bg-color);
+}
+
+.consoleOutput::-webkit-scrollbar-thumb {
+	background: var(--bg-color-dark);
+}
+
+/* Mobile: no left border, add top border instead */
+@media (width < 1140px) {
+	.consoleContainer {
+		flex: none;
+		border-left: none;
+		border-top: 1px solid var(--border-color);
+	}
+}

--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -15,6 +15,10 @@ import useViewPortStore from "@/lib/store/viewPort.store";
 import useUserStore from "@/lib/store/user.store";
 import codeMirrorOptions from "@/lib/constants/codeMirror";
 import { MenuPrefixes, SnippetState } from "@/lib/constants/core";
+import {
+	LanguagePreviewKinds,
+	PreviewKind,
+} from "@/lib/constants/preview.constants";
 import { getCodeMirrorTheme, ThemeName } from "@/lib/config/themes";
 import { aiActions, AiPaneTab } from "@/lib/constants/ai";
 import { requestAiAction } from "@/utils/ai.utils";
@@ -32,6 +36,8 @@ import MarkdownToolbar from "@/components/CodeEditor/MarkdownToolbar";
 import SnippetDetails from "@/components/CodeEditor/SnippetDetails/SnippetDetails";
 import History from "@/components/History/History";
 import MarkdownPreview from "@/components/MarkdownPreview/MarkdownPreview";
+import HtmlPreview from "@/components/HtmlPreview/HtmlPreview";
+import CodeConsole from "@/components/CodeConsole/CodeConsole";
 import AiAssistantPanel from "@/components/AiAssistantPanel/AiAssistantPanel";
 import SkeletonCodeEditor from "@/components/ui/Skeleton/SkeletonCodeEditor";
 import EmptyState from "@/components/ui/EmptyState/EmptyState";
@@ -87,6 +93,7 @@ const CodeEditor = ({
 	const { menuType } = codeEditorStates ?? {};
 	const isTrashActive = menuType === "trash";
 	const [mobileChatTab, setMobileChatTab] = useState<AiPaneTab>(AiPaneTab.Chat);
+	const [isPreviewVisible, setIsPreviewVisible] = useState(true);
 	const editorContentRef = useRef<HTMLDivElement>(null);
 	const editorViewRef = useRef<EditorView | null>(null);
 	const editorTheme = useMemo(() => getCodeMirrorTheme(theme), [theme]);
@@ -160,11 +167,19 @@ const CodeEditor = ({
 
 	const isMarkdownLanguage =
 		currentSnippet?.language === SupportedLanguages.Markdown;
+	const previewKind =
+		LanguagePreviewKinds[currentSnippet.language] ?? PreviewKind.None;
+	const hasPreviewPanel = previewKind !== PreviewKind.None;
 	const isChatMode = rightPane === "chat";
-	const showPreview = !isChatMode && isMarkdownLanguage && !isTrashActive;
+	const showPreview =
+		!isChatMode && hasPreviewPanel && !isTrashActive && isPreviewVisible;
 	const showChatPane = isChatMode && !isTrashActive;
 	const hasRightPane = showPreview || showChatPane;
-	const showMarkdownToolbar = !isMobile && isMarkdownLanguage && !isTrashActive;
+	const showPreviewToggle = hasPreviewPanel && !isChatMode;
+	const showMarkdownToolbar =
+		!isMobile &&
+		!isTrashActive &&
+		(isMarkdownLanguage || (hasPreviewPanel && !isChatMode));
 
 	const editorHeight = calculateEditorHeight({
 		hasMarkdownToolbar: showMarkdownToolbar,
@@ -291,120 +306,128 @@ const CodeEditor = ({
 						</>
 					)}
 
-					{hasRightPane ? (
-						<div
-							ref={editorContentRef}
-							className={isMobile ? styles.splitViewMobile : styles.splitView}
-						>
-							{showChatPane && isMobile && (
-								<div className={styles.chatTabs} role="tablist">
-									<button
-										type="button"
-										role="tab"
-										aria-selected={mobileChatTab === AiPaneTab.Chat}
-										className={`${styles.chatTab} ${mobileChatTab === AiPaneTab.Chat ? styles.chatTabActive : ""}`}
-										onClick={() => setMobileChatTab(AiPaneTab.Chat)}
-									>
-										Chat
-									</button>
-									<button
-										type="button"
-										role="tab"
-										aria-selected={mobileChatTab === AiPaneTab.Code}
-										className={`${styles.chatTab} ${mobileChatTab === AiPaneTab.Code ? styles.chatTabActive : ""}`}
-										onClick={() => setMobileChatTab(AiPaneTab.Code)}
-									>
-										Code
-									</button>
-								</div>
-							)}
+					{/* One stable tree for every mode: the right pane, resizer, and
+					    toolbar toggle in and out around a single CodeMirror instance,
+					    so toggling the preview never remounts the editor (which would
+					    wipe undo history, cursor, and scroll position). */}
+					<div
+						ref={editorContentRef}
+						className={isMobile ? styles.splitViewMobile : styles.splitView}
+					>
+						{showChatPane && isMobile && (
+							<div className={styles.chatTabs} role="tablist">
+								<button
+									type="button"
+									role="tab"
+									aria-selected={mobileChatTab === AiPaneTab.Chat}
+									className={`${styles.chatTab} ${mobileChatTab === AiPaneTab.Chat ? styles.chatTabActive : ""}`}
+									onClick={() => setMobileChatTab(AiPaneTab.Chat)}
+								>
+									Chat
+								</button>
+								<button
+									type="button"
+									role="tab"
+									aria-selected={mobileChatTab === AiPaneTab.Code}
+									className={`${styles.chatTab} ${mobileChatTab === AiPaneTab.Code ? styles.chatTabActive : ""}`}
+									onClick={() => setMobileChatTab(AiPaneTab.Code)}
+								>
+									Code
+								</button>
+							</div>
+						)}
 
+						<div
+							className={`${styles.editorPanel} ${
+								showChatPane && isMobile && mobileChatTab !== AiPaneTab.Code
+									? styles.paneHidden
+									: ""
+							}`}
+							style={
+								!isMobile
+									? { width: hasRightPane ? `${editorWidthPercent}%` : "100%" }
+									: undefined
+							}
+						>
+							{showMarkdownToolbar && (
+								<MarkdownToolbar
+									getEditorView={() => editorViewRef.current}
+									isPreviewVisible={isPreviewVisible}
+									onTogglePreview={() => setIsPreviewVisible(!isPreviewVisible)}
+									showFormattingActions={isMarkdownLanguage}
+									showPreviewToggle={showPreviewToggle}
+								/>
+							)}
+							<CodeMirror
+								autoFocus={false}
+								indentWithTab={true}
+								basicSetup={
+									isTrashActive ? { lineNumbers: true } : codeMirrorOptions
+								}
+								placeholder={"Write your snipped here"}
+								className={styles.codeMirrorContainer}
+								value={currentSnippet?.snippet ?? ""}
+								extensions={[
+									currentSnippet.extension,
+									inlineCompletionExtension,
+									wikiAutocompleteExtension,
+									...(isMarkdownLanguage && !isTrashActive
+										? [markdownKeymap]
+										: []),
+								]}
+								theme={editorTheme}
+								height={
+									showChatPane && isMobile ? chatTabPaneHeight : editorHeight
+								}
+								width="100%"
+								readOnly={isTrashActive}
+								onChange={updateCurrentSnippetValue}
+								onCreateEditor={(view) => {
+									editorViewRef.current = view;
+								}}
+							/>
+						</div>
+						{!isMobile && hasRightPane && (
 							<div
-								className={`${styles.editorPanel} ${
-									showChatPane && isMobile && mobileChatTab !== AiPaneTab.Code
+								className={styles.previewResizer}
+								onMouseDown={handlePreviewMouseDown}
+							/>
+						)}
+						{showChatPane ? (
+							<AiAssistantPanel
+								currentSnippet={currentSnippet}
+								allSnippets={allSnippets}
+								height={isMobile ? chatTabPaneHeight : previewHeight}
+								className={
+									isMobile && mobileChatTab !== AiPaneTab.Chat
 										? styles.paneHidden
 										: ""
-								}`}
-								style={
-									!isMobile ? { width: `${editorWidthPercent}%` } : undefined
 								}
-							>
-								{showMarkdownToolbar && (
-									<MarkdownToolbar
-										getEditorView={() => editorViewRef.current}
-									/>
-								)}
-								<CodeMirror
-									autoFocus={false}
-									indentWithTab={true}
-									basicSetup={codeMirrorOptions}
-									placeholder={"Write your snipped here"}
-									className={styles.codeMirrorContainer}
-									value={currentSnippet?.snippet ?? ""}
-									extensions={[
-										currentSnippet.extension,
-										inlineCompletionExtension,
-										wikiAutocompleteExtension,
-										...(isMarkdownLanguage ? [markdownKeymap] : []),
-									]}
-									theme={editorTheme}
-									height={
-										showChatPane && isMobile ? chatTabPaneHeight : editorHeight
-									}
-									width="100%"
-									onChange={updateCurrentSnippetValue}
-									onCreateEditor={(view) => {
-										editorViewRef.current = view;
-									}}
-								/>
-							</div>
-							{!isMobile && (
-								<div
-									className={styles.previewResizer}
-									onMouseDown={handlePreviewMouseDown}
-								/>
-							)}
-							{showChatPane ? (
-								<AiAssistantPanel
-									currentSnippet={currentSnippet}
-									allSnippets={allSnippets}
-									height={isMobile ? chatTabPaneHeight : previewHeight}
-									className={
-										isMobile && mobileChatTab !== AiPaneTab.Chat
-											? styles.paneHidden
-											: ""
-									}
-									onCopyToSnippet={handleCopyToSnippet}
-									onReplaceSnippet={updateCurrentSnippetValue}
-									onSelectSnippet={onActiveSnippet}
-									onNewSnippet={onNewSnippet}
-								/>
-							) : (
-								<MarkdownPreview
-									content={currentSnippet.snippet}
-									height={previewHeight}
-									onWikiNavigate={onWikiNavigate}
-								/>
-							)}
-						</div>
-					) : (
-						<CodeMirror
-							autoFocus={false}
-							indentWithTab={true}
-							basicSetup={
-								isTrashActive ? { lineNumbers: true } : codeMirrorOptions
-							}
-							placeholder={"Write your snipped here"}
-							className={styles.codeMirrorContainer}
-							value={currentSnippet?.snippet ?? ""}
-							extensions={[currentSnippet.extension, wikiAutocompleteExtension]}
-							theme={editorTheme}
-							height={editorHeight}
-							width="100%"
-							readOnly={isTrashActive}
-							onChange={updateCurrentSnippetValue}
-						/>
-					)}
+								onCopyToSnippet={handleCopyToSnippet}
+								onReplaceSnippet={updateCurrentSnippetValue}
+								onSelectSnippet={onActiveSnippet}
+								onNewSnippet={onNewSnippet}
+							/>
+						) : !showPreview ? null : previewKind === PreviewKind.Html ? (
+							<HtmlPreview
+								content={currentSnippet.snippet ?? ""}
+								height={previewHeight}
+							/>
+						) : previewKind === PreviewKind.Console ? (
+							<CodeConsole
+								key={currentSnippet.snippet_id}
+								code={currentSnippet.snippet ?? ""}
+								height={previewHeight}
+								language={currentSnippet.language}
+							/>
+						) : (
+							<MarkdownPreview
+								content={currentSnippet.snippet}
+								height={previewHeight}
+								onWikiNavigate={onWikiNavigate}
+							/>
+						)}
+					</div>
 				</>
 			) : (
 				<EmptyState

--- a/app/components/CodeEditor/MarkdownToolbar.tsx
+++ b/app/components/CodeEditor/MarkdownToolbar.tsx
@@ -3,6 +3,10 @@ import { Fragment, ReactElement } from "react";
 /* Lib */
 import markdownToolbarActions from "@/lib/markdown/markdownToolbarActions";
 
+/* Components */
+import EyeClosed from "@/components/ui/icons/EyeClosed";
+import EyeOpen from "@/components/ui/icons/EyeOpen";
+
 /* Types */
 import type { EditorView } from "@codemirror/view";
 
@@ -11,10 +15,18 @@ import styles from "./markdownToolbar.module.css";
 
 type MarkdownToolbarProps = {
 	getEditorView: () => EditorView | null;
+	isPreviewVisible: boolean;
+	onTogglePreview: () => void;
+	showFormattingActions: boolean;
+	showPreviewToggle: boolean;
 };
 
 const MarkdownToolbar = ({
 	getEditorView,
+	isPreviewVisible,
+	onTogglePreview,
+	showFormattingActions,
+	showPreviewToggle,
 }: MarkdownToolbarProps): ReactElement => {
 	const runAction = (apply: (view: EditorView) => void): void => {
 		const editorView = getEditorView();
@@ -26,32 +38,53 @@ const MarkdownToolbar = ({
 		apply(editorView);
 	};
 
+	const previewToggleLabel = isPreviewVisible ? "Hide preview" : "Show preview";
+
 	return (
 		<div
-			aria-label="Markdown formatting"
+			aria-label={
+				showFormattingActions ? "Markdown formatting" : "Editor toolbar"
+			}
 			className={styles.toolbar}
 			role="toolbar"
 		>
-			{markdownToolbarActions.map((action) => {
-				const ActionIcon = action.icon;
+			{showFormattingActions &&
+				markdownToolbarActions.map((action) => {
+					const ActionIcon = action.icon;
 
-				return (
-					<Fragment key={action.label}>
-						{action.hasDividerBefore ? (
-							<span aria-hidden="true" className={styles.divider} />
-						) : null}
-						<button
-							aria-label={action.label}
-							className={styles.toolbarButton}
-							onClick={() => runAction(action.apply)}
-							title={action.label}
-							type="button"
-						>
-							<ActionIcon height={16} width={16} />
-						</button>
-					</Fragment>
-				);
-			})}
+					return (
+						<Fragment key={action.label}>
+							{action.hasDividerBefore ? (
+								<span aria-hidden="true" className={styles.divider} />
+							) : null}
+							<button
+								aria-label={action.label}
+								className={styles.toolbarButton}
+								onClick={() => runAction(action.apply)}
+								title={action.label}
+								type="button"
+							>
+								<ActionIcon height={16} width={16} />
+							</button>
+						</Fragment>
+					);
+				})}
+			{showPreviewToggle && (
+				<button
+					aria-label={previewToggleLabel}
+					aria-pressed={isPreviewVisible}
+					className={`${styles.toolbarButton} ${styles.previewToggle}`}
+					onClick={onTogglePreview}
+					title={previewToggleLabel}
+					type="button"
+				>
+					{isPreviewVisible ? (
+						<EyeOpen height={16} width={16} />
+					) : (
+						<EyeClosed height={16} width={16} />
+					)}
+				</button>
+			)}
 		</div>
 	);
 };

--- a/app/components/CodeEditor/markdownToolbar.module.css
+++ b/app/components/CodeEditor/markdownToolbar.module.css
@@ -46,3 +46,7 @@
 	margin: 0 0.375rem;
 	background: var(--border-color);
 }
+
+.previewToggle {
+	margin-left: auto;
+}

--- a/app/components/HtmlPreview/HtmlPreview.tsx
+++ b/app/components/HtmlPreview/HtmlPreview.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ReactElement, useMemo } from "react";
+
+/* Lib */
+import { buildHtmlPreviewDocument } from "@/lib/htmlPreviewRenderer";
+
+/* Styles */
+import styles from "./htmlPreview.module.css";
+
+type HtmlPreviewProps = {
+	content: string;
+	height: string;
+};
+
+const HtmlPreview = ({ content, height }: HtmlPreviewProps): ReactElement => {
+	const previewDocument = useMemo(
+		() => buildHtmlPreviewDocument(content),
+		[content]
+	);
+
+	return (
+		<div className={styles.previewContainer} style={{ height }}>
+			<div className={styles.previewHeader}>
+				<span className={styles.previewTitle}>Preview</span>
+			</div>
+			{/* sandbox="" grants nothing: opaque origin, no scripts, no forms,
+			    no popups — the rendered document cannot touch the parent app */}
+			<iframe
+				className={styles.previewFrame}
+				referrerPolicy="no-referrer"
+				sandbox=""
+				srcDoc={previewDocument}
+				title="HTML preview"
+			/>
+		</div>
+	);
+};
+
+export default HtmlPreview;

--- a/app/components/HtmlPreview/htmlPreview.module.css
+++ b/app/components/HtmlPreview/htmlPreview.module.css
@@ -1,0 +1,45 @@
+.previewContainer {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	border-left: 1px solid var(--border-color);
+	background: var(--bg-color-dark);
+}
+
+.previewHeader {
+	display: flex;
+	align-items: center;
+	height: 2rem;
+	padding: 0 0.75rem;
+	background: var(--bg-color-dark);
+	border-bottom: 1px solid var(--border-color);
+	flex-shrink: 0;
+}
+
+.previewTitle {
+	font-size: var(--smaller-font-size);
+	color: var(--gray-color);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.previewFrame {
+	flex: 1;
+	min-height: 0;
+	width: 100%;
+	border: none;
+
+	/* Rendered HTML expects a light page background regardless of app theme */
+	background: #fff;
+}
+
+/* Mobile: no left border, add top border instead */
+@media (width < 1140px) {
+	.previewContainer {
+		flex: none;
+		border-left: none;
+		border-top: 1px solid var(--border-color);
+	}
+}

--- a/app/components/ui/icons/Play.tsx
+++ b/app/components/ui/icons/Play.tsx
@@ -1,0 +1,26 @@
+import { ReactElement } from "react";
+
+const Play = ({
+	className = "",
+	fill = "currentColor",
+	viewBox = "0 0 256 256",
+	width = "32",
+	height = "32",
+	onClick,
+}: Icon): ReactElement => {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			className={className}
+			width={width}
+			height={height}
+			fill={fill}
+			viewBox={viewBox}
+			onClick={onClick}
+		>
+			<path d="M232.4,114.49,88.32,26.35a16,16,0,0,0-16.2-.3A15.86,15.86,0,0,0,64,39.87V216.13A15.94,15.94,0,0,0,80,232a16.07,16.07,0,0,0,8.36-2.35L232.4,141.51a15.81,15.81,0,0,0,0-27ZM80,215.94V40l143.83,88Z" />
+		</svg>
+	);
+};
+
+export default Play;

--- a/app/lib/consoleRunner.ts
+++ b/app/lib/consoleRunner.ts
@@ -1,0 +1,24 @@
+import SupportedLanguages from "@/lib/config/languages";
+
+export const prepareConsoleCode = async (
+	code: string,
+	language: SupportedLanguages
+): Promise<string> => {
+	if (language !== SupportedLanguages.TypeScript) {
+		return code;
+	}
+
+	// ponytail: transpile with the already-installed typescript package,
+	// lazy-loaded so it only downloads when a TypeScript snippet is run; swap
+	// for a small transpiler (sucrase / esbuild-wasm) if chunk size matters.
+	const typescriptModule = await import("typescript");
+
+	const output = typescriptModule.transpileModule(code, {
+		compilerOptions: {
+			module: typescriptModule.ModuleKind.None,
+			target: typescriptModule.ScriptTarget.ES2022,
+		},
+	});
+
+	return output.outputText;
+};

--- a/app/lib/constants/preview.constants.ts
+++ b/app/lib/constants/preview.constants.ts
@@ -1,0 +1,365 @@
+import SupportedLanguages from "@/lib/config/languages";
+
+export const enum PreviewKind {
+	Console = "console",
+	Html = "html",
+	Markdown = "markdown",
+	None = "none",
+}
+
+export const enum ConsoleMessageLevel {
+	Done = "done",
+	Error = "error",
+	Info = "info",
+	Log = "log",
+	Warn = "warn",
+}
+
+export const LanguagePreviewKinds: Partial<
+	Record<SupportedLanguages, PreviewKind>
+> = {
+	[SupportedLanguages.HTML]: PreviewKind.Html,
+	[SupportedLanguages.JavaScript]: PreviewKind.Console,
+	[SupportedLanguages.Markdown]: PreviewKind.Markdown,
+	[SupportedLanguages.TypeScript]: PreviewKind.Console,
+};
+
+// Levels a sandbox message may carry into the rendered entry list; anything
+// else coming out of the (untrusted) frame is dropped.
+export const ConsoleEntryLevels: readonly ConsoleMessageLevel[] = [
+	ConsoleMessageLevel.Error,
+	ConsoleMessageLevel.Info,
+	ConsoleMessageLevel.Log,
+	ConsoleMessageLevel.Warn,
+];
+
+export const ConsoleMessageSource = "snippets-console";
+
+export const ConsoleRunMessageSource = "snippets-console-run";
+
+export const ConsoleRunTimeoutMs = 5000;
+
+// The HTML preview frame is fully sandboxed (sandbox="", opaque origin, no
+// scripts); this CSP is defense in depth on top of that: deny everything
+// except inline styles and images.
+export const HtmlPreviewContentSecurityPolicy =
+	"default-src 'none'; img-src data: https:; style-src 'unsafe-inline'";
+
+// Bootstrap document for the JS/TS console sandbox. Runs inside an iframe
+// with sandbox="allow-scripts" only: opaque origin, so no cookies, storage,
+// or parent DOM access. The CSP additionally denies all network
+// (connect/img/font/frame/etc. via default-src 'none'); 'unsafe-eval' is
+// required for the new Function() execution and 'unsafe-inline' for this
+// bootstrap script itself. Snippet code arrives via postMessage (never
+// embedded in the document), console output leaves the same way as plain
+// strings. The console shim covers the common Console API surface (log,
+// info, warn, error, debug, dir, table, group/groupCollapsed/groupEnd,
+// count/countReset, time/timeLog/timeEnd, assert, trace); every method maps
+// onto the four ConsoleMessageLevel entry levels the parent accepts, with
+// tables rendered as monospace text and groups rendered as indentation.
+export const ConsoleSandboxDocument = `<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval'" />
+	</head>
+	<body>
+		<script>
+			(function () {
+				"use strict";
+
+				var indentDepth = 0;
+				var counters = {};
+				var timers = {};
+
+				var repeatText = function (text, count) {
+					return new Array(count + 1).join(text);
+				};
+
+				var indentText = function (text) {
+					if (indentDepth === 0) {
+						return text;
+					}
+
+					var prefix = repeatText("  ", indentDepth);
+
+					return String(text)
+						.split("\\n")
+						.map(function (line) {
+							return prefix + line;
+						})
+						.join("\\n");
+				};
+
+				var post = function (level, text) {
+					window.parent.postMessage(
+						{ level: level, source: "${ConsoleMessageSource}", text: indentText(text) },
+						"*"
+					);
+				};
+
+				var format = function (value) {
+					if (typeof value === "string") {
+						return value;
+					}
+
+					if (value instanceof Error) {
+						return value.name + ": " + value.message;
+					}
+
+					try {
+						var json = JSON.stringify(value);
+
+						return json === undefined ? String(value) : json;
+					} catch (serializationError) {
+						return String(value);
+					}
+				};
+
+				var formatAll = function (values) {
+					return Array.prototype.map.call(values, format).join(" ");
+				};
+
+				var toLabelKey = function (label) {
+					return label === undefined ? "default" : String(label);
+				};
+
+				var isRowObject = function (row) {
+					return row !== null && typeof row === "object";
+				};
+
+				var buildTable = function (data, columns) {
+					if (!isRowObject(data)) {
+						return format(data);
+					}
+
+					var rowKeys = Object.keys(data);
+					var columnNames = [];
+
+					if (Array.isArray(columns)) {
+						columnNames = columns.map(String);
+					} else {
+						var seenColumns = {};
+
+						rowKeys.forEach(function (rowKey) {
+							var row = data[rowKey];
+
+							if (!isRowObject(row)) {
+								return;
+							}
+
+							Object.keys(row).forEach(function (columnName) {
+								if (!seenColumns[columnName]) {
+									seenColumns[columnName] = true;
+									columnNames.push(columnName);
+								}
+							});
+						});
+					}
+
+					var hasValuesColumn = rowKeys.some(function (rowKey) {
+						return !isRowObject(data[rowKey]);
+					});
+					var header = ["(index)"].concat(columnNames);
+
+					if (hasValuesColumn) {
+						header.push("Values");
+					}
+
+					var bodyRows = rowKeys.map(function (rowKey) {
+						var row = data[rowKey];
+						var cells = [rowKey];
+
+						columnNames.forEach(function (columnName) {
+							cells.push(
+								isRowObject(row) && columnName in row ? format(row[columnName]) : ""
+							);
+						});
+
+						if (hasValuesColumn) {
+							cells.push(isRowObject(row) ? "" : format(row));
+						}
+
+						return cells;
+					});
+
+					var columnWidths = header.map(function (headerCell, columnIndex) {
+						var width = String(headerCell).length;
+
+						bodyRows.forEach(function (cells) {
+							var cellWidth = String(cells[columnIndex]).length;
+
+							if (cellWidth > width) {
+								width = cellWidth;
+							}
+						});
+
+						return width;
+					});
+
+					var padCell = function (cell, width) {
+						var text = String(cell);
+
+						return text + repeatText(" ", width - text.length);
+					};
+
+					var renderRow = function (cells) {
+						var rendered = cells.map(function (cell, columnIndex) {
+							return padCell(cell, columnWidths[columnIndex]);
+						});
+
+						return "| " + rendered.join(" | ") + " |";
+					};
+
+					var divider =
+						"+" +
+						columnWidths
+							.map(function (width) {
+								return repeatText("-", width + 2);
+							})
+							.join("+") +
+						"+";
+
+					var lines = [divider, renderRow(header), divider];
+
+					bodyRows.forEach(function (cells) {
+						lines.push(renderRow(cells));
+					});
+					lines.push(divider);
+
+					return lines.join("\\n");
+				};
+
+				["debug", "error", "info", "log", "warn"].forEach(function (level) {
+					var entryLevel = level === "debug" ? "log" : level;
+
+					console[level] = function () {
+						post(entryLevel, formatAll(arguments));
+					};
+				});
+
+				console.dir = function (value) {
+					post("log", format(value));
+				};
+
+				console.table = function (data, columns) {
+					post("log", buildTable(data, columns));
+				};
+
+				console.group = function () {
+					post("log", arguments.length > 0 ? formatAll(arguments) : "console.group");
+					indentDepth += 1;
+				};
+
+				console.groupCollapsed = console.group;
+
+				console.groupEnd = function () {
+					if (indentDepth > 0) {
+						indentDepth -= 1;
+					}
+				};
+
+				console.count = function (label) {
+					var key = toLabelKey(label);
+
+					counters[key] = (counters[key] || 0) + 1;
+					post("log", key + ": " + counters[key]);
+				};
+
+				console.countReset = function (label) {
+					counters[toLabelKey(label)] = 0;
+				};
+
+				console.time = function (label) {
+					timers[toLabelKey(label)] = performance.now();
+				};
+
+				console.timeLog = function (label) {
+					var key = toLabelKey(label);
+
+					if (timers[key] === undefined) {
+						post("warn", "Timer '" + key + "' does not exist");
+
+						return;
+					}
+
+					post("log", key + ": " + (performance.now() - timers[key]).toFixed(2) + " ms");
+				};
+
+				console.timeEnd = function (label) {
+					var key = toLabelKey(label);
+
+					if (timers[key] === undefined) {
+						post("warn", "Timer '" + key + "' does not exist");
+
+						return;
+					}
+
+					post("log", key + ": " + (performance.now() - timers[key]).toFixed(2) + " ms");
+					delete timers[key];
+				};
+
+				console.assert = function (condition) {
+					if (condition) {
+						return;
+					}
+
+					var details = Array.prototype.slice.call(arguments, 1).map(format).join(" ");
+
+					post("error", details ? "Assertion failed: " + details : "Assertion failed");
+				};
+
+				console.trace = function () {
+					var details = formatAll(arguments);
+					var stack = String(new Error().stack || "");
+					var stackLines = stack.split("\\n").slice(2).join("\\n");
+
+					post(
+						"log",
+						"Trace" + (details ? ": " + details : "") + (stackLines ? "\\n" + stackLines : "")
+					);
+				};
+
+				window.addEventListener("error", function (event) {
+					post("error", event.message);
+				});
+
+				window.addEventListener("unhandledrejection", function (event) {
+					post("error", format(event.reason));
+				});
+
+				window.addEventListener("message", function (event) {
+					if (event.source !== window.parent) {
+						return;
+					}
+
+					var data = event.data;
+
+					if (!data || data.source !== "${ConsoleRunMessageSource}") {
+						return;
+					}
+
+					var finish = function () {
+						post("done", "");
+					};
+
+					try {
+						var execute = new Function(
+							'"use strict"; return (async function () {\\n' +
+								data.code +
+								'\\n}).call(undefined);'
+						);
+
+						execute().then(finish, function (runError) {
+							post("error", format(runError));
+							finish();
+						});
+					} catch (runError) {
+						post("error", format(runError));
+						finish();
+					}
+				});
+			})();
+		</script>
+	</body>
+</html>`;

--- a/app/lib/htmlPreviewRenderer.ts
+++ b/app/lib/htmlPreviewRenderer.ts
@@ -1,0 +1,19 @@
+import DOMPurify from "isomorphic-dompurify";
+
+/* Lib */
+import { HtmlPreviewContentSecurityPolicy } from "@/lib/constants/preview.constants";
+
+// Sanitization here is defense in depth: the preview iframe is rendered with
+// sandbox="" (opaque origin, scripts disabled), so anything DOMPurify were to
+// miss still could not execute or reach the parent application.
+export const buildHtmlPreviewDocument = (content: string): string => {
+	const sanitizedHtml = DOMPurify.sanitize(content);
+
+	return [
+		'<!doctype html><html><head><meta charset="utf-8" />',
+		`<meta http-equiv="Content-Security-Policy" content="${HtmlPreviewContentSecurityPolicy}" />`,
+		"</head><body>",
+		sanitizedHtml,
+		"</body></html>",
+	].join("");
+};

--- a/types/preview.d.ts
+++ b/types/preview.d.ts
@@ -1,0 +1,15 @@
+import type { ConsoleMessageLevel } from "@/lib/constants/preview.constants";
+
+declare global {
+	type ConsoleEntry = {
+		id: number;
+		level: ConsoleMessageLevel;
+		text: string;
+	};
+
+	type ConsoleSandboxMessage = {
+		level: ConsoleMessageLevel;
+		source: string;
+		text: string;
+	};
+}


### PR DESCRIPTION
## Summary

Add live preview capabilities to the code editor for HTML and JavaScript/TypeScript snippets.

### Changes

- **HtmlPreview**: Sandboxed iframe rendering sanitized HTML (DOMPurify + CSP + sandbox="") — preview only, no script execution
- **CodeConsole**: Sandboxed JS/TS execution with console output capture, 5s timeout, and TypeScript transpilation via lazy-loaded `typescript` package
- **Preview toggle**: Eye icon in MarkdownToolbar lets users show/hide the preview panel
- **Language mapping**: `LanguagePreviewKinds` config routes each language to its preview type (HTML → HtmlPreview, JS/TS → Console, Markdown → MarkdownPreview)
- **CodeEditor refactor**: Single stable editor tree across all modes — toggling preview never remounts the editor (preserves undo history, cursor, scroll)

### Security

- HTML preview: `sandbox=""` (no scripts, no forms, no network) + CSP + DOMPurify
- Console runner: `sandbox="allow-scripts"` with opaque origin (no cookies/storage/parent DOM) + CSP denying all network
- Message handling validates `event.source` and message shapes before use