### PR TITLE
feat(ai): add OpenRouter attribution headers

### DIFF
--- a/app/api/ai/models/route.ts
+++ b/app/api/ai/models/route.ts
@@ -8,8 +8,10 @@ import {
 	ollamaCloudUrl,
 	openAiBaseUrl,
 	openAiExcludedPrefixes,
+	openRouterAppTitle,
 	openRouterBaseUrl,
 	openRouterFreeSuffix,
+	openRouterRefererUrl,
 } from "@/lib/constants/ai";
 import { HttpStatusCode } from "@/lib/constants/ui.constants";
 import createSupabaseServerClient from "@/lib/supabase/server";
@@ -91,7 +93,10 @@ const fetchOpenAiCompatibleModels = async (
 };
 
 const fetchOpenRouterModels = async (apiKey: string): Promise<string[]> => {
-	const headers: Record<string, string> = {};
+	const headers: Record<string, string> = {
+		"HTTP-Referer": openRouterRefererUrl,
+		"X-Title": openRouterAppTitle,
+	};
 
 	if (apiKey) {
 		headers["Authorization"] = `Bearer ${apiKey}`;

--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -13,7 +13,9 @@ import {
 	nvidiaBaseUrl,
 	ollamaCloudUrl,
 	openAiBaseUrl,
+	openRouterAppTitle,
 	openRouterBaseUrl,
+	openRouterRefererUrl,
 	UserRole,
 } from "@/lib/constants/ai";
 import { HttpStatusCode } from "@/lib/constants/ui.constants";
@@ -309,7 +311,11 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 				systemPrompt,
 				openRouterApiKey,
 				openRouterModel,
-				upstreamAbort.signal
+				upstreamAbort.signal,
+				{
+					"HTTP-Referer": openRouterRefererUrl,
+					"X-Title": openRouterAppTitle,
+				}
 			);
 
 			return createStreamResponse(upstreamAbort, async (emit) => {

--- a/app/lib/ai/providers/openAiCompatible.ts
+++ b/app/lib/ai/providers/openAiCompatible.ts
@@ -14,13 +14,15 @@ export const connectOpenAiCompatible = async (
 	systemPrompt: string,
 	apiKey: string,
 	model: string,
-	abortSignal?: AbortSignal
+	abortSignal?: AbortSignal,
+	extraHeaders?: Record<string, string>
 ): Promise<Response> => {
 	const response = await fetch(`${baseUrl}/chat/completions`, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
 			Authorization: `Bearer ${apiKey}`,
+			...extraHeaders,
 		},
 		body: JSON.stringify({
 			model,

--- a/app/lib/constants/ai.ts
+++ b/app/lib/constants/ai.ts
@@ -165,6 +165,9 @@ export const defaultNvidiaModel =
 export const defaultOpenRouterModel =
 	process.env.OPENROUTER_MODEL || "openrouter/free";
 export const openRouterFreeSuffix = ":free";
+export const openRouterRefererUrl =
+	process.env.NEXT_PUBLIC_BASE_URL || "https://snippets.vianch.com";
+export const openRouterAppTitle = "Snippets";
 
 export const ssePrefix = "data:";
 export const sseDoneSentinel = "[DONE]";


### PR DESCRIPTION
#### Why are you creating this PR? What value is added?

Adds `HTTP-Referer` and `X-Title` headers to OpenRouter API calls for proper attribution. Updates `connectOpenAiCompatible` to accept optional extra headers.