### PR TITLE
feat: add Catppuccin and Quiet Green themes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -369,6 +369,138 @@ table {
 	--pet-glow: rgb(130 80 223 / 38%);
 }
 
+[data-theme="catppuccin-frappe"] {
+	--bg-color-dark: #292c3c;
+	--bg-color: #303446;
+	--border-color: #51576d;
+	--current-line: #414559;
+	--comment-color: #838ba7;
+	--cyan-color: #99d1db;
+	--blue-color: #8caaee;
+	--green-color: #a6d189;
+	--dark-green-color: #8aae6f;
+	--gray-color: #a5adce;
+	--purple-color: #ca9ee6;
+	--yellow-color: #e5c890;
+	--orange-color: #ef9f76;
+	--dark-orange-color: #d98456;
+	--red-color: #e78284;
+	--dark-red-color: #d16b6d;
+	--foreground-color: #c6d0f5;
+	--success-color: #eff7ee;
+	--error-color: #fbeeed;
+	--warning-color: #fef4e6;
+	--info-color: #e8f6fd;
+	--skeleton-shimmer: #51576d;
+	--button-bg: #414559;
+	--input-bg: #232634;
+	--glass-bg: rgb(255 255 255 / 4%);
+	--glass-border: rgb(255 255 255 / 10%);
+	--card-shadow: 0 0.75rem 2rem rgb(0 0 0 / 45%);
+	--card-shadow-hover: 0 1.25rem 2.5rem rgb(0 0 0 / 58%);
+	--grid-line: rgb(255 255 255 / 5%);
+	--pet-glow: rgb(202 158 230 / 50%);
+}
+
+[data-theme="catppuccin-macchiato"] {
+	--bg-color-dark: #1e2030;
+	--bg-color: #24273a;
+	--border-color: #494d64;
+	--current-line: #363a4f;
+	--comment-color: #8087a2;
+	--cyan-color: #91d7e3;
+	--blue-color: #8aadf4;
+	--green-color: #a6da95;
+	--dark-green-color: #86bd76;
+	--gray-color: #a5adcb;
+	--purple-color: #c6a0f6;
+	--yellow-color: #eed49f;
+	--orange-color: #f5a97f;
+	--dark-orange-color: #dd8a60;
+	--red-color: #ed8796;
+	--dark-red-color: #d76f7e;
+	--foreground-color: #cad3f5;
+	--success-color: #eff7ee;
+	--error-color: #fbeeed;
+	--warning-color: #fef4e6;
+	--info-color: #e8f6fd;
+	--skeleton-shimmer: #494d64;
+	--button-bg: #363a4f;
+	--input-bg: #181926;
+	--glass-bg: rgb(255 255 255 / 4%);
+	--glass-border: rgb(255 255 255 / 10%);
+	--card-shadow: 0 0.75rem 2rem rgb(0 0 0 / 45%);
+	--card-shadow-hover: 0 1.25rem 2.5rem rgb(0 0 0 / 58%);
+	--grid-line: rgb(255 255 255 / 5%);
+	--pet-glow: rgb(198 160 246 / 50%);
+}
+
+[data-theme="catppuccin-mocha"] {
+	--bg-color-dark: #181825;
+	--bg-color: #1e1e2e;
+	--border-color: #45475a;
+	--current-line: #313244;
+	--comment-color: #7f849c;
+	--cyan-color: #89dceb;
+	--blue-color: #89b4fa;
+	--green-color: #a6e3a1;
+	--dark-green-color: #86c781;
+	--gray-color: #a6adc8;
+	--purple-color: #cba6f7;
+	--yellow-color: #f9e2af;
+	--orange-color: #fab387;
+	--dark-orange-color: #e39866;
+	--red-color: #f38ba8;
+	--dark-red-color: #d97490;
+	--foreground-color: #cdd6f4;
+	--success-color: #eff7ee;
+	--error-color: #fbeeed;
+	--warning-color: #fef4e6;
+	--info-color: #e8f6fd;
+	--skeleton-shimmer: #45475a;
+	--button-bg: #313244;
+	--input-bg: #11111b;
+	--glass-bg: rgb(255 255 255 / 4%);
+	--glass-border: rgb(255 255 255 / 10%);
+	--card-shadow: 0 0.75rem 2rem rgb(0 0 0 / 45%);
+	--card-shadow-hover: 0 1.25rem 2.5rem rgb(0 0 0 / 58%);
+	--grid-line: rgb(255 255 255 / 5%);
+	--pet-glow: rgb(203 166 247 / 50%);
+}
+
+[data-theme="quiet-green"] {
+	--bg-color-dark: #cdddc9;
+	--bg-color: #dbe7d7;
+	--border-color: #bacdb4;
+	--current-line: #cbdac6;
+	--comment-color: #7d9080;
+	--cyan-color: #2f8a7d;
+	--blue-color: #3f7d8f;
+	--green-color: #4a7c59;
+	--dark-green-color: #2d4a3e;
+	--gray-color: #617066;
+	--purple-color: #8d7099;
+	--yellow-color: #c2922f;
+	--orange-color: #d97b52;
+	--dark-orange-color: #bd5f38;
+	--red-color: #e0705f;
+	--dark-red-color: #c85a49;
+	--foreground-color: #2d4a3e;
+	--success-color: #dff0dd;
+	--error-color: #f5e1dc;
+	--warning-color: #f4ecd6;
+	--info-color: #dbecec;
+	--skeleton-shimmer: #dbe7d7;
+	--button-bg: #cdddc9;
+	--input-bg: #fff;
+	--glass-bg: rgb(255 255 255 / 62%);
+	--glass-border: rgb(45 74 62 / 14%);
+	--card-shadow: 0 0.5rem 1.5rem rgb(45 74 62 / 10%);
+	--card-shadow-hover: 0 1rem 2.25rem rgb(45 74 62 / 16%);
+	--grid-line: rgb(45 74 62 / 6%);
+	--pet-glow: rgb(74 124 89 / 42%);
+}
+
 [data-theme="dracula"] {
 	--bg-color-dark: #282a36;
 	--bg-color: #363945;
@@ -477,13 +609,17 @@ html:not([data-theme]) {
 
 html[data-theme="dracula"],
 html[data-theme="shades-of-purple"],
-html[data-theme="github-dark"] {
+html[data-theme="github-dark"],
+html[data-theme="catppuccin-frappe"],
+html[data-theme="catppuccin-macchiato"],
+html[data-theme="catppuccin-mocha"] {
 	color-scheme: dark;
 }
 
 html[data-theme="catppuccin-latte"],
 html[data-theme="ayu-light"],
-html[data-theme="github-light"] {
+html[data-theme="github-light"],
+html[data-theme="quiet-green"] {
 	color-scheme: light;
 }
 

--- a/app/lib/config/shiki.ts
+++ b/app/lib/config/shiki.ts
@@ -11,8 +11,12 @@ const getHighlighter = (): Promise<HighlighterCore> => {
 			engine: createOnigurumaEngine(import("shiki/wasm")),
 			themes: [
 				import("@shikijs/themes/ayu-light"),
+				import("@shikijs/themes/catppuccin-frappe"),
 				import("@shikijs/themes/catppuccin-latte"),
+				import("@shikijs/themes/catppuccin-macchiato"),
+				import("@shikijs/themes/catppuccin-mocha"),
 				import("@shikijs/themes/dracula"),
+				import("@shikijs/themes/everforest-light"),
 				import("@shikijs/themes/github-dark"),
 				import("@shikijs/themes/github-light"),
 				import("@shikijs/themes/material-theme-palenight"),
@@ -47,10 +51,14 @@ const getHighlighter = (): Promise<HighlighterCore> => {
 
 const shikiThemeMap: Record<ThemeName, string> = {
 	[ThemeNames.AyuLight]: "ayu-light",
+	[ThemeNames.CatppuccinFrappe]: "catppuccin-frappe",
 	[ThemeNames.CatppuccinLatte]: "catppuccin-latte",
+	[ThemeNames.CatppuccinMacchiato]: "catppuccin-macchiato",
+	[ThemeNames.CatppuccinMocha]: "catppuccin-mocha",
 	[ThemeNames.Dracula]: "dracula",
 	[ThemeNames.GithubDark]: "github-dark",
 	[ThemeNames.GithubLight]: "github-light",
+	[ThemeNames.QuietGreen]: "everforest-light",
 	// Shiki has no shades-of-purple bundle; material-theme-palenight is the closest dark-purple equivalent
 	[ThemeNames.ShadesOfPurple]: "material-theme-palenight",
 };

--- a/app/lib/config/themes.ts
+++ b/app/lib/config/themes.ts
@@ -9,8 +9,12 @@ export const ThemeNames = {
 	ShadesOfPurple: "shades-of-purple",
 	CatppuccinLatte: "catppuccin-latte",
 	AyuLight: "ayu-light",
+	CatppuccinFrappe: "catppuccin-frappe",
+	CatppuccinMacchiato: "catppuccin-macchiato",
+	CatppuccinMocha: "catppuccin-mocha",
 	GithubDark: "github-dark",
 	GithubLight: "github-light",
+	QuietGreen: "quiet-green",
 } as const;
 
 export type ThemeName = (typeof ThemeNames)[keyof typeof ThemeNames];
@@ -92,6 +96,50 @@ export const themeList: ThemeConfig[] = [
 			sidebar: "#f6f8fa",
 			accent: "#8250df",
 			text: "#1f2328",
+		},
+	},
+	{
+		name: ThemeNames.QuietGreen,
+		label: "Quiet Green",
+		isDark: false,
+		previewColors: {
+			bg: "#dbe7d7",
+			sidebar: "#cdddc9",
+			accent: "#e0705f",
+			text: "#2d4a3e",
+		},
+	},
+	{
+		name: ThemeNames.CatppuccinFrappe,
+		label: "Catppuccin Frappé",
+		isDark: true,
+		previewColors: {
+			bg: "#303446",
+			sidebar: "#292c3c",
+			accent: "#ca9ee6",
+			text: "#c6d0f5",
+		},
+	},
+	{
+		name: ThemeNames.CatppuccinMacchiato,
+		label: "Catppuccin Macchiato",
+		isDark: true,
+		previewColors: {
+			bg: "#24273a",
+			sidebar: "#1e2030",
+			accent: "#c6a0f6",
+			text: "#cad3f5",
+		},
+	},
+	{
+		name: ThemeNames.CatppuccinMocha,
+		label: "Catppuccin Mocha",
+		isDark: true,
+		previewColors: {
+			bg: "#1e1e2e",
+			sidebar: "#181825",
+			accent: "#cba6f7",
+			text: "#cdd6f4",
 		},
 	},
 ];
@@ -187,6 +235,123 @@ const catppuccinLatteTheme = createTheme({
 	],
 });
 
+const catppuccinFrappeTheme = createTheme({
+	theme: "dark",
+	settings: {
+		background: "#303446",
+		foreground: "#c6d0f5",
+		caret: "#f2d5cf",
+		selection: "#babbf133",
+		selectionMatch: "#babbf122",
+		lineHighlight: "#292c3c",
+		gutterBackground: "#303446",
+		gutterForeground: "#838ba7",
+		gutterActiveForeground: "#c6d0f5",
+		gutterBorder: "transparent",
+		...codeMirrorSettings,
+	},
+	styles: [
+		{ tag: tags.comment, color: "#838ba7" },
+		{ tag: tags.keyword, color: "#ca9ee6" },
+		{ tag: [tags.string, tags.special(tags.brace)], color: "#a6d189" },
+		{ tag: tags.number, color: "#ef9f76" },
+		{ tag: tags.bool, color: "#ef9f76" },
+		{ tag: tags.null, color: "#ef9f76" },
+		{
+			tag: [
+				tags.definition(tags.variableName),
+				tags.function(tags.variableName),
+			],
+			color: "#8caaee",
+		},
+		{ tag: tags.variableName, color: "#c6d0f5" },
+		{ tag: tags.typeName, color: "#e5c890" },
+		{ tag: tags.propertyName, color: "#8caaee" },
+		{ tag: tags.operator, color: "#81c8be" },
+		{ tag: tags.punctuation, color: "#a5adce" },
+		{ tag: tags.tagName, color: "#e78284" },
+		{ tag: tags.attributeName, color: "#e5c890" },
+	],
+});
+
+const catppuccinMacchiatoTheme = createTheme({
+	theme: "dark",
+	settings: {
+		background: "#24273a",
+		foreground: "#cad3f5",
+		caret: "#f4dbd6",
+		selection: "#b7bdf833",
+		selectionMatch: "#b7bdf822",
+		lineHighlight: "#1e2030",
+		gutterBackground: "#24273a",
+		gutterForeground: "#8087a2",
+		gutterActiveForeground: "#cad3f5",
+		gutterBorder: "transparent",
+		...codeMirrorSettings,
+	},
+	styles: [
+		{ tag: tags.comment, color: "#8087a2" },
+		{ tag: tags.keyword, color: "#c6a0f6" },
+		{ tag: [tags.string, tags.special(tags.brace)], color: "#a6da95" },
+		{ tag: tags.number, color: "#f5a97f" },
+		{ tag: tags.bool, color: "#f5a97f" },
+		{ tag: tags.null, color: "#f5a97f" },
+		{
+			tag: [
+				tags.definition(tags.variableName),
+				tags.function(tags.variableName),
+			],
+			color: "#8aadf4",
+		},
+		{ tag: tags.variableName, color: "#cad3f5" },
+		{ tag: tags.typeName, color: "#eed49f" },
+		{ tag: tags.propertyName, color: "#8aadf4" },
+		{ tag: tags.operator, color: "#8bd5ca" },
+		{ tag: tags.punctuation, color: "#a5adcb" },
+		{ tag: tags.tagName, color: "#ed8796" },
+		{ tag: tags.attributeName, color: "#eed49f" },
+	],
+});
+
+const catppuccinMochaTheme = createTheme({
+	theme: "dark",
+	settings: {
+		background: "#1e1e2e",
+		foreground: "#cdd6f4",
+		caret: "#f5e0dc",
+		selection: "#b4befe33",
+		selectionMatch: "#b4befe22",
+		lineHighlight: "#181825",
+		gutterBackground: "#1e1e2e",
+		gutterForeground: "#7f849c",
+		gutterActiveForeground: "#cdd6f4",
+		gutterBorder: "transparent",
+		...codeMirrorSettings,
+	},
+	styles: [
+		{ tag: tags.comment, color: "#7f849c" },
+		{ tag: tags.keyword, color: "#cba6f7" },
+		{ tag: [tags.string, tags.special(tags.brace)], color: "#a6e3a1" },
+		{ tag: tags.number, color: "#fab387" },
+		{ tag: tags.bool, color: "#fab387" },
+		{ tag: tags.null, color: "#fab387" },
+		{
+			tag: [
+				tags.definition(tags.variableName),
+				tags.function(tags.variableName),
+			],
+			color: "#89b4fa",
+		},
+		{ tag: tags.variableName, color: "#cdd6f4" },
+		{ tag: tags.typeName, color: "#f9e2af" },
+		{ tag: tags.propertyName, color: "#89b4fa" },
+		{ tag: tags.operator, color: "#94e2d5" },
+		{ tag: tags.punctuation, color: "#a6adc8" },
+		{ tag: tags.tagName, color: "#f38ba8" },
+		{ tag: tags.attributeName, color: "#f9e2af" },
+	],
+});
+
 const ayuLightTheme = createTheme({
 	theme: "light",
 	settings: {
@@ -226,6 +391,45 @@ const ayuLightTheme = createTheme({
 	],
 });
 
+const quietGreenTheme = createTheme({
+	theme: "light",
+	settings: {
+		background: "#dbe7d7",
+		foreground: "#2d4a3e",
+		caret: "#e0705f",
+		selection: "#4a7c5933",
+		selectionMatch: "#4a7c5922",
+		lineHighlight: "#cdddc9",
+		gutterBackground: "#dbe7d7",
+		gutterForeground: "#7d9080",
+		gutterActiveForeground: "#2d4a3e",
+		gutterBorder: "transparent",
+		...codeMirrorSettings,
+	},
+	styles: [
+		{ tag: tags.comment, color: "#8a9c8d" },
+		{ tag: tags.keyword, color: "#2f8a7d" },
+		{ tag: [tags.string, tags.special(tags.brace)], color: "#6f8f3f" },
+		{ tag: tags.number, color: "#c2922f" },
+		{ tag: tags.bool, color: "#c2922f" },
+		{ tag: tags.null, color: "#c2922f" },
+		{
+			tag: [
+				tags.definition(tags.variableName),
+				tags.function(tags.variableName),
+			],
+			color: "#3f7d8f",
+		},
+		{ tag: tags.variableName, color: "#2d4a3e" },
+		{ tag: tags.typeName, color: "#b07a3c" },
+		{ tag: tags.propertyName, color: "#3f7d8f" },
+		{ tag: tags.operator, color: "#2f8a7d" },
+		{ tag: tags.punctuation, color: "#617066" },
+		{ tag: tags.tagName, color: "#e0705f" },
+		{ tag: tags.attributeName, color: "#c2922f" },
+	],
+});
+
 const githubDarkTheme = githubDarkInit({
 	settings: {
 		background: "#161b22",
@@ -245,8 +449,12 @@ const codeMirrorThemes: Record<ThemeName, Extension> = {
 	[ThemeNames.ShadesOfPurple]: shadesOfPurpleTheme,
 	[ThemeNames.CatppuccinLatte]: catppuccinLatteTheme,
 	[ThemeNames.AyuLight]: ayuLightTheme,
+	[ThemeNames.CatppuccinFrappe]: catppuccinFrappeTheme,
+	[ThemeNames.CatppuccinMacchiato]: catppuccinMacchiatoTheme,
+	[ThemeNames.CatppuccinMocha]: catppuccinMochaTheme,
 	[ThemeNames.GithubDark]: githubDarkTheme,
 	[ThemeNames.GithubLight]: githubLightTheme,
+	[ThemeNames.QuietGreen]: quietGreenTheme,
 };
 
 export const getCodeMirrorTheme = (themeName: ThemeName): Extension =>


### PR DESCRIPTION
#### Github Issue

relates to https://github.com/vianch/snippets/issues/{issue number}

#### Why are you creating this PR? What value is added?

Adds four new editor themes: Catppuccin Frappé, Catppuccin Macchiato, Catppuccin Mocha (dark variants), and Quiet Green (light). Each theme includes CSS variables, CodeMirror syntax highlighting, and Shiki preview support.

#### Include screenshots below (if appropriate)
