### PR TITLE
feat(admin): add database explorer to admin panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ OPENROUTER_API_KEY=<SUBSTITUTE_OPENROUTER_API_KEY>
 OPENROUTER_MODEL=openrouter/free
 # Encrypts pluggable-storage connection configs (any string; hashed to a 32-byte key)
 STORAGE_CONFIG_SECRET=<SUBSTITUTE_STORAGE_CONFIG_SECRET>
+# Admin database explorer only. PostgREST cannot read information_schema, so the
+# explorer opens Supabase as plain Postgres. Use the POOLER URL (port 6543) —
+# a direct 5432 connection per serverless request exhausts the connection limit.
+SUPABASE_DB_URL=<SUBSTITUTE_SUPABASE_POOLER_CONNECTION_STRING>
 NEXT_PUBLIC_SENTRY_DSN=<SUBSTITUTE_SENTRY_DSN>
 # Optional: only needed for source-map upload at build time
 SENTRY_AUTH_TOKEN=<SUBSTITUTE_SENTRY_AUTH_TOKEN>

--- a/app/api/admin/database/route.ts
+++ b/app/api/admin/database/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import { logger } from "@/lib/logger/logger";
+import { loadActiveConfig } from "@/lib/storage/config.server";
+import { introspectSchema } from "@/lib/storage/server/introspect";
+import { runWithServerDriver } from "@/lib/storage/server/resolve";
+import { requireAdmin } from "@/lib/supabase/adminGuard";
+
+// Admin-only. Returns the live schema of whichever backend `storage_config`
+// currently points at. The source is never supplied by the client — it is read
+// from the active config — so switching backends switches this view with it.
+//
+// This connection bypasses RLS by design; `requireAdmin` is the only thing
+// standing between a signed-in user and every row, so it runs first and the
+// connection details never leave the server.
+export const GET = async (request: NextRequest): Promise<NextResponse> => {
+	const guard = await requireAdmin(request);
+
+	if (guard.error) {
+		return guard.error;
+	}
+
+	const config = await loadActiveConfig();
+
+	try {
+		const schema = await runWithServerDriver(config, async (driver) => ({
+			backend: config.backend,
+			dialect: driver.dialect,
+			tables: await introspectSchema(driver),
+		}));
+
+		return NextResponse.json(schema, {
+			headers: { "Cache-Control": "no-store" },
+		});
+	} catch (cause) {
+		logger.error(cause, { query: "introspect database schema" });
+
+		return NextResponse.json(
+			{
+				error:
+					cause instanceof Error
+						? cause.message
+						: "Schema introspection failed",
+			},
+			{ status: HttpStatusCode.InternalServerError }
+		);
+	}
+};

--- a/app/api/admin/database/rows/route.ts
+++ b/app/api/admin/database/rows/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import { logger } from "@/lib/logger/logger";
+import { loadActiveConfig } from "@/lib/storage/config.server";
+import { selectTablePage } from "@/lib/storage/server/introspect";
+import { runWithServerDriver } from "@/lib/storage/server/resolve";
+import { requireAdmin } from "@/lib/supabase/adminGuard";
+
+// Admin-only. One page of rows from any table in the active backend. `table` and
+// `orderBy` are identifiers and cannot be bound as parameters, so
+// `selectTablePage` validates them against `IdentifierPattern` before they reach
+// the SQL string — an invalid name throws and surfaces here as a 400.
+export const GET = async (request: NextRequest): Promise<NextResponse> => {
+	const guard = await requireAdmin(request);
+
+	if (guard.error) {
+		return guard.error;
+	}
+
+	const parameters = request.nextUrl.searchParams;
+	const table = parameters.get("table");
+
+	if (!table) {
+		return NextResponse.json(
+			{ error: "Missing table" },
+			{ status: HttpStatusCode.BadRequest }
+		);
+	}
+
+	const requestedPage = Number.parseInt(parameters.get("page") ?? "", 10);
+	const page =
+		Number.isFinite(requestedPage) && requestedPage > 0 ? requestedPage : 0;
+	const config = await loadActiveConfig();
+
+	try {
+		const rowsPage = await runWithServerDriver(config, (driver) =>
+			selectTablePage(driver, table, parameters.get("orderBy"), page)
+		);
+
+		return NextResponse.json(rowsPage, {
+			headers: { "Cache-Control": "no-store" },
+		});
+	} catch (cause) {
+		logger.error(cause, { query: `read rows from ${table}` });
+
+		return NextResponse.json(
+			{ error: cause instanceof Error ? cause.message : "Row read failed" },
+			{ status: HttpStatusCode.BadRequest }
+		);
+	}
+};

--- a/app/components/admin/AdminDashboard/AdminDashboard.tsx
+++ b/app/components/admin/AdminDashboard/AdminDashboard.tsx
@@ -8,10 +8,12 @@ import { demoAccountData } from "@/lib/constants/account";
 import { AdminTab } from "@/lib/constants/admin.constants";
 
 /* Components */
+import DatabaseExplorer from "@/components/admin/DatabaseExplorer/DatabaseExplorer";
 import SnippetAnalytics from "@/components/admin/SnippetAnalytics/SnippetAnalytics";
 import UserManagement from "@/components/admin/UserManagement/UserManagement";
 import Button from "@/components/ui/Button/Button";
 import Book from "@/components/ui/icons/Book";
+import Database from "@/components/ui/icons/Database";
 import ListChecks from "@/components/ui/icons/ListChecks";
 import ShieldCheck from "@/components/ui/icons/ShieldCheck";
 import User from "@/components/ui/icons/User";
@@ -38,6 +40,11 @@ const AdminDashboard = (): ReactElement => {
 			icon: <ListChecks width={18} height={18} />,
 			label: "Analytics",
 			value: AdminTab.Analytics,
+		},
+		{
+			icon: <Database width={18} height={18} />,
+			label: "Database",
+			value: AdminTab.Database,
 		},
 	];
 
