### PR TITLE
fix(html-preview): preserve full document structure and sandbox styles

### DIFF
--- a/app/lib/htmlPreviewRenderer.ts
+++ b/app/lib/htmlPreviewRenderer.ts
@@ -7,13 +7,19 @@ import { HtmlPreviewContentSecurityPolicy } from "@/lib/constants/preview.consta
 // sandbox="" (opaque origin, scripts disabled), so anything DOMPurify were to
 // miss still could not execute or reach the parent application.
 export const buildHtmlPreviewDocument = (content: string): string => {
-	const sanitizedHtml = DOMPurify.sanitize(content);
+	// WHOLE_DOCUMENT keeps <head>/<body> and their <style> blocks intact — the
+	// default (body-fragment) mode drops the <head>, so a full-document snippet
+	// loses all its styling. The sandboxed iframe contains whatever renders.
+	const sanitizedDocument = DOMPurify.sanitize(content, {
+		WHOLE_DOCUMENT: true,
+	});
 
-	return [
-		'<!doctype html><html><head><meta charset="utf-8" />',
-		`<meta http-equiv="Content-Security-Policy" content="${HtmlPreviewContentSecurityPolicy}" />`,
-		"</head><body>",
-		sanitizedHtml,
-		"</body></html>",
-	].join("");
+	const headMeta = `<head><meta charset="utf-8" /><meta http-equiv="Content-Security-Policy" content="${HtmlPreviewContentSecurityPolicy}" />`;
+
+	// WHOLE_DOCUMENT always emits a <head>; inject the CSP as its first child.
+	if (sanitizedDocument.includes("<head>")) {
+		return `<!doctype html>${sanitizedDocument.replace("<head>", headMeta)}`;
+	}
+
+	return `<!doctype html><html>${headMeta}</head><body>${sanitizedDocument}</body></html>`;
 };

--- a/app/lib/markdownRenderer.ts
+++ b/app/lib/markdownRenderer.ts
@@ -72,7 +72,12 @@ export const renderMarkdownToHtml = async (
 
 	const rawHtml = await markedInstance.parse(content);
 
+	// This HTML is injected into the app DOM (dangerouslySetInnerHTML), so a
+	// raw <style> in the snippet would restyle the whole app (body/* selectors
+	// leak out). Forbid it — styled full documents belong in the HTML preview,
+	// which renders inside a sandboxed iframe.
 	return DOMPurify.sanitize(rawHtml, {
 		ADD_ATTR: ["data-wiki-target"],
+		FORBID_TAGS: ["style"],
 	});
 };


### PR DESCRIPTION
## What

- Use DOMPurify `WHOLE_DOCUMENT` mode so `<head>`/`<body>`/`<style>` blocks survive sanitization in the HTML preview
- Forbid `<style>` tags in markdown renderer to prevent CSS leaking into the app DOM

## Why

Full-document HTML snippets lost all styling because DOMPurify's default body-fragment mode drops `<head>`. And markdown snippets with `<style>` tags could restyle the entire app since they render via `dangerouslySetInnerHTML` in the main DOM.

## How

- `htmlPreviewRenderer.ts`: switched to `WHOLE_DOCUMENT: true`, inject CSP meta into the preserved `<head>`
- `markdownRenderer.ts`: added `FORBID_TAGS: [style]` to the DOMPurify config