### PR TITLE
feat: add markdown file upload to snippet editor

### DIFF
--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -72,6 +72,7 @@ type CodeEditorProps = {
 	onWikiNavigate?: (target: string) => void;
 	onActiveSnippet?: (snippetId: UUID | null) => void;
 	onNewSnippet?: () => void;
+	onUploadMarkdown: (upload: UploadedMarkdown) => void;
 };
 
 const CodeEditor = ({
@@ -89,6 +90,7 @@ const CodeEditor = ({
 	onWikiNavigate,
 	onActiveSnippet,
 	onNewSnippet,
+	onUploadMarkdown,
 }: CodeEditorProps): ReactElement => {
 	const isMobile = useViewPortStore((state) => state.isMobile);
 	const theme = useUserStore((state) => state.theme) as ThemeName;
@@ -357,6 +359,7 @@ const CodeEditor = ({
 									getEditorView={() => editorViewRef.current}
 									isPreviewVisible={isPreviewVisible}
 									onTogglePreview={() => setIsPreviewVisible(!isPreviewVisible)}
+									onUploadMarkdown={onUploadMarkdown}
 									showFormattingActions={isMarkdownLanguage}
 									showPreviewToggle={showPreviewToggle}
 								/>

--- a/app/components/CodeEditor/MarkdownToolbar.tsx
+++ b/app/components/CodeEditor/MarkdownToolbar.tsx
@@ -1,11 +1,16 @@
-import { Fragment, ReactElement } from "react";
+import { ChangeEvent, Fragment, ReactElement, useRef } from "react";
 
 /* Lib */
 import markdownToolbarActions from "@/lib/markdown/markdownToolbarActions";
+import {
+	markdownExtensionPattern,
+	markdownFileAccept,
+} from "@/lib/constants/markdown.constants";
 
 /* Components */
 import EyeClosed from "@/components/ui/icons/EyeClosed";
 import EyeOpen from "@/components/ui/icons/EyeOpen";
+import Upload from "@/components/ui/icons/Upload";
 
 /* Types */
 import type { EditorView } from "@codemirror/view";
@@ -17,6 +22,7 @@ type MarkdownToolbarProps = {
 	getEditorView: () => EditorView | null;
 	isPreviewVisible: boolean;
 	onTogglePreview: () => void;
+	onUploadMarkdown: (upload: UploadedMarkdown) => void;
 	showFormattingActions: boolean;
 	showPreviewToggle: boolean;
 };
@@ -25,9 +31,12 @@ const MarkdownToolbar = ({
 	getEditorView,
 	isPreviewVisible,
 	onTogglePreview,
+	onUploadMarkdown,
 	showFormattingActions,
 	showPreviewToggle,
 }: MarkdownToolbarProps): ReactElement => {
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
 	const runAction = (apply: (view: EditorView) => void): void => {
 		const editorView = getEditorView();
 
@@ -36,6 +45,26 @@ const MarkdownToolbar = ({
 		}
 
 		apply(editorView);
+	};
+
+	const handleFileSelected = async (
+		event: ChangeEvent<HTMLInputElement>
+	): Promise<void> => {
+		const file = event.target.files?.[0];
+
+		// Reset so picking the same file twice still fires a change event.
+		if (fileInputRef.current) {
+			fileInputRef.current.value = "";
+		}
+
+		if (!file) {
+			return;
+		}
+
+		onUploadMarkdown({
+			content: await file.text(),
+			name: file.name.replace(markdownExtensionPattern, ""),
+		});
 	};
 
 	const previewToggleLabel = isPreviewVisible ? "Hide preview" : "Show preview";
@@ -69,6 +98,27 @@ const MarkdownToolbar = ({
 						</Fragment>
 					);
 				})}
+			{showFormattingActions && (
+				<>
+					<span aria-hidden="true" className={styles.divider} />
+					<button
+						aria-label="Upload markdown file"
+						className={styles.toolbarButton}
+						onClick={() => fileInputRef.current?.click()}
+						title="Upload markdown file"
+						type="button"
+					>
+						<Upload height={16} width={16} />
+					</button>
+					<input
+						accept={markdownFileAccept}
+						hidden
+						onChange={handleFileSelected}
+						ref={fileInputRef}
+						type="file"
+					/>
+				</>
+			)}
 			{showPreviewToggle && (
 				<button
 					aria-label={previewToggleLabel}

--- a/app/components/SnippetsWorkspace/SnippetsWorkspace.tsx
+++ b/app/components/SnippetsWorkspace/SnippetsWorkspace.tsx
@@ -26,6 +26,8 @@ import {
 	trashRestoreSnippet,
 } from "@/lib/storage/snippets";
 import { getSmartGroups, saveSmartGroups } from "@/lib/supabase/queries";
+import SupportedLanguages from "@/lib/config/languages";
+import languageExtensions from "@/lib/codeEditor";
 import { MenuItems, MenuPrefixes, SnippetState } from "@/lib/constants/core";
 import { DefaultSettingsSection } from "@/lib/constants/settings.constants";
 import { buildSettingsHash } from "@/utils/settings.utils";
@@ -69,6 +71,8 @@ const SnippetsWorkspace = ({
 	const [isLoading, setIsLoading] = useState<boolean>(true);
 	const [showUnsavedSnippetModal, setShowUnsavedSnippetModal] =
 		useState<boolean>(false);
+	const [pendingMarkdownUpload, setPendingMarkdownUpload] =
+		useState<UploadedMarkdown | null>(null);
 	const { addToast } = useToastStore();
 
 	const findIndexForCurrentSnippet = (currentSnippet: CurrentSnippet): number =>
@@ -78,11 +82,11 @@ const SnippetsWorkspace = ({
 		);
 
 	const setActiveSnippetId = (snippetId: UUID | null): void => {
-		setCodedEditorStates({
-			...codeEditorStates,
+		setCodedEditorStates((previousStates) => ({
+			...previousStates,
 			activeSnippetId: snippetId,
-			isSaving: codeEditorStates.touched,
-		});
+			isSaving: previousStates.touched,
+		}));
 	};
 
 	const findSnippetIndexById = (snippetId: UUID | null): number =>
@@ -106,10 +110,10 @@ const SnippetsWorkspace = ({
 	};
 
 	const touchedHandler = (touched: boolean): void => {
-		setCodedEditorStates({
-			...codeEditorStates,
+		setCodedEditorStates((previousStates) => ({
+			...previousStates,
 			touched,
-		});
+		}));
 	};
 
 	const getFolders = (snippetsLoaded: Snippet[]): void => {
@@ -232,11 +236,11 @@ const SnippetsWorkspace = ({
 			setSnippets(snippetsSorted);
 		}
 
-		setCodedEditorStates({
-			...codeEditorStates,
+		setCodedEditorStates((previousStates) => ({
+			...previousStates,
 			isSaving: false,
 			touched: false,
-		});
+		}));
 	};
 
 	const updateSnippetTagList = async (
@@ -270,24 +274,36 @@ const SnippetsWorkspace = ({
 		currentSnippet: CurrentSnippet,
 		fromButton: boolean | SnippetState.Favorite = false
 	): Promise<void> => {
-		const activeSnippet = snippets.find(
+		// Match on the snippet being saved, not on whatever is active now: the
+		// auto-save-on-switch path fires for the outgoing snippet. A snippet the
+		// list no longer holds was just trashed, so saving it would resurrect it —
+		// skip silently instead of warning about a snippet the user already dropped.
+		const storedSnippet = snippets.find(
 			(snippet: Snippet): boolean =>
-				snippet.snippet_id === codeEditorStates.activeSnippetId
+				snippet.snippet_id === currentSnippet?.snippet_id
 		);
 
+		if (!storedSnippet) {
+			setCodedEditorStates((previousStates) => ({
+				...previousStates,
+				isSaving: false,
+			}));
+
+			return;
+		}
+
 		if (
-			activeSnippet?.snippet_id &&
 			currentSnippet?.name &&
 			currentSnippet?.name?.length > 0 &&
 			currentSnippet?.snippet
 		) {
-			setCodedEditorStates({
-				...codeEditorStates,
+			setCodedEditorStates((previousStates) => ({
+				...previousStates,
 				isSaving: true,
-			});
+			}));
 
-			const previousTags = activeSnippet.tags ?? null;
-			const previousFolder = activeSnippet.folder ?? null;
+			const previousTags = storedSnippet.tags ?? null;
+			const previousFolder = storedSnippet.folder ?? null;
 			const updatedSnippet = {
 				...currentSnippet,
 				updated_at: new Date().toISOString(),
@@ -323,10 +339,10 @@ const SnippetsWorkspace = ({
 			}
 
 			setTimeout(() => {
-				setCodedEditorStates({
-					...codeEditorStates,
+				setCodedEditorStates((previousStates) => ({
+					...previousStates,
 					isSaving: false,
-				});
+				}));
 			}, 400);
 		}
 	};
@@ -545,10 +561,11 @@ const SnippetsWorkspace = ({
 		cloneSnippets.splice(foundIndex, 1);
 		setSnippets(cloneSnippets);
 
+		// No `touched: true` here — trashing is not an edit, and flagging it made
+		// the editor auto-save the snippet that was just removed on the switch.
 		setCodedEditorStates((prevStates) => ({
 			...prevStates,
 			isSaving: true,
-			touched: true,
 			activeSnippetId: pickNextActiveId(foundIndex, cloneSnippets),
 		}));
 
@@ -677,12 +694,38 @@ const SnippetsWorkspace = ({
 		});
 	};
 
-	const performCreateSnippet = async (): Promise<void> => {
+	const performCreateSnippet = async (
+		upload: UploadedMarkdown | null = null
+	): Promise<void> => {
 		const newSnippet = await setNewSnippet();
 
-		if (newSnippet) {
-			newSnippetHandler(newSnippet);
+		if (!newSnippet) {
+			return;
 		}
+
+		if (!upload) {
+			newSnippetHandler(newSnippet);
+
+			return;
+		}
+
+		const uploadedSnippet: CurrentSnippet = {
+			...newSnippet,
+			extension: languageExtensions[SupportedLanguages.Markdown],
+			language: SupportedLanguages.Markdown,
+			name: upload.name,
+			snippet: upload.content,
+		};
+
+		newSnippetHandler(uploadedSnippet);
+
+		await saveSnippet(uploadedSnippet);
+		await updateSnippetTagList();
+
+		addToast({
+			type: ToastType.Success,
+			message: `Imported "${upload.name}"`,
+		});
 	};
 
 	const createSnippetFromPalette = async (): Promise<void> => {
@@ -695,14 +738,31 @@ const SnippetsWorkspace = ({
 		await performCreateSnippet();
 	};
 
-	const handleConfirmCreateSnippet = async (): Promise<void> => {
-		setShowUnsavedSnippetModal(false);
+	const uploadMarkdownHandler = async (
+		upload: UploadedMarkdown
+	): Promise<void> => {
+		if (codeEditorStates.touched) {
+			setPendingMarkdownUpload(upload);
+			setShowUnsavedSnippetModal(true);
 
-		await performCreateSnippet();
+			return;
+		}
+
+		await performCreateSnippet(upload);
+	};
+
+	const handleConfirmCreateSnippet = async (): Promise<void> => {
+		const upload = pendingMarkdownUpload;
+
+		setShowUnsavedSnippetModal(false);
+		setPendingMarkdownUpload(null);
+
+		await performCreateSnippet(upload);
 	};
 
 	const handleCancelCreateSnippet = (): void => {
 		setShowUnsavedSnippetModal(false);
+		setPendingMarkdownUpload(null);
 	};
 
 	useEffect(() => {
@@ -787,6 +847,7 @@ const SnippetsWorkspace = ({
 						onWikiNavigate={handleWikiNavigate}
 						onActiveSnippet={setActiveSnippetId}
 						onNewSnippet={createSnippetFromPalette}
+						onUploadMarkdown={uploadMarkdownHandler}
 					/>
 				}
 			/>

--- a/app/components/ui/icons/Upload.tsx
+++ b/app/components/ui/icons/Upload.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from "react";
+
+import IconContainer from "@/components/ui/icons/Icon";
+
+const Upload = (props: Icon): ReactElement => {
+	return (
+		<IconContainer viewBox="0 0 256 256" {...props}>
+			<path d="M240,136v64a16,16,0,0,1-16,16H32a16,16,0,0,1-16-16V136a16,16,0,0,1,16-16H72a8,8,0,0,1,0,16H32v64H224V136H184a8,8,0,0,1,0-16h40A16,16,0,0,1,240,136ZM85.66,77.66,120,43.31V128a8,8,0,0,0,16,0V43.31l34.34,34.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,77.66Z"></path>
+		</IconContainer>
+	);
+};
+
+export default Upload;

--- a/app/lib/constants/markdown.constants.ts
+++ b/app/lib/constants/markdown.constants.ts
@@ -20,6 +20,9 @@ export const headingPattern = /^(#{1,6})\s/;
 export const numberedListPattern = /^\d+\.\s/;
 export const linkSyntaxPattern = /^\[(.*)\]\((.*)\)$/;
 
+export const markdownFileAccept = ".md,.markdown";
+export const markdownExtensionPattern = /\.(md|markdown)$/i;
+
 export const boldShortcutKey = "Mod-b";
 export const duplicateLineShortcutKey = "Mod-d";
 export const inlineCodeShortcutKey = "Mod-e";

--- a/types/markdown.d.ts
+++ b/types/markdown.d.ts
@@ -10,6 +10,11 @@ declare global {
 		label: string;
 	};
 
+	type UploadedMarkdown = {
+		content: string;
+		name: string;
+	};
+
 	type LinePrefixTransform = {
 		addToLine: (lineText: string, indexWithinSelection: number) => string;
 		isLinePrefixed: (lineText: string) => boolean;


### PR DESCRIPTION
#### Github Issue

relates to https://github.com/vianch/snippets/issues/

#### Why are you creating this PR? What value is added?

Adds ability to import `.md` / `.markdown` files directly into the snippet editor. Upload button appears in the markdown toolbar when editing a markdown snippet. Handles unsaved-changes prompt before importing, and creates a new markdown snippet from the uploaded content.

Also fixes stale-closure bugs in `setCodedEditorStates` calls throughout SnippetsWorkspace where the previous state was captured at call time instead of via functional update.

#### Include screenshots below (if appropriate)