### PR TITLE
feat: add Cmd+M shortcut with unsaved changes guard

### DIFF
--- a/app/components/CommandPalette/CommandPalette.tsx
+++ b/app/components/CommandPalette/CommandPalette.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactElement, useEffect } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import { Command } from "cmdk";
 
 import useMenuStore from "@/lib/store/menu.store";
@@ -53,6 +53,11 @@ const CommandPalette = ({
 	const toggleCommandPalette = useMenuStore(
 		(store) => store.toggleCommandPalette
 	);
+	const [isMac, setIsMac] = useState<boolean>(true);
+
+	useEffect(() => {
+		setIsMac(window.navigator.userAgent.includes("Mac"));
+	}, []);
 
 	useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent): void => {
@@ -60,12 +65,23 @@ const CommandPalette = ({
 				event.preventDefault();
 				toggleCommandPalette();
 			}
+
+			const isMacPlatform = window.navigator.userAgent.includes("Mac");
+			const newSnippetModifier = isMacPlatform
+				? event.metaKey && !event.ctrlKey
+				: event.ctrlKey && !event.metaKey;
+
+			if (newSnippetModifier && event.code === "KeyM") {
+				event.preventDefault();
+				setCommandPaletteOpen(false);
+				onNewSnippet();
+			}
 		};
 
-		document.addEventListener("keydown", handleKeyDown);
+		document.addEventListener("keydown", handleKeyDown, true);
 
-		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, []);
+		return () => document.removeEventListener("keydown", handleKeyDown, true);
+	}, [onNewSnippet, setCommandPaletteOpen, toggleCommandPalette]);
 
 	const runAction = (action: () => void): void => {
 		setCommandPaletteOpen(false);
@@ -98,6 +114,7 @@ const CommandPalette = ({
 					>
 						<NewFile width={16} height={16} />
 						<span>New snippet</span>
+						<span className={styles.shortcut}>{isMac ? "⌘" : "Ctrl"} m</span>
 					</Command.Item>
 					<Command.Item
 						className={styles.item}

--- a/app/components/CommandPalette/commandPalette.module.css
+++ b/app/components/CommandPalette/commandPalette.module.css
@@ -104,6 +104,12 @@
 	color: var(--comment-color);
 }
 
+.shortcut {
+	margin-left: auto;
+	font-size: var(--tiny-font-size);
+	color: var(--comment-color);
+}
+
 .footer {
 	display: flex;
 	align-items: center;

--- a/app/components/SnippetsWorkspace/SnippetsWorkspace.tsx
+++ b/app/components/SnippetsWorkspace/SnippetsWorkspace.tsx
@@ -9,6 +9,8 @@ import CodeEditor from "@/components/CodeEditor/CodeEditor";
 import ResizableLayout from "@/components/ResizableLayout/ResizableLayout";
 import AccountModal from "@/components/AccountModal/AccountModal";
 import CommandPalette from "@/components/CommandPalette/CommandPalette";
+import ConfirmationModal from "@/components/ui/ConfirmationModal/ConfirmationModal";
+import Warning from "@/components/ui/icons/Warning";
 
 /* Lib */
 import {
@@ -65,6 +67,8 @@ const SnippetsWorkspace = ({
 	const [uncategorizedCount, setUncategorizedCount] = useState<number>(0);
 	const [favoritesCount, setFavoritesCount] = useState<number>(0);
 	const [isLoading, setIsLoading] = useState<boolean>(true);
+	const [showUnsavedSnippetModal, setShowUnsavedSnippetModal] =
+		useState<boolean>(false);
 	const { addToast } = useToastStore();
 
 	const findIndexForCurrentSnippet = (currentSnippet: CurrentSnippet): number =>
@@ -420,9 +424,14 @@ const SnippetsWorkspace = ({
 
 	const newSnippetHandler = (newSnippet: Snippet): void => {
 		if (newSnippet) {
-			setSnippets([newSnippet, ...snippets]);
+			setSnippets((previousSnippets) => [newSnippet, ...previousSnippets]);
 
-			setActiveSnippetId(newSnippet.snippet_id);
+			setCodedEditorStates((previousStates) => ({
+				...previousStates,
+				activeSnippetId: newSnippet.snippet_id,
+				isSaving: false,
+				touched: false,
+			}));
 		}
 	};
 
@@ -669,12 +678,32 @@ const SnippetsWorkspace = ({
 		});
 	};
 
-	const createSnippetFromPalette = async (): Promise<void> => {
+	const performCreateSnippet = async (): Promise<void> => {
 		const newSnippet = await setNewSnippet();
 
 		if (newSnippet) {
 			newSnippetHandler(newSnippet);
 		}
+	};
+
+	const createSnippetFromPalette = async (): Promise<void> => {
+		if (codeEditorStates.touched) {
+			setShowUnsavedSnippetModal(true);
+
+			return;
+		}
+
+		await performCreateSnippet();
+	};
+
+	const handleConfirmCreateSnippet = async (): Promise<void> => {
+		setShowUnsavedSnippetModal(false);
+
+		await performCreateSnippet();
+	};
+
+	const handleCancelCreateSnippet = (): void => {
+		setShowUnsavedSnippetModal(false);
 	};
 
 	useEffect(() => {
@@ -774,6 +803,16 @@ const SnippetsWorkspace = ({
 				onGetTrash={getTrashHandler}
 				onTagClick={getSnippetsByTagHandler}
 				onAccountClick={handleAccountClick}
+			/>
+			<ConfirmationModal
+				isOpen={showUnsavedSnippetModal}
+				icon={<Warning width={20} height={20} />}
+				title="You have unsaved changes"
+				description="Create a new snippet anyway?"
+				cancelLabel="Cancel"
+				confirmLabel="Create new"
+				onCancel={handleCancelCreateSnippet}
+				onConfirm={handleConfirmCreateSnippet}
 			/>
 		</>
 	);

--- a/app/components/ui/ConfirmationModal/ConfirmationModal.tsx
+++ b/app/components/ui/ConfirmationModal/ConfirmationModal.tsx
@@ -1,0 +1,59 @@
+import { ReactElement } from "react";
+
+/* Components */
+import Button from "@/components/ui/Button/Button";
+import Modal from "@/components/ui/Modal/Modal";
+
+/* Styles */
+import styles from "./confirmationModal.module.css";
+
+type ConfirmationModalProps = {
+	cancelLabel?: string;
+	confirmLabel?: string;
+	description: string;
+	icon: ReactElement;
+	isOpen: boolean;
+	onCancel: () => void;
+	onConfirm: () => void;
+	title: string;
+};
+
+const ConfirmationModal = ({
+	cancelLabel = "Cancel",
+	confirmLabel = "Confirm",
+	description,
+	icon,
+	isOpen,
+	onCancel,
+	onConfirm,
+	title,
+}: ConfirmationModalProps): ReactElement => {
+	return (
+		<Modal
+			isOpen={isOpen}
+			onClose={onCancel}
+			showCloseButton={false}
+			className={styles.modal}
+		>
+			<div className={styles.header}>
+				<span className={styles.icon}>{icon}</span>
+				<h2 className={styles.title}>{title}</h2>
+			</div>
+			<p className={styles.description}>{description}</p>
+			<div className={styles.actions}>
+				<Button
+					variant="secondary"
+					className={styles.button}
+					onClick={onCancel}
+				>
+					{cancelLabel}
+				</Button>
+				<Button variant="primary" className={styles.button} onClick={onConfirm}>
+					{confirmLabel}
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export default ConfirmationModal;

--- a/app/components/ui/ConfirmationModal/confirmationModal.module.css
+++ b/app/components/ui/ConfirmationModal/confirmationModal.module.css
@@ -1,0 +1,31 @@
+.modal {
+	min-width: 350px;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-bottom: 8px;
+}
+
+.title {
+	margin: 0;
+	font-size: var(--font-size);
+}
+
+.description {
+	margin: 24px 0;
+	color: var(--foreground-color);
+}
+
+.actions {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+}
+
+.button {
+	padding: 0.4rem 1rem;
+	height: 44px;
+}

--- a/app/lib/constants/shortcuts.ts
+++ b/app/lib/constants/shortcuts.ts
@@ -16,7 +16,8 @@ const shortcutGroups: ShortcutGroup[] = [
 	{
 		heading: "Editor",
 		items: [
-			{ keys: ["Mod", "S"], description: "Save current snippet" },
+			{ keys: ["Mod", "m"], description: "Create a new snippet" },
+			{ keys: ["Mod", "s"], description: "Save current snippet" },
 			{
 				keys: ["Mod", "Shift", "I"],
 				description: "Request AI inline completion",


### PR DESCRIPTION
#### Github Issue

relates to https://github.com/vianch/snippets/issues/

#### Why are you creating this PR? What value is added?

Adds a Cmd/Ctrl+M keyboard shortcut to create new snippets directly from anywhere in the app, bypassing the command palette. When the current snippet has unsaved changes, a confirmation modal warns the user before creating a new snippet. Also adds a reusable ConfirmationModal component to the UI library and displays the shortcut hint in the command palette next to the "New snippet" action.

#### Include screenshots below (if appropriate)