### PR TITLE
minor: add auto-tag release workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,50 @@
+name: Auto Tag on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute and push next tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          latest=$(git tag --list --sort=-v:refname | head -n1)
+          latest=${latest:-0.0.0}
+          IFS=. read -r major minor patch <<< "$latest"
+
+          # fix/minor PR -> patch bump; anything else -> minor bump
+          if echo "$PR_TITLE" | grep -qiE '^(fix|minor)(\(.+\))?!?:'; then
+            patch=$((patch + 1))
+          else
+            minor=$((minor + 1))
+            patch=0
+          fi
+
+          next="$major.$minor.$patch"
+          echo "Latest: $latest -> Next: $next (PR: $PR_TITLE)"
+
+          git tag "$next"
+          git push origin "$next"
+
+          # Release with auto-generated notes (commits/PRs since last tag)
+          gh release create "$next" \
+            --title "$next" \
+            --generate-notes \
+            --notes "Merged: #${PR_NUMBER} $PR_TITLE"


### PR DESCRIPTION
Adds GitHub Actions workflow that automatically tags merged PRs and creates releases with auto-generated notes.

When a PR is merged to `main`, the workflow:
1. Computes the next semver tag based on PR title (`fix`/`minor` prefix → patch bump, otherwise → minor bump)
2. Pushes the new tag
3. Creates a GitHub release with auto-generated notes