### PR TITLE
fix(snippet-item): truncate long titles with ellipsis

### DIFF
--- a/app/components/SnippetItem/SnippetItem.tsx
+++ b/app/components/SnippetItem/SnippetItem.tsx
@@ -92,8 +92,10 @@ const SnippetItem: FC<SnippetItemPropsComponent> = ({
 							}
 						/>
 					)}
-					{touched && isSnippetActive && "* "}
-					{snippet?.name ?? "Untitled"}
+					<span className={styles.snippetName} title={snippet?.name ?? ""}>
+						{touched && isSnippetActive && "* "}
+						{snippet?.name ?? "Untitled"}
+					</span>
 					<LanguageBadge language={snippet.language} />
 				</div>
 

--- a/app/components/SnippetList/snippetlist.module.css
+++ b/app/components/SnippetList/snippetlist.module.css
@@ -351,12 +351,20 @@
 	min-width: 0;
 	overflow: hidden;
 	white-space: nowrap;
+}
+
+/* Only the title truncates — icons and badge keep their space. */
+.snippetName {
+	min-width: 0;
+	overflow: hidden;
 	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .trashIcon,
 .restoreIcon,
 .listIcon {
+	flex-shrink: 0;
 	margin-right: 0.313rem;
 	transition:
 		color var(--duration-fast) var(--ease-fluid),
@@ -383,6 +391,7 @@
 
 .favoriteIconWrapper {
 	display: inline-flex;
+	flex-shrink: 0;
 	align-items: center;
 	cursor: pointer;
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
#### Github Issue

fixes #{ISSUE_NUMBER}

#### Why are you creating this PR? What value is added?

Long snippet titles overflow the sidebar layout. This fix wraps the title in a dedicated span with CSS text-overflow: ellipsis truncation, and adds flex-shrink: 0 on icons/badge so they keep their space while the title clips cleanly.

#### Include screenshots below (if appropriate)