@@ -77,11 +84,11 @@ const AdminDashboard = (): ReactElement => {
 			</aside>
 
 			<main className={styles.main}>
-				{section === AdminTab.Users ? (
+				{section === AdminTab.Users && (
 					<UserManagement isReadOnly={isReadOnly} />
-				) : (
-					<SnippetAnalytics />
 				)}
+				{section === AdminTab.Analytics && <SnippetAnalytics />}
+				{section === AdminTab.Database && <DatabaseExplorer />}
 			</main>
 		</div>
 	);

--- a/app/components/admin/DatabaseExplorer/DatabaseExplorer.tsx
+++ b/app/components/admin/DatabaseExplorer/DatabaseExplorer.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { ReactElement, useCallback, useEffect, useState } from "react";
+
+/* Constants */
+import { AdminApiPaths, RequestStatus } from "@/lib/constants/admin.constants";
+import { StorageBackendLabels } from "@/lib/constants/storage.constants";
+
+/* Components */
+import DatabaseTableGrid from "@/components/admin/DatabaseExplorer/DatabaseTableGrid";
+import Alert from "@/components/ui/Alert/Alert";
+import Button from "@/components/ui/Button/Button";
+import EmptyState from "@/components/ui/EmptyState/EmptyState";
+import Skeleton from "@/components/ui/Skeleton/Skeleton";
+import Database from "@/components/ui/icons/Database";
+import Rows from "@/components/ui/icons/Rows";
+
+/* Styles */
+import styles from "./databaseExplorer.module.css";
+
+// Read-only explorer over whichever backend `storage_config` points at. The
+// source is not selectable here on purpose — the server reports the active
+// backend, so this view follows the app's real database automatically.
+const DatabaseExplorer = (): ReactElement => {
+	const [schema, setSchema] = useState<DatabaseSchema | null>(null);
+	const [status, setStatus] = useState<RequestStatus>(RequestStatus.Loading);
+	const [message, setMessage] = useState<string>("");
+	const [selectedTable, setSelectedTable] = useState<string>("");
+	const [page, setPage] = useState<number>(0);
+	const [rowsPage, setRowsPage] = useState<DatabaseRowsPage | null>(null);
+	const [rowsStatus, setRowsStatus] = useState<RequestStatus>(
+		RequestStatus.Loading
+	);
+	const activeTable =
+		schema?.tables.find((table) => table.name === selectedTable) ?? null;
+	const totalPages = rowsPage
+		? Math.max(1, Math.ceil(rowsPage.total / rowsPage.pageSize))
+		: 1;
+
+	const readError = async (
+		response: Response | null,
+		fallback: string
+	): Promise<string> => {
+		const detail = response
+			? ((await response.json().catch(() => null)) as {
+					error?: string;
+				} | null)
+			: null;
+
+		return detail?.error ?? fallback;
+	};
+
+	const loadRows = useCallback(
+		async (table: DbTable, nextPage: number): Promise<void> => {
+			setRowsStatus(RequestStatus.Loading);
+
+			// Pagination needs a stable sort; the primary key is the only column
+			// guaranteed to provide one, so tables without a PK go unordered.
+			const primaryKey = table.columns.find((column) => column.isPrimaryKey);
+			const parameters = new URLSearchParams({
+				page: String(nextPage),
+				table: table.name,
+			});
+
+			if (primaryKey) {
+				parameters.set("orderBy", primaryKey.name);
+			}
+
+			const response = await fetch(
+				`${AdminApiPaths.database}/rows?${parameters.toString()}`
+			).catch(() => null);
+
+			if (!response?.ok) {
+				setMessage(await readError(response, "Could not read table rows"));
+				setRowsStatus(RequestStatus.Error);
+
+				return;
+			}
+
+			setRowsPage((await response.json()) as DatabaseRowsPage);
+			setMessage("");
+			setRowsStatus(RequestStatus.Ready);
+		},
+		[]
+	);
+
+	useEffect(() => {
+		const loadSchema = async (): Promise<void> => {
+			const response = await fetch(AdminApiPaths.database).catch(() => null);
+
+			if (!response?.ok) {
+				setMessage(await readError(response, "Could not read the schema"));
+				setStatus(RequestStatus.Error);
+
+				return;
+			}
+
+			const data = (await response.json()) as DatabaseSchema;
+
+			setSchema(data);
+			setSelectedTable(data.tables[0]?.name ?? "");
+			setStatus(RequestStatus.Ready);
+		};
+
+		loadSchema();
+	}, []);
+
+	useEffect(() => {
+		if (activeTable) {
+			loadRows(activeTable, page);
+		}
+	}, [activeTable, page, loadRows]);
+
+	const selectTableHandler = (name: string): void => {
+		// Re-clicking the active table must be a no-op. Without this, the resets
+		// below clear the rows while `selectedTable` stays put — so `activeTable`
+		// keeps its identity, the load effect never re-fires, and the grid empties.
+		if (name === selectedTable) {
+			return;
+		}
+
+		setSelectedTable(name);
+		setPage(0);
+		setRowsPage(null);
+		setMessage("");
+	};
+
+	if (status === RequestStatus.Loading) {
+		return (
+			<div className={styles.container}>
+				<Skeleton height="2rem" width="40%" />
+				<Skeleton height="18rem" />
+			</div>
+		);
+	}
+
+	if (status === RequestStatus.Error || !schema) {
+		return (
+			<div className={styles.container}>
+				<Alert severity="error">{message}</Alert>
+			</div>
+		);
+	}
+
+	return (
+		<div className={styles.container}>
+			{/* The selected table's meta lives up here, not above the grid, so the
+			    table list and the data table share the same top edge. */}
+			<header className={styles.header}>
+				<div className={styles.source}>
+					<Database width={20} height={20} />
+					<div className={styles.sourceText}>
+						<span className={styles.sourceName}>
+							{StorageBackendLabels[schema.backend]}
+						</span>
+						<span className={styles.sourceMeta}>
+							{schema.dialect} · {schema.tables.length} tables
+						</span>
+					</div>
+				</div>
+
+				{activeTable && (
+					<div className={styles.gridMeta}>
+						<span>
+							{activeTable.columns.length} columns · {rowsPage?.total ?? 0} rows
+						</span>
+						{activeTable.foreignKeys.map((foreignKey) => (
+							<span
+								key={`${foreignKey.column}-${foreignKey.targetTable}`}
+								className={styles.relation}
+							>
+								{foreignKey.column} → {foreignKey.targetTable}.
+								{foreignKey.targetColumn}
+							</span>
+						))}
+					</div>
+				)}
+			</header>
+
+			{schema.tables.length === 0 ? (
+				<EmptyState
+					title="No tables found"
+					description="The active backend has no tables in its default schema yet."
+				/>
+			) : (
+				<div className={styles.body}>
+					<nav className={styles.tableList}>
+						{schema.tables.map((table) => (
+							<button
+								key={table.name}
+								type="button"
+								className={`${styles.tableItem} ${table.name === selectedTable ? styles.tableItemActive : ""}`}
+								aria-current={table.name === selectedTable}
+								onClick={() => selectTableHandler(table.name)}
+							>
+								<Rows width={15} height={15} />
+								<span className={styles.tableName}>{table.name}</span>
+								<span className={styles.columnCount}>
+									{table.columns.length}
+								</span>
+							</button>
+						))}
+					</nav>
+
+					<section className={styles.grid}>
+						{message && <Alert severity="error">{message}</Alert>}
+
+						{rowsStatus === RequestStatus.Loading && (
+							<Skeleton height="18rem" />
+						)}
+
+						{rowsStatus === RequestStatus.Ready && activeTable && rowsPage && (
+							<DatabaseTableGrid
+								columns={activeTable.columns}
+								rows={rowsPage.rows}
+							/>
+						)}
+
+						{rowsPage && rowsPage.total > rowsPage.pageSize && (
+							<div className={styles.pager}>
+								<Button
+									variant="secondary"
+									disabled={page === 0}
+									onClick={() => setPage(page - 1)}
+								>
+									Previous
+								</Button>
+								<span className={styles.pageLabel}>
+									Page {page + 1} of {totalPages}
+								</span>
+								<Button
+									variant="secondary"
+									disabled={page + 1 >= totalPages}
+									onClick={() => setPage(page + 1)}
+								>
+									Next
+								</Button>
+							</div>
+						)}
+					</section>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default DatabaseExplorer;

--- a/app/components/admin/DatabaseExplorer/DatabaseTableGrid.tsx
+++ b/app/components/admin/DatabaseExplorer/DatabaseTableGrid.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { ReactElement } from "react";
+
+/* Constants */
+import { NullDisplayValue } from "@/lib/constants/database.constants";
+
+/* Components */
+import Table from "@/components/ui/Table/Table";
+
+/* Styles */
+import styles from "./databaseTableGrid.module.css";
+
+type DatabaseTableGridProps = {
+	columns: DbColumn[];
+	rows: Record<string, string | null>[];
+};
+
+const DatabaseTableGrid = ({
+	columns,
+	rows,
+}: DatabaseTableGridProps): ReactElement => {
+	const tableColumns: TableColumn[] = columns.map((column) => ({
+		label: `${column.name}  ${column.dataType}`,
+	}));
+
+	return (
+		<Table columns={tableColumns}>
+			{rows.map((row, index) => (
+				// ponytail: index key — a table may have no primary key, and the whole
+				// page is replaced on every fetch, so there is nothing stabler to use.
+				<tr key={index}>
+					{columns.map((column) => {
+						const value = row[column.name] ?? null;
+
+						return (
+							<td key={column.name} className={styles.cell}>
+								{value === null ? (
+									<span className={styles.nullValue}>{NullDisplayValue}</span>
+								) : (
+									<span className={styles.value} title={value}>
+										{value}
+									</span>
+								)}
+							</td>
+						);
+					})}
+				</tr>
+			))}
+		</Table>
+	);
+};
+
+export default DatabaseTableGrid;

--- a/app/components/admin/DatabaseExplorer/databaseExplorer.module.css
+++ b/app/components/admin/DatabaseExplorer/databaseExplorer.module.css
@@ -1,0 +1,131 @@
+.container {
+	display: flex;
+	flex-direction: column;
+	gap: 1.25rem;
+}
+
+.header {
+	display: flex;
+	gap: 1rem;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.source {
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+	color: var(--foreground-color);
+}
+
+.sourceText {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+}
+
+.sourceName {
+	font-size: var(--small-font-size);
+	font-weight: 600;
+}
+
+.sourceMeta {
+	font-size: var(--tiny-font-size);
+	color: var(--gray-color);
+}
+
+.body {
+	display: grid;
+	grid-template-columns: 220px minmax(0, 1fr);
+	gap: 1.25rem;
+	align-items: start;
+}
+
+.tableList {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	padding: 0.5rem;
+	background: var(--bg-color-dark);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+}
+
+.tableItem {
+	display: flex;
+	gap: 0.5rem;
+	align-items: center;
+	padding: 0.5rem 0.625rem;
+	font-size: var(--small-font-size);
+	color: var(--gray-color);
+	cursor: pointer;
+	background: none;
+	border: none;
+	border-radius: var(--border-radius);
+	transition: color var(--duration-fast) var(--ease-fluid);
+}
+
+.tableItem:hover {
+	color: var(--foreground-color);
+	background: var(--current-line);
+}
+
+.tableItemActive {
+	color: var(--foreground-color);
+	background: var(--current-line);
+}
+
+.tableName {
+	flex: 1;
+	overflow: hidden;
+	text-align: left;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.columnCount {
+	font-size: var(--tiny-font-size);
+	color: var(--gray-color);
+}
+
+.grid {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	min-width: 0;
+}
+
+.gridMeta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem 0.75rem;
+	align-items: center;
+	justify-content: flex-end;
+	font-size: var(--tiny-font-size);
+	color: var(--gray-color);
+}
+
+.relation {
+	padding: 0.125rem 0.5rem;
+	color: var(--cyan-color);
+	background: color-mix(in srgb, var(--cyan-color) 12%, transparent);
+	border-radius: var(--border-radius);
+}
+
+.pager {
+	display: flex;
+	gap: 0.75rem;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+.pageLabel {
+	font-size: var(--tiny-font-size);
+	color: var(--gray-color);
+}
+
+@media (width <= 900px) {
+	.body {
+		grid-template-columns: 1fr;
+	}
+}

--- a/app/components/admin/DatabaseExplorer/databaseTableGrid.module.css
+++ b/app/components/admin/DatabaseExplorer/databaseTableGrid.module.css
@@ -1,0 +1,19 @@
+.cell {
+	max-width: 260px;
+}
+
+/* Native truncation — no JS slicing, and the full value stays in the title. */
+.value {
+	display: block;
+	overflow: hidden;
+	font-family: monospace;
+	font-size: var(--tiny-font-size);
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.nullValue {
+	font-size: var(--tiny-font-size);
+	font-style: italic;
+	color: var(--gray-color);
+}

--- a/app/lib/constants/admin.constants.ts
+++ b/app/lib/constants/admin.constants.ts
@@ -3,6 +3,7 @@
 
 export const enum AdminTab {
 	Analytics = "analytics",
+	Database = "database",
 	Users = "users",
 }
 
@@ -63,6 +64,7 @@ export const MinPasswordLength = 6;
 
 export const AdminApiPaths = {
 	analytics: "/api/admin/analytics",
+	database: "/api/admin/database",
 	users: "/api/admin/users",
 } as const;
 

--- a/app/lib/constants/database.constants.ts
+++ b/app/lib/constants/database.constants.ts
@@ -1,0 +1,17 @@
+// Admin database explorer. Read-only introspection of the active storage
+// backend, so the constants here are about *reading* a schema safely: page size,
+// identifier validation, and the schema scope each dialect is limited to.
+
+export const DatabaseRowsPageSize = 50;
+
+// Table and column names are interpolated into SQL because neither `FROM` nor a
+// PRAGMA argument can be parameterized. Nothing matching this pattern can carry
+// a quote, space, semicolon, or comment marker, so interpolation is safe — this
+// is the injection boundary, not the quoting below it.
+export const IdentifierPattern = /^[A-Za-z_][A-Za-z0-9_]{0,62}$/;
+
+// The explorer stays inside one schema: `public` on PostgreSQL/Supabase, the
+// connection's own database on MySQL, the single file on SQLite/Turso.
+export const PostgresSchemaName = "public";
+
+export const NullDisplayValue = "NULL";

--- a/app/lib/storage/server/introspect.ts
+++ b/app/lib/storage/server/introspect.ts
@@ -1,0 +1,289 @@
+import {
+	DatabaseRowsPageSize,
+	IdentifierPattern,
+	PostgresSchemaName,
+} from "@/lib/constants/database.constants";
+import { SqlDialect } from "@/lib/constants/storage.constants";
+
+// Server-only. Generic schema introspection and paginated row reads for the
+// admin database explorer. Written once against `SqlDriver`, so PostgreSQL /
+// Supabase, MySQL, Turso and local SQLite are all covered by one code path.
+//
+// Every catalog query aliases its output to the same lowercase column names
+// (`table_name`, `name`, `data_type`, `not_null`, `primary_key`) because
+// information_schema reports them in different cases per engine, and normalizes
+// the two flag columns to 1/0 in SQL so one reader handles all three dialects.
+
+const text = (value: unknown): string =>
+	value === null || value === undefined ? "" : String(value);
+
+const truthy = (value: unknown): boolean =>
+	value === true || value === 1 || value === 1n || value === "1";
+
+const toColumn = (row: Record<string, unknown>): DbColumn => ({
+	dataType: text(row.data_type),
+	isPrimaryKey: truthy(row.primary_key),
+	name: text(row.name),
+	notNull: truthy(row.not_null),
+});
+
+const toForeignKey = (row: Record<string, unknown>): DbForeignKey => ({
+	column: text(row.column_name),
+	targetColumn: text(row.target_column),
+	targetTable: text(row.target_table),
+});
+
+// Groups the three flat catalog result sets into one table per row of `tableRows`.
+const assemble = (
+	tableRows: Record<string, unknown>[],
+	columnRows: Record<string, unknown>[],
+	foreignKeyRows: Record<string, unknown>[]
+): DbTable[] =>
+	tableRows.map((tableRow) => {
+		const name = text(tableRow.name);
+
+		return {
+			columns: columnRows
+				.filter((columnRow) => text(columnRow.table_name) === name)
+				.map(toColumn),
+			foreignKeys: foreignKeyRows
+				.filter((keyRow) => text(keyRow.table_name) === name)
+				.map(toForeignKey),
+			name,
+		};
+	});
+
+// PostgreSQL keeps primary and foreign keys in the constraint views rather than
+// on the column itself, so both need a join back through key_column_usage.
+const introspectPostgres = async (driver: SqlDriver): Promise<DbTable[]> => {
+	const tables = await driver.query(
+		`SELECT table_name AS name
+		 FROM information_schema.tables
+		 WHERE table_schema = ? AND table_type = 'BASE TABLE'
+		 ORDER BY table_name`,
+		[PostgresSchemaName]
+	);
+	const columns = await driver.query(
+		`SELECT column_info.table_name AS table_name,
+		        column_info.column_name AS name,
+		        column_info.data_type AS data_type,
+		        CASE WHEN column_info.is_nullable = 'NO' THEN 1 ELSE 0 END AS not_null,
+		        CASE WHEN primary_keys.column_name IS NULL THEN 0 ELSE 1 END AS primary_key
+		 FROM information_schema.columns AS column_info
+		 LEFT JOIN (
+		   SELECT key_usage.table_name AS table_name,
+		          key_usage.column_name AS column_name
+		   FROM information_schema.table_constraints AS constraint_info
+		   JOIN information_schema.key_column_usage AS key_usage
+		     ON key_usage.constraint_name = constraint_info.constraint_name
+		    AND key_usage.table_schema = constraint_info.table_schema
+		   WHERE constraint_info.table_schema = ?
+		     AND constraint_info.constraint_type = 'PRIMARY KEY'
+		 ) AS primary_keys
+		   ON primary_keys.table_name = column_info.table_name
+		  AND primary_keys.column_name = column_info.column_name
+		 WHERE column_info.table_schema = ?
+		 ORDER BY column_info.table_name, column_info.ordinal_position`,
+		[PostgresSchemaName, PostgresSchemaName]
+	);
+	const foreignKeys = await driver.query(
+		`SELECT constraint_info.table_name AS table_name,
+		        key_usage.column_name AS column_name,
+		        target_usage.table_name AS target_table,
+		        target_usage.column_name AS target_column
+		 FROM information_schema.table_constraints AS constraint_info
+		 JOIN information_schema.key_column_usage AS key_usage
+		   ON key_usage.constraint_name = constraint_info.constraint_name
+		  AND key_usage.table_schema = constraint_info.table_schema
+		 JOIN information_schema.constraint_column_usage AS target_usage
+		   ON target_usage.constraint_name = constraint_info.constraint_name
+		  AND target_usage.table_schema = constraint_info.table_schema
+		 WHERE constraint_info.table_schema = ?
+		   AND constraint_info.constraint_type = 'FOREIGN KEY'`,
+		[PostgresSchemaName]
+	);
+
+	return assemble(tables.rows, columns.rows, foreignKeys.rows);
+};
+
+// MySQL is friendlier here: `column_key` already flags primary keys and
+// key_column_usage carries the referenced table/column inline. `column_type` is
+// used over `data_type` because it keeps the length (`varchar(36)`).
+const introspectMysql = async (driver: SqlDriver): Promise<DbTable[]> => {
+	const tables = await driver.query(
+		`SELECT table_name AS name
+		 FROM information_schema.tables
+		 WHERE table_schema = database() AND table_type = 'BASE TABLE'
+		 ORDER BY table_name`,
+		[]
+	);
+	const columns = await driver.query(
+		`SELECT table_name AS table_name,
+		        column_name AS name,
+		        column_type AS data_type,
+		        CASE WHEN is_nullable = 'NO' THEN 1 ELSE 0 END AS not_null,
+		        CASE WHEN column_key = 'PRI' THEN 1 ELSE 0 END AS primary_key
+		 FROM information_schema.columns
+		 WHERE table_schema = database()
+		 ORDER BY table_name, ordinal_position`,
+		[]
+	);
+	const foreignKeys = await driver.query(
+		`SELECT table_name AS table_name,
+		        column_name AS column_name,
+		        referenced_table_name AS target_table,
+		        referenced_column_name AS target_column
+		 FROM information_schema.key_column_usage
+		 WHERE table_schema = database() AND referenced_table_name IS NOT NULL`,
+		[]
+	);
+
+	return assemble(tables.rows, columns.rows, foreignKeys.rows);
+};
+
+// SQLite has no information_schema, but every PRAGMA has an eponymous
+// table-valued function — so the table name binds as a parameter instead of
+// being interpolated. `notnull`, `from`, `to` and `table` are quoted as they are
+// keywords or ambiguous bare words.
+const introspectSqlite = async (driver: SqlDriver): Promise<DbTable[]> => {
+	const tables = await driver.query(
+		`SELECT name AS name
+		 FROM sqlite_master
+		 WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+		 ORDER BY name`,
+		[]
+	);
+	const collected: DbTable[] = [];
+
+	// ponytail: one PRAGMA pair per table (N+1). Fine at POC table counts; batch
+	// into a single UNION ALL over pragma_table_info if a target grows to hundreds.
+	for (const tableRow of tables.rows) {
+		const name = text(tableRow.name);
+		const columns = await driver.query(
+			`SELECT name AS name,
+			        type AS data_type,
+			        "notnull" AS not_null,
+			        CASE WHEN pk > 0 THEN 1 ELSE 0 END AS primary_key
+			 FROM pragma_table_info(?)`,
+			[name]
+		);
+		const foreignKeys = await driver.query(
+			`SELECT "from" AS column_name,
+			        "table" AS target_table,
+			        "to" AS target_column
+			 FROM pragma_foreign_key_list(?)`,
+			[name]
+		);
+
+		collected.push({
+			columns: columns.rows.map(toColumn),
+			foreignKeys: foreignKeys.rows.map(toForeignKey),
+			name,
+		});
+	}
+
+	return collected;
+};
+
+export const introspectSchema = async (
+	driver: SqlDriver
+): Promise<DbTable[]> => {
+	if (driver.dialect === SqlDialect.Postgres) {
+		return introspectPostgres(driver);
+	}
+
+	if (driver.dialect === SqlDialect.Mysql) {
+		return introspectMysql(driver);
+	}
+
+	return introspectSqlite(driver);
+};
+
+// Identifiers cannot be bound, so they are validated against
+// `IdentifierPattern` first and only then quoted for the dialect. Rejecting
+// early means a name carrying a quote or semicolon never reaches the SQL string.
+const quoteIdentifier = (name: string, dialect: SqlDialectType): string => {
+	if (!IdentifierPattern.test(name)) {
+		throw new Error(`Invalid identifier: ${name}`);
+	}
+
+	if (dialect === SqlDialect.Mysql) {
+		return `\`${name}\``;
+	}
+
+	return `"${name}"`;
+};
+
+// Qualifying PostgreSQL with `public` keeps reads inside the same scope the
+// introspection listed, regardless of the connection's search_path.
+const qualifiedTable = (table: string, dialect: SqlDialectType): string => {
+	const quoted = quoteIdentifier(table, dialect);
+
+	if (dialect === SqlDialect.Postgres) {
+		return `"${PostgresSchemaName}".${quoted}`;
+	}
+
+	return quoted;
+};
+
+// Every cell is stringified here because this view is read-only, which also
+// sidesteps bigint (libSQL/mysql2), Buffer and Date not surviving JSON.
+// Revisit when the grid becomes editable and needs real types round-tripped.
+const toCell = (value: unknown): string | null => {
+	if (value === null || value === undefined) {
+		return null;
+	}
+
+	if (value instanceof Date) {
+		return value.toISOString();
+	}
+
+	if (value instanceof Uint8Array) {
+		return `\\x${Buffer.from(value).toString("hex")}`;
+	}
+
+	if (typeof value === "bigint") {
+		return value.toString();
+	}
+
+	if (typeof value === "object") {
+		return JSON.stringify(value);
+	}
+
+	return String(value);
+};
+
+export const selectTablePage = async (
+	driver: SqlDriver,
+	table: string,
+	orderBy: string | null,
+	page: number
+): Promise<DatabaseRowsPage> => {
+	const target = qualifiedTable(table, driver.dialect);
+	// Without a primary key there is no stable sort, so rows are left in whatever
+	// order the engine returns rather than inventing one.
+	const order = orderBy
+		? ` ORDER BY ${quoteIdentifier(orderBy, driver.dialect)}`
+		: "";
+	// ponytail: COUNT(*) scans on every page. Swap for a catalog estimate if a
+	// target table ever gets big enough for the scan to show.
+	const counted = await driver.query(
+		`SELECT COUNT(*) AS total FROM ${target}`,
+		[]
+	);
+	const selected = await driver.query(
+		`SELECT * FROM ${target}${order} LIMIT ? OFFSET ?`,
+		[DatabaseRowsPageSize, page * DatabaseRowsPageSize]
+	);
+
+	return {
+		page,
+		pageSize: DatabaseRowsPageSize,
+		rows: selected.rows.map((row) =>
+			Object.fromEntries(
+				Object.entries(row).map(([column, value]) => [column, toCell(value)])
+			)
+		),
+		total: Number(counted.rows[0]?.total ?? 0),
+	};
+};

--- a/app/lib/storage/server/resolve.ts
+++ b/app/lib/storage/server/resolve.ts
@@ -4,13 +4,26 @@ import { createMysqlDriver } from "@/lib/storage/server/drivers/mysql";
 import { createPgDriver } from "@/lib/storage/server/drivers/pg";
 import { createSqlSnippetStorage } from "@/lib/storage/server/sqlStorage";
 
-// Server-only. Builds the right SQL driver for the active credentialed backend.
-// Supabase never reaches here — it runs in the client.
+// Server-only. Builds the right SQL driver for the active backend.
+//
+// Snippet *persistence* on Supabase runs in the client over PostgREST and never
+// reaches here. The admin database explorer does, because PostgREST cannot run
+// raw SQL or read information_schema — so Supabase is opened as what it is,
+// plain PostgreSQL, over SUPABASE_DB_URL.
 
 // Guards against silently-empty connections (e.g. a blank Turso config would
 // otherwise fall back to a local file and pass a bogus connectivity test).
 const assertConnection = (config: StorageConfig): void => {
 	const { connection } = config;
+
+	if (
+		config.backend === StorageBackend.Supabase &&
+		!process.env.SUPABASE_DB_URL?.trim()
+	) {
+		throw new Error(
+			"Reading the Supabase database directly requires SUPABASE_DB_URL"
+		);
+	}
 
 	if (config.backend === StorageBackend.Turso && !connection.url?.trim()) {
 		throw new Error("Turso requires a database URL");
@@ -43,6 +56,14 @@ const createDriver = async (config: StorageConfig): Promise<SqlDriver> => {
 		return createMysqlDriver(config.connection);
 	}
 
+	// Supabase is PostgreSQL. Use the *pooler* URL (port 6543) — a direct 5432
+	// connection per serverless request exhausts the instance's connection limit.
+	if (config.backend === StorageBackend.Supabase) {
+		return createPgDriver({
+			connectionString: process.env.SUPABASE_DB_URL ?? "",
+		});
+	}
+
 	if (config.backend === StorageBackend.Postgres) {
 		return createPgDriver(config.connection);
 	}
@@ -58,20 +79,30 @@ const createDriver = async (config: StorageConfig): Promise<SqlDriver> => {
 	throw new Error(`Backend ${config.backend} does not run server-side`);
 };
 
-// Opens a driver, runs the callback against a SnippetStorage, and always closes
-// the connection (serverless = one op per request, so no pooling reuse).
-export const runWithServerStorage = async <ResultType>(
+// Opens a driver, hands the raw driver to the callback, and always closes the
+// connection (serverless = one op per request, so no pooling reuse). Used by the
+// admin explorer, which needs arbitrary SQL rather than the snippet interface.
+export const runWithServerDriver = async <ResultType>(
 	config: StorageConfig,
-	callback: (storage: SnippetStorage) => Promise<ResultType>
+	callback: (driver: SqlDriver) => Promise<ResultType>
 ): Promise<ResultType> => {
 	const driver = await createDriver(config);
 
 	try {
-		return await callback(createSqlSnippetStorage(driver));
+		return await callback(driver);
 	} finally {
 		await driver.close();
 	}
 };
+
+// Same lifecycle, but scoped to the SnippetStorage interface app code uses.
+export const runWithServerStorage = async <ResultType>(
+	config: StorageConfig,
+	callback: (storage: SnippetStorage) => Promise<ResultType>
+): Promise<ResultType> =>
+	runWithServerDriver(config, (driver) =>
+		callback(createSqlSnippetStorage(driver))
+	);
 
 export const testServerConnection = async (
 	config: StorageConfig

--- a/types/database.d.ts
+++ b/types/database.d.ts
@@ -1,0 +1,45 @@
+declare global {
+	// One column as reported by the active backend's own catalog. `dataType` is
+	// the backend's native type name, not a normalized one — the explorer shows
+	// the database as it actually is.
+	type DbColumn = {
+		dataType: string;
+		isPrimaryKey: boolean;
+		name: string;
+		notNull: boolean;
+	};
+
+	// One single-column foreign key edge. Composite keys arrive as one entry per
+	// column, which is enough to draw the relation.
+	type DbForeignKey = {
+		column: string;
+		targetColumn: string;
+		targetTable: string;
+	};
+
+	type DbTable = {
+		columns: DbColumn[];
+		foreignKeys: DbForeignKey[];
+		name: string;
+	};
+
+	// Live schema of whichever backend `storage_config` currently points at. The
+	// client never picks the source, so `backend`/`dialect` are reported, not sent.
+	type DatabaseSchema = {
+		backend: StorageBackendType;
+		dialect: SqlDialectType;
+		tables: DbTable[];
+	};
+
+	// One page of rows. Values are pre-stringified server-side (read-only view),
+	// so bigint/Buffer/Date all survive JSON transport. `null` stays null so the
+	// grid can tell an empty string from a NULL.
+	type DatabaseRowsPage = {
+		page: number;
+		pageSize: number;
+		rows: Record<string, string | null>[];
+		total: number;
+	};
+}
+
+export {};


### PR DESCRIPTION
#### Why are you creating this PR? What value is added?

Adds a database explorer to the admin panel that allows viewing all tables in the Supabase database and inspecting their contents.

**Changes:**
- DatabaseExplorer component with table listing and row preview
- DatabaseTableGrid component for table data display
- `/api/admin/database` and `/api/admin/database/rows` API routes
- Supabase schema introspection utility (`introspect.ts`)
- Database types and constants
- Wired up in AdminDashboard with table navigation

**Features:**
- Lists all tables in the database
- Shows row count per table
- Preview table data with pagination
- Click into any table to see its contents