### PR TITLE
feat: add focus mode, font preview, and markdown toolbar

### DIFF
--- a/app/components/AccountModal/AccountModal.tsx
+++ b/app/components/AccountModal/AccountModal.tsx
@@ -13,10 +13,11 @@ import {
 	getUserEmailBySession,
 	updateUser,
 } from "@/lib/supabase/queries";
+import { isValidFont } from "@/lib/config/fonts";
 import { settingsSections } from "@/lib/config/settings";
 import { ThemeName, isValidTheme } from "@/lib/config/themes";
 import { setCookie } from "@/lib/cookies";
-import { themeCookieName } from "@/lib/constants/cookies";
+import { fontCookieName, themeCookieName } from "@/lib/constants/cookies";
 
 /* Constants */
 import {
@@ -40,6 +41,7 @@ import Button from "@/components/ui/Button/Button";
 import Alert from "@/components/ui/Alert/Alert";
 import Switch from "@/components/ui/Switch/Switch";
 import DatabaseSettings from "@/components/AccountModal/DatabaseSettings";
+import FontPreview from "@/components/AccountModal/FontPreview";
 import SettingsSidebar from "@/components/AccountModal/SettingsSidebar";
 import ThemePreview from "@/components/AccountModal/ThemePreview";
 import TwoFactorSettings from "@/components/TwoFactorSettings/TwoFactorSettings";
@@ -83,6 +85,9 @@ const AccountModal = (): ReactElement | null => {
 	const [originalTheme, setOriginalTheme] = useState<string | undefined>(
 		accountInitialStateData.theme
 	);
+	const [originalFont, setOriginalFont] = useState<string | undefined>(
+		accountInitialStateData.font
+	);
 	const [aiModels, setAiModels] = useState<string[]>([]);
 	const [originalAiUrl, setOriginalAiUrl] = useState<string>("");
 	const [modelsLoading, setModelsLoading] = useState(false);
@@ -117,6 +122,15 @@ const AccountModal = (): ReactElement | null => {
 		useUserStore.getState().setTheme(themeName);
 	};
 
+	const handleFontChange = (fontName: FontName): void => {
+		setUserData((prev) => ({
+			...prev,
+			font: fontName,
+		}));
+
+		useUserStore.getState().setFont(fontName);
+	};
+
 	// Apply theme to the document whenever userData.theme changes (optimistic update)
 	useEffect(() => {
 		if (userData.theme) {
@@ -124,6 +138,14 @@ const AccountModal = (): ReactElement | null => {
 			setCookie(themeCookieName, userData.theme);
 		}
 	}, [userData.theme]);
+
+	// Apply font to the document whenever userData.font changes (optimistic update)
+	useEffect(() => {
+		if (userData.font) {
+			document.documentElement.dataset.font = userData.font;
+			setCookie(fontCookieName, userData.font);
+		}
+	}, [userData.font]);
 
 	const refreshModels = async (provider?: AiProvider): Promise<void> => {
 		const activeProvider =
@@ -212,6 +234,7 @@ const AccountModal = (): ReactElement | null => {
 			username: userData.username,
 			avatar: userData.avatar,
 			theme: userData.theme,
+			font: userData.font,
 			auto_save: userData.autoSave ?? false,
 			ai_provider: userData.aiProvider ?? AiProviderId.Ollama,
 			ai_api_key: userData.aiApiKey ?? "",
@@ -236,20 +259,31 @@ const AccountModal = (): ReactElement | null => {
 		const { hasUserNameChanged, hasUserAvatarChanged } =
 			checkForUserDataChanges();
 		const hasThemeChanged = userData.theme !== originalTheme;
+		const hasFontChanged = userData.font !== originalFont;
 
 		useUserStore.getState().setAutoSave(userData.autoSave ?? false);
 		useChatStore.getState().setSelectedModel(userData.aiModel ?? "");
 
-		if (hasUserNameChanged || hasUserAvatarChanged || hasThemeChanged) {
+		if (
+			hasUserNameChanged ||
+			hasUserAvatarChanged ||
+			hasThemeChanged ||
+			hasFontChanged
+		) {
 			setStoreUserData({
 				userName: userData.username,
 				userAvatar: userData.avatar,
 				email: userData.email,
 				theme: userData.theme,
+				font: userData.font,
 			});
 
 			if (hasThemeChanged) {
 				setOriginalTheme(userData.theme);
+			}
+
+			if (hasFontChanged) {
+				setOriginalFont(userData.font);
 			}
 		}
 	};
@@ -319,6 +353,12 @@ const AccountModal = (): ReactElement | null => {
 			useUserStore.getState().setTheme(originalTheme);
 		}
 
+		if (originalFont && userData.font !== originalFont) {
+			document.documentElement.dataset.font = originalFont;
+			setCookie(fontCookieName, originalFont);
+			useUserStore.getState().setFont(originalFont);
+		}
+
 		close();
 	};
 
@@ -377,6 +417,14 @@ const AccountModal = (): ReactElement | null => {
 						theme: userMetadata.theme,
 					}));
 					setOriginalTheme(userMetadata.theme);
+				}
+
+				if (userMetadata?.font && isValidFont(userMetadata.font)) {
+					setUserData((prev) => ({
+						...prev,
+						font: userMetadata.font,
+					}));
+					setOriginalFont(userMetadata.font);
 				}
 
 				if (userMetadata?.auto_save !== undefined) {
@@ -630,6 +678,15 @@ const AccountModal = (): ReactElement | null => {
 				<ThemePreview
 					activeTheme={userData.theme}
 					onThemeChange={handleThemeChange}
+				/>
+			</div>
+
+			{/* Typography */}
+			<div className={styles.section}>
+				<h3 className={styles.sectionTitle}>Typography</h3>
+				<FontPreview
+					activeFont={userData.font}
+					onFontChange={handleFontChange}
 				/>
 			</div>
 

--- a/app/components/AccountModal/FontPreview.tsx
+++ b/app/components/AccountModal/FontPreview.tsx
@@ -1,0 +1,47 @@
+import { ReactElement } from "react";
+
+/* Lib */
+import { fontList } from "@/lib/config/fonts";
+
+/* Styles */
+import styles from "./accountModal.module.css";
+
+type FontPreviewProps = {
+	activeFont?: string;
+	onFontChange: (fontName: FontName) => void;
+};
+
+const FontPreview = ({
+	activeFont,
+	onFontChange,
+}: FontPreviewProps): ReactElement => {
+	return (
+		<div className={styles.fontGrid}>
+			{fontList.map((fontConfig) => (
+				<button
+					key={fontConfig.name}
+					type="button"
+					className={`${styles.fontOption} ${
+						activeFont === fontConfig.name ? styles.fontOptionSelected : ""
+					}`}
+					onClick={() => onFontChange(fontConfig.name)}
+				>
+					<span
+						className={styles.fontPreviewSample}
+						style={{ fontFamily: `var(${fontConfig.cssVariable})` }}
+					>
+						Aa
+					</span>
+					<span
+						className={styles.fontName}
+						style={{ fontFamily: `var(${fontConfig.cssVariable})` }}
+					>
+						{fontConfig.label}
+					</span>
+				</button>
+			))}
+		</div>
+	);
+};
+
+export default FontPreview;

--- a/app/components/AccountModal/accountModal.module.css
+++ b/app/components/AccountModal/accountModal.module.css
@@ -432,6 +432,74 @@
 	transition: color var(--duration-fast) var(--ease-fluid);
 }
 
+.fontGrid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 0.75rem;
+}
+
+.fontOption {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.375rem;
+	padding: 0.75rem 0.5rem;
+	border: 2px solid var(--border-color);
+	border-radius: var(--border-radius-md);
+	background: none;
+	cursor: pointer;
+	transition:
+		border-color var(--duration-fast) var(--ease-fluid),
+		box-shadow var(--duration-base) var(--ease-fluid),
+		transform var(--duration-base) var(--ease-spring);
+	color: var(--gray-color);
+}
+
+.fontOption:hover {
+	border-color: var(--green-color);
+	transform: translateY(-2px);
+	box-shadow: 0 8px 20px rgb(0 0 0 / 22%);
+}
+
+.fontOption:active {
+	transform: translateY(0) scale(0.98);
+}
+
+.fontOptionSelected {
+	border-color: var(--green-color);
+	box-shadow: 0 0 0 2px var(--green-color);
+}
+
+.fontOptionSelected::after {
+	content: "✓";
+	position: absolute;
+	top: 0.375rem;
+	right: 0.375rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.125rem;
+	height: 1.125rem;
+	border-radius: 50%;
+	background: var(--green-color);
+	color: var(--bg-color-dark);
+	font-size: 0.625rem;
+	font-weight: 700;
+}
+
+.fontPreviewSample {
+	font-size: var(--big-font-size);
+	line-height: 1;
+}
+
+.fontName {
+	font-size: var(--tiny-font-size);
+	white-space: nowrap;
+	transition: color var(--duration-fast) var(--ease-fluid);
+}
+
 @media (width <= 768px) {
 	.accountModal {
 		max-width: 100%;

--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { ReactElement, useMemo, useRef, useState } from "react";
+import { ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import { EditorView } from "@codemirror/view";
 import CodeMirror from "@uiw/react-codemirror";
-
-import type { EditorView } from "@codemirror/view";
 
 /* Lib */
 import SupportedLanguages from "@/lib/config/languages";
@@ -25,6 +24,7 @@ import { requestAiAction } from "@/utils/ai.utils";
 
 /* Hooks */
 import useCurrentSnippet from "@/components/CodeEditor/hooks/useCurrentSnippet";
+import useFocusModeShortcut from "@/components/CodeEditor/hooks/useFocusModeShortcut";
 import useKeyboardSave from "@/components/CodeEditor/hooks/useKeyboardSave";
 import usePreviewResize from "@/components/CodeEditor/hooks/usePreviewResize";
 
@@ -32,6 +32,7 @@ import usePreviewResize from "@/components/CodeEditor/hooks/usePreviewResize";
 import CodeEditorTags from "@/components/CodeEditor/CodeEditorTags";
 import CodeEditorHeader from "@/components/CodeEditor/CodeEditorHeader";
 import CodeEditorActions from "@/components/CodeEditor/CodeEditorActions";
+import FocusModeBar from "@/components/CodeEditor/FocusModeBar";
 import MarkdownToolbar from "@/components/CodeEditor/MarkdownToolbar";
 import SnippetDetails from "@/components/CodeEditor/SnippetDetails/SnippetDetails";
 import History from "@/components/History/History";
@@ -93,6 +94,8 @@ const CodeEditor = ({
 	onUploadMarkdown,
 }: CodeEditorProps): ReactElement => {
 	const isMobile = useViewPortStore((state) => state.isMobile);
+	const isFocusMode = useViewPortStore((state) => state.isFocusMode);
+	const setFocusMode = useViewPortStore((state) => state.setFocusMode);
 	const theme = useUserStore((state) => state.theme) as ThemeName;
 	const { menuType } = codeEditorStates ?? {};
 	const isTrashActive = menuType === "trash";
@@ -180,28 +183,83 @@ const CodeEditor = ({
 	const showChatPane = isChatMode && !isTrashActive;
 	const hasRightPane = showPreview || showChatPane;
 	const showPreviewToggle = hasPreviewPanel && !isChatMode;
+	const canToggleFocusMode = isMarkdownLanguage && !isTrashActive;
+
+	// Long-form prose fixes: wrap instead of horizontal-scrolling, and let the
+	// browser spellcheck markdown content the way it would a text field.
+	const markdownProseExtensions = useMemo(
+		() =>
+			isMarkdownLanguage && !isTrashActive
+				? [
+						EditorView.lineWrapping,
+						EditorView.contentAttributes.of({ spellcheck: "true" }),
+					]
+				: [],
+		[isMarkdownLanguage, isTrashActive]
+	);
+
 	const showMarkdownToolbar =
 		!isMobile &&
 		!isTrashActive &&
+		!isFocusMode &&
 		(isMarkdownLanguage || (hasPreviewPanel && !isChatMode));
+
+	const toggleFocusModeHandler = (): void => {
+		if (!canToggleFocusMode) {
+			return;
+		}
+
+		setFocusMode(!isFocusMode);
+	};
+
+	useFocusModeShortcut({
+		canToggleFocusMode,
+		isFocusMode,
+		onExit: () => setFocusMode(false),
+		onToggle: toggleFocusModeHandler,
+	});
+
+	// Focus mode is only meaningful for markdown, outside trash. If either
+	// condition stops holding while it's on (language switch, trash open),
+	// drop back to the normal layout instead of leaving a broken overlay.
+	useEffect(() => {
+		if (isFocusMode && !canToggleFocusMode) {
+			setFocusMode(false);
+		}
+	}, [isFocusMode, canToggleFocusMode, setFocusMode]);
+
+	useEffect(() => {
+		if (!isFocusMode) {
+			return;
+		}
+
+		const previousOverflow = document.body.style.overflow;
+
+		document.body.style.overflow = "hidden";
+
+		return () => {
+			document.body.style.overflow = previousOverflow;
+		};
+	}, [isFocusMode]);
 
 	const editorHeight = calculateEditorHeight({
 		hasMarkdownToolbar: showMarkdownToolbar,
 		hasRightPane,
+		isFocusMode,
 		isMobile,
 		isTrashActive,
 	});
-	const previewHeight = calculatePreviewHeight(isMobile);
+	const previewHeight = calculatePreviewHeight(isMobile, isFocusMode);
 
 	return (
 		<div
-			className={`${styles.codeEditorContainer} ${!snippet && !isLoading && styles.noSnippetContainer}`}
+			className={`${styles.codeEditorContainer} ${!snippet && !isLoading && styles.noSnippetContainer} ${isFocusMode ? styles.focusOverlay : ""}`}
 		>
 			{isLoading ? (
 				<SkeletonCodeEditor />
 			) : snippet ? (
 				<>
-					{!isTrashActive && (
+					{!isTrashActive && !isFocusMode && (
 						<>
 							<CodeEditorHeader
 								currentSnippet={currentSnippet}
@@ -311,6 +369,17 @@ const CodeEditor = ({
 						</>
 					)}
 
+					{isFocusMode && (
+						<FocusModeBar
+							content={currentSnippet.snippet ?? ""}
+							isPreviewVisible={isPreviewVisible}
+							showPreviewToggle={showPreviewToggle}
+							snippetName={currentSnippet.name ?? ""}
+							onExit={() => setFocusMode(false)}
+							onTogglePreview={() => setIsPreviewVisible(!isPreviewVisible)}
+						/>
+					)}
+
 					{/* One stable tree for every mode: the right pane, resizer, and
 					    toolbar toggle in and out around a single CodeMirror instance,
 					    so toggling the preview never remounts the editor (which would
@@ -347,7 +416,7 @@ const CodeEditor = ({
 								showChatPane && isMobile && mobileChatTab !== AiPaneTab.Code
 									? styles.paneHidden
 									: ""
-							}`}
+							} ${isFocusMode && !hasRightPane ? styles.focusEditorPanel : ""}`}
 							style={
 								!isMobile
 									? { width: hasRightPane ? `${editorWidthPercent}%` : "100%" }
@@ -357,7 +426,9 @@ const CodeEditor = ({
 							{showMarkdownToolbar && (
 								<MarkdownToolbar
 									getEditorView={() => editorViewRef.current}
+									isFocusMode={isFocusMode}
 									isPreviewVisible={isPreviewVisible}
+									onToggleFocusMode={toggleFocusModeHandler}
 									onTogglePreview={() => setIsPreviewVisible(!isPreviewVisible)}
 									onUploadMarkdown={onUploadMarkdown}
 									showFormattingActions={isMarkdownLanguage}
@@ -371,7 +442,9 @@ const CodeEditor = ({
 									isTrashActive ? { lineNumbers: true } : codeMirrorOptions
 								}
 								placeholder={"Write your snipped here"}
-								className={styles.codeMirrorContainer}
+								className={`${styles.codeMirrorContainer} ${
+									isFocusMode ? styles.focusCodeMirror : ""
+								}`}
 								value={currentSnippet?.snippet ?? ""}
 								extensions={[
 									currentSnippet.extension,
@@ -380,6 +453,7 @@ const CodeEditor = ({
 									...(isMarkdownLanguage && !isTrashActive
 										? [markdownKeymap]
 										: []),
+									...markdownProseExtensions,
 								]}
 								theme={editorTheme}
 								height={

--- a/app/components/CodeEditor/FocusModeBar.tsx
+++ b/app/components/CodeEditor/FocusModeBar.tsx
@@ -1,0 +1,84 @@
+import { ReactElement, useMemo } from "react";
+
+/* Components */
+import EyeClosed from "@/components/ui/icons/EyeClosed";
+import EyeOpen from "@/components/ui/icons/EyeOpen";
+import CloseSquare from "@/components/ui/icons/CloseSquare";
+
+/* Utils */
+import {
+	countCharacters,
+	countWords,
+	estimateReadingMinutes,
+} from "@/utils/markdown.utils";
+
+/* Styles */
+import styles from "./focusModeBar.module.css";
+
+type FocusModeBarProps = {
+	content: string;
+	isPreviewVisible: boolean;
+	showPreviewToggle: boolean;
+	snippetName: string;
+	onExit: () => void;
+	onTogglePreview: () => void;
+};
+
+const FocusModeBar = ({
+	content,
+	isPreviewVisible,
+	showPreviewToggle,
+	snippetName,
+	onExit,
+	onTogglePreview,
+}: FocusModeBarProps): ReactElement => {
+	const wordCount = useMemo(() => countWords(content), [content]);
+	const characterCount = useMemo(() => countCharacters(content), [content]);
+	const readingMinutes = useMemo(
+		() => estimateReadingMinutes(wordCount),
+		[wordCount]
+	);
+	const previewToggleLabel = isPreviewVisible ? "Hide preview" : "Show preview";
+
+	return (
+		<div className={styles.bar}>
+			<span className={styles.name}>{snippetName || "Untitled"}</span>
+
+			<span className={styles.stats}>
+				{wordCount} words · {characterCount} characters · {readingMinutes} min
+				read
+			</span>
+
+			<div className={styles.actions}>
+				{showPreviewToggle && (
+					<button
+						aria-label={previewToggleLabel}
+						aria-pressed={isPreviewVisible}
+						className={styles.actionButton}
+						onClick={onTogglePreview}
+						title={previewToggleLabel}
+						type="button"
+					>
+						{isPreviewVisible ? (
+							<EyeOpen height={16} width={16} />
+						) : (
+							<EyeClosed height={16} width={16} />
+						)}
+					</button>
+				)}
+
+				<button
+					aria-label="Exit distraction-free writing"
+					className={styles.actionButton}
+					onClick={onExit}
+					title="Exit distraction-free writing (Esc)"
+					type="button"
+				>
+					<CloseSquare height={16} width={16} />
+				</button>
+			</div>
+		</div>
+	);
+};
+
+export default FocusModeBar;

--- a/app/components/CodeEditor/MarkdownToolbar.tsx
+++ b/app/components/CodeEditor/MarkdownToolbar.tsx
@@ -10,6 +10,7 @@ import {
 /* Components */
 import EyeClosed from "@/components/ui/icons/EyeClosed";
 import EyeOpen from "@/components/ui/icons/EyeOpen";
+import FocusMode from "@/components/ui/icons/FocusMode";
 import Upload from "@/components/ui/icons/Upload";
 
 /* Types */
@@ -20,7 +21,9 @@ import styles from "./markdownToolbar.module.css";
 
 type MarkdownToolbarProps = {
 	getEditorView: () => EditorView | null;
+	isFocusMode: boolean;
 	isPreviewVisible: boolean;
+	onToggleFocusMode: () => void;
 	onTogglePreview: () => void;
 	onUploadMarkdown: (upload: UploadedMarkdown) => void;
 	showFormattingActions: boolean;
@@ -29,7 +32,9 @@ type MarkdownToolbarProps = {
 
 const MarkdownToolbar = ({
 	getEditorView,
+	isFocusMode,
 	isPreviewVisible,
+	onToggleFocusMode,
 	onTogglePreview,
 	onUploadMarkdown,
 	showFormattingActions,
@@ -68,6 +73,9 @@ const MarkdownToolbar = ({
 	};
 
 	const previewToggleLabel = isPreviewVisible ? "Hide preview" : "Show preview";
+	const focusModeLabel = isFocusMode
+		? "Exit distraction-free writing"
+		: "Enter distraction-free writing";
 
 	return (
 		<div
@@ -134,6 +142,21 @@ const MarkdownToolbar = ({
 						<EyeClosed height={16} width={16} />
 					)}
 				</button>
+			)}
+			{showFormattingActions && (
+				<>
+					<span aria-hidden="true" className={styles.divider} />
+					<button
+						aria-label={focusModeLabel}
+						aria-pressed={isFocusMode}
+						className={styles.toolbarButton}
+						onClick={onToggleFocusMode}
+						title={focusModeLabel}
+						type="button"
+					>
+						<FocusMode height={16} width={16} />
+					</button>
+				</>
 			)}
 		</div>
 	);

--- a/app/components/CodeEditor/codeEditor.module.css
+++ b/app/components/CodeEditor/codeEditor.module.css
@@ -493,3 +493,31 @@
 		width: 100%;
 	}
 }
+
+/* Distraction-free writing: the whole editor takes over the viewport, header
+   and tags chrome are unmounted, and the FocusModeBar substitutes for them. */
+.focusOverlay {
+	position: fixed;
+	inset: 0;
+	z-index: 1000;
+	margin-bottom: 0;
+	background: var(--bg-color);
+}
+
+.focusEditorPanel {
+	margin: 0 auto;
+	max-width: 72ch;
+	width: 100%;
+}
+
+.focusCodeMirror {
+	font-size: 1.125rem;
+}
+
+.focusCodeMirror :global(.cm-content) {
+	line-height: 1.9;
+}
+
+.focusCodeMirror :global(.cm-line) {
+	padding: 0 0.125rem;
+}

--- a/app/components/CodeEditor/editorHeight.ts
+++ b/app/components/CodeEditor/editorHeight.ts
@@ -1,16 +1,26 @@
 type EditorHeightParams = {
 	hasMarkdownToolbar: boolean;
 	hasRightPane: boolean;
+	isFocusMode: boolean;
 	isMobile: boolean;
 	isTrashActive: boolean;
 };
 
+// Fixed-overlay bar shown in place of the header/tags/toolbar while
+// distraction-free writing is active.
+const focusModeBarHeight = "3rem";
+
 export const calculateEditorHeight = ({
 	hasMarkdownToolbar,
 	hasRightPane,
+	isFocusMode,
 	isMobile,
 	isTrashActive,
 }: EditorHeightParams): string => {
+	if (isFocusMode) {
+		return `calc(100vh - ${focusModeBarHeight})`;
+	}
+
 	if (isMobile && !isTrashActive) {
 		return hasRightPane ? "calc(50vh - 5rem)" : "calc(100vh - 9.7rem)";
 	}
@@ -30,7 +40,14 @@ export const calculateEditorHeight = ({
 	return "calc(100vh - 6.45rem)";
 };
 
-export const calculatePreviewHeight = (isMobile: boolean): string => {
+export const calculatePreviewHeight = (
+	isMobile: boolean,
+	isFocusMode: boolean = false
+): string => {
+	if (isFocusMode) {
+		return `calc(100vh - ${focusModeBarHeight})`;
+	}
+
 	if (isMobile) {
 		return "calc(50vh - 5rem)";
 	}

--- a/app/components/CodeEditor/focusModeBar.module.css
+++ b/app/components/CodeEditor/focusModeBar.module.css
@@ -1,0 +1,72 @@
+.bar {
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+	height: 3rem;
+	flex-shrink: 0;
+	padding: 0 1rem;
+	background: var(--bg-color-dark);
+	border-bottom: 1px solid var(--border-color);
+}
+
+.name {
+	font-size: var(--normal-font-size);
+	font-weight: 600;
+	color: var(--foreground-color);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 16rem;
+}
+
+.stats {
+	flex: 1;
+	font-size: var(--small-font-size);
+	color: var(--gray-color);
+	text-align: center;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.actions {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+	flex-shrink: 0;
+}
+
+.actionButton {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0.375rem;
+	background: transparent;
+	border: none;
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	color: var(--gray-color);
+	transition:
+		color 0.2s ease,
+		background-color 0.2s ease;
+}
+
+.actionButton:hover {
+	background: var(--bg-color);
+	color: var(--cyan-color);
+}
+
+.actionButton:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 2px var(--cyan-color);
+}
+
+@media (width < 1140px) {
+	.name {
+		max-width: 8rem;
+	}
+
+	.stats {
+		display: none;
+	}
+}

--- a/app/components/CodeEditor/hooks/useFocusModeShortcut.ts
+++ b/app/components/CodeEditor/hooks/useFocusModeShortcut.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+
+type UseFocusModeShortcutParams = {
+	canToggleFocusMode: boolean;
+	isFocusMode: boolean;
+	onExit: () => void;
+	onToggle: () => void;
+};
+
+const useFocusModeShortcut = ({
+	canToggleFocusMode,
+	isFocusMode,
+	onExit,
+	onToggle,
+}: UseFocusModeShortcutParams): void => {
+	useEffect(() => {
+		const handleKeyDown = (event: KeyboardEvent): void => {
+			const isModifierPressed = event.ctrlKey || event.metaKey;
+			const isToggleShortcut =
+				isModifierPressed && event.shiftKey && event.key.toLowerCase() === "f";
+
+			if (isToggleShortcut) {
+				if (!canToggleFocusMode) {
+					return;
+				}
+
+				event.preventDefault();
+				onToggle();
+
+				return;
+			}
+
+			if (event.key === "Escape" && isFocusMode) {
+				event.preventDefault();
+				event.stopPropagation();
+				onExit();
+			}
+		};
+
+		// Capture phase: focus-mode exit must win over other Esc listeners
+		// (modals, suggestion popovers) that are also bound while it is open.
+		window.addEventListener("keydown", handleKeyDown, true);
+
+		return () => {
+			window.removeEventListener("keydown", handleKeyDown, true);
+		};
+	}, [canToggleFocusMode, isFocusMode, onExit, onToggle]);
+};
+
+export default useFocusModeShortcut;

--- a/app/components/CommandPalette/CommandPalette.tsx
+++ b/app/components/CommandPalette/CommandPalette.tsx
@@ -12,6 +12,7 @@ import Globe from "@/components/ui/icons/Globe";
 import Star from "@/components/ui/icons/Star";
 import Trash from "@/components/ui/icons/Trash";
 import Bookmark from "@/components/ui/icons/Bookmark";
+import FocusMode from "@/components/ui/icons/FocusMode";
 import Settings from "@/components/ui/icons/Settings";
 import NewFile from "@/components/ui/icons/NewFile";
 import LanguageBadge from "@/components/ui/LanguageBadge/LanguageBadge";
@@ -20,6 +21,7 @@ import LanguageBadge from "@/components/ui/LanguageBadge/LanguageBadge";
 import styles from "./commandPalette.module.css";
 
 type CommandPaletteProps = {
+	canToggleFocusMode: boolean;
 	snippets: Snippet[];
 	tags: TagItem[];
 	onActiveSnippet: (snippetId: UUID) => void;
@@ -31,9 +33,11 @@ type CommandPaletteProps = {
 	onGetTrash: () => void;
 	onTagClick: (tag: string) => void;
 	onAccountClick: () => void;
+	onToggleFocusMode: () => void;
 };
 
 const CommandPalette = ({
+	canToggleFocusMode,
 	snippets,
 	tags,
 	onActiveSnippet,
@@ -45,6 +49,7 @@ const CommandPalette = ({
 	onGetTrash,
 	onTagClick,
 	onAccountClick,
+	onToggleFocusMode,
 }: CommandPaletteProps): ReactElement => {
 	const open = useMenuStore((store) => store.commandPaletteOpen);
 	const setCommandPaletteOpen = useMenuStore(
@@ -123,6 +128,18 @@ const CommandPalette = ({
 						<Settings width={16} height={16} />
 						<span>Open settings</span>
 					</Command.Item>
+					{canToggleFocusMode && (
+						<Command.Item
+							className={styles.item}
+							onSelect={() => runAction(onToggleFocusMode)}
+						>
+							<FocusMode width={16} height={16} />
+							<span>Toggle distraction-free writing</span>
+							<span className={styles.shortcut}>
+								{isMac ? "⌘" : "Ctrl"} ⇧ F
+							</span>
+						</Command.Item>
+					)}
 				</Command.Group>
 
 				<Command.Group heading="Navigate" className={styles.group}>

--- a/app/components/SnippetsWorkspace/SnippetsWorkspace.tsx
+++ b/app/components/SnippetsWorkspace/SnippetsWorkspace.tsx
@@ -33,6 +33,7 @@ import { DefaultSettingsSection } from "@/lib/constants/settings.constants";
 import { buildSettingsHash } from "@/utils/settings.utils";
 import { ToastType } from "@/lib/constants/toast";
 import useToastStore from "@/lib/store/toast.store";
+import useViewPortStore from "@/lib/store/viewPort.store";
 import { findSnippetByName } from "@/lib/wikiLinkResolver";
 
 /* Utils */
@@ -765,6 +766,28 @@ const SnippetsWorkspace = ({
 		setPendingMarkdownUpload(null);
 	};
 
+	const isFocusMode = useViewPortStore((store) => store.isFocusMode);
+	const setFocusMode = useViewPortStore((store) => store.setFocusMode);
+
+	const activeSnippet =
+		snippets?.length > 0
+			? (snippets.find(
+					(snippetItem: Snippet): boolean =>
+						snippetItem.snippet_id === codeEditorStates.activeSnippetId
+				) ?? snippets[0])
+			: null;
+	const canToggleFocusMode =
+		activeSnippet?.language === SupportedLanguages.Markdown &&
+		codeEditorStates.menuType !== MenuItems.Trash;
+
+	const toggleFocusModeFromPalette = (): void => {
+		if (!canToggleFocusMode) {
+			return;
+		}
+
+		setFocusMode(!isFocusMode);
+	};
+
 	useEffect(() => {
 		getSnippets().then(() => null);
 		loadSmartGroups().then(() => null);
@@ -853,6 +876,7 @@ const SnippetsWorkspace = ({
 			/>
 			<AccountModal />
 			<CommandPalette
+				canToggleFocusMode={canToggleFocusMode}
 				snippets={snippets}
 				tags={tags}
 				onActiveSnippet={setActiveSnippetId}
@@ -864,6 +888,7 @@ const SnippetsWorkspace = ({
 				onGetTrash={getTrashHandler}
 				onTagClick={getSnippetsByTagHandler}
 				onAccountClick={handleAccountClick}
+				onToggleFocusMode={toggleFocusModeFromPalette}
 			/>
 			<ConfirmationModal
 				isOpen={showUnsavedSnippetModal}

--- a/app/components/ui/icons/FocusMode.tsx
+++ b/app/components/ui/icons/FocusMode.tsx
@@ -1,0 +1,26 @@
+import { ReactElement } from "react";
+
+const FocusMode = ({
+	className = "",
+	fill = "currentColor",
+	viewBox = "0 0 256 256",
+	width = "32",
+	height = "32",
+	onClick,
+}: Icon): ReactElement => {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			className={className}
+			width={width}
+			height={height}
+			fill={fill}
+			viewBox={viewBox}
+			onClick={onClick}
+		>
+			<path d="M48,96V56a8,8,0,0,1,8-8H96a8,8,0,0,1,0,16H64V96a8,8,0,0,1-16,0Zm112-40a8,8,0,0,0,0,16h32V96a8,8,0,0,0,16,0V56a8,8,0,0,0-8-8Zm48,104a8,8,0,0,0-8,8v32H160a8,8,0,0,0,0,16h40a8,8,0,0,0,8-8V160A8,8,0,0,0,208,160ZM96,192H64V160a8,8,0,0,0-16,0v40a8,8,0,0,0,8,8H96a8,8,0,0,0,0-16Z" />
+		</svg>
+	);
+};
+
+export default FocusMode;

--- a/app/globals.css
+++ b/app/globals.css
@@ -201,6 +201,45 @@ table {
 	/* Desktop pixel pet (body uses the active palette's darkest token) */
 	--pet-glow: rgb(165 153 233 / 55%);
 	--pet-ground-offset: 10px;
+
+	/* Typography (default: Google Sans Flex) */
+	--app-font: var(--font-google-sans-flex), var(--font-inter), sans-serif;
+}
+
+html[data-font="google-sans-flex"] {
+	--app-font: var(--font-google-sans-flex), var(--font-inter), sans-serif;
+}
+
+html[data-font="google-sans-code"] {
+	--app-font: var(--font-google-sans-code), var(--font-inter), monospace;
+}
+
+html[data-font="source-code-pro"] {
+	--app-font: var(--font-source-code-pro), var(--font-inter), monospace;
+}
+
+html[data-font="montserrat"] {
+	--app-font: var(--font-montserrat), var(--font-inter), sans-serif;
+}
+
+html[data-font="aleo"] {
+	--app-font: var(--font-aleo), var(--font-inter), serif;
+}
+
+html[data-font="open-sans"] {
+	--app-font: var(--font-open-sans), var(--font-inter), sans-serif;
+}
+
+html[data-font="source-sans-3"] {
+	--app-font: var(--font-source-sans-3), var(--font-inter), sans-serif;
+}
+
+html[data-font="raleway"] {
+	--app-font: var(--font-raleway), var(--font-inter), sans-serif;
+}
+
+html[data-font="inconsolata"] {
+	--app-font: var(--font-inconsolata), var(--font-inter), monospace;
 }
 
 [data-theme="shades-of-purple"] {
@@ -536,6 +575,12 @@ body {
 	overflow-x: hidden;
 	background: var(--bg-color);
 	color: var(--foreground-color);
+	font-family: var(--app-font);
+}
+
+.cm-editor,
+.cm-content {
+	font-family: var(--app-font);
 }
 
 .green-color {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,24 @@
 import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
-import { Inter } from "next/font/google";
+import {
+	Aleo,
+	Google_Sans_Code,
+	Google_Sans_Flex,
+	Inconsolata,
+	Inter,
+	Montserrat,
+	Open_Sans,
+	Raleway,
+	Source_Code_Pro,
+	Source_Sans_3,
+} from "next/font/google";
 import { cookies } from "next/headers";
 
 /* Styles */
 import "./globals.css";
 
 /* Lib */
-import { themeCookieName } from "@/lib/constants/cookies";
+import { fontCookieName, themeCookieName } from "@/lib/constants/cookies";
 
 /* Utils */
 import metaGenerator from "@/utils/meta.utils";
@@ -15,7 +26,82 @@ import metaGenerator from "@/utils/meta.utils";
 /* Components */
 import Toasty from "@/components/ui/Toasty/Toasty";
 
-const inter = Inter({ subsets: ["latin"] });
+// next/font has no capsize metrics for the Google Sans faces yet, so its
+// automatic size-adjusted fallback can't be generated. Opt out explicitly and
+// name the fallback stack ourselves instead of letting it warn on every render.
+const googleSansFlex = Google_Sans_Flex({
+	adjustFontFallback: false,
+	display: "swap",
+	fallback: ["system-ui", "-apple-system", "Segoe UI", "sans-serif"],
+	subsets: ["latin"],
+	variable: "--font-google-sans-flex",
+});
+const googleSansCode = Google_Sans_Code({
+	adjustFontFallback: false,
+	display: "swap",
+	fallback: ["ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
+	subsets: ["latin"],
+	variable: "--font-google-sans-code",
+});
+const sourceCodePro = Source_Code_Pro({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-source-code-pro",
+});
+const montserrat = Montserrat({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-montserrat",
+});
+const aleo = Aleo({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-aleo",
+});
+const openSans = Open_Sans({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-open-sans",
+});
+const sourceSans3 = Source_Sans_3({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-source-sans-3",
+});
+const raleway = Raleway({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-raleway",
+});
+const inconsolata = Inconsolata({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-inconsolata",
+});
+// The app's font before the typography selector existed. Kept loaded so it can
+// stay the last real family in every --app-font chain.
+const inter = Inter({
+	subsets: ["latin"],
+	display: "swap",
+	variable: "--font-inter",
+});
+
+// These classes go on <html>, not <body>: --app-font is declared on :root and
+// its nested var() is substituted in the scope where it is declared, so the
+// per-font variables have to exist on that same element or the whole
+// font-family resolves to an invalid value.
+const fontVariables = [
+	inter.variable,
+	googleSansFlex.variable,
+	googleSansCode.variable,
+	sourceCodePro.variable,
+	montserrat.variable,
+	aleo.variable,
+	openSans.variable,
+	sourceSans3.variable,
+	raleway.variable,
+	inconsolata.variable,
+].join(" ");
 
 export const metadata: Metadata = metaGenerator({
 	description:
@@ -32,16 +118,22 @@ export default async function RootLayout({
 }) {
 	const cookieStore = await cookies();
 	const theme = cookieStore.get(themeCookieName)?.value;
+	const font = cookieStore.get(fontCookieName)?.value;
 
 	return (
-		<html lang="en" {...(theme ? { "data-theme": theme } : {})}>
+		<html
+			className={fontVariables}
+			lang="en"
+			{...(theme ? { "data-theme": theme } : {})}
+			{...(font ? { "data-font": font } : {})}
+		>
 			<head>
 				<meta
 					name="viewport"
 					content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"
 				/>
 			</head>
-			<body className={inter.className}>
+			<body>
 				{children}
 				<Analytics />
 				<Toasty />

--- a/app/lib/config/fonts.ts
+++ b/app/lib/config/fonts.ts
@@ -1,0 +1,64 @@
+export const FontNames = {
+	Aleo: "aleo",
+	GoogleSansCode: "google-sans-code",
+	GoogleSansFlex: "google-sans-flex",
+	Inconsolata: "inconsolata",
+	Montserrat: "montserrat",
+	OpenSans: "open-sans",
+	Raleway: "raleway",
+	SourceCodePro: "source-code-pro",
+	SourceSans3: "source-sans-3",
+} as const;
+
+export const fontList: FontConfig[] = [
+	{
+		cssVariable: "--font-google-sans-flex",
+		label: "Google Sans Flex",
+		name: FontNames.GoogleSansFlex,
+	},
+	{
+		cssVariable: "--font-google-sans-code",
+		label: "Google Sans Code",
+		name: FontNames.GoogleSansCode,
+	},
+	{
+		cssVariable: "--font-source-code-pro",
+		label: "Source Code Pro",
+		name: FontNames.SourceCodePro,
+	},
+	{
+		cssVariable: "--font-montserrat",
+		label: "Montserrat",
+		name: FontNames.Montserrat,
+	},
+	{
+		cssVariable: "--font-aleo",
+		label: "Aleo",
+		name: FontNames.Aleo,
+	},
+	{
+		cssVariable: "--font-open-sans",
+		label: "Open Sans",
+		name: FontNames.OpenSans,
+	},
+	{
+		cssVariable: "--font-source-sans-3",
+		label: "Source Sans 3",
+		name: FontNames.SourceSans3,
+	},
+	{
+		cssVariable: "--font-raleway",
+		label: "Raleway",
+		name: FontNames.Raleway,
+	},
+	{
+		cssVariable: "--font-inconsolata",
+		label: "Inconsolata",
+		name: FontNames.Inconsolata,
+	},
+];
+
+export const DefaultFontName: FontName = FontNames.GoogleSansFlex;
+
+export const isValidFont = (font: string): font is FontName =>
+	fontList.some((fontConfig) => fontConfig.name === font);

--- a/app/lib/constants/account.ts
+++ b/app/lib/constants/account.ts
@@ -1,4 +1,5 @@
 import { ThemeNames } from "@/lib/config/themes";
+import { DefaultFontName } from "@/lib/config/fonts";
 
 export const avatarImages = [
 	"/assets/images/avatars/frog.png",
@@ -29,6 +30,7 @@ export const accountInitialStateData: InitialAccountStateData = {
 	confirmPassword: "",
 	avatar: defaultAvatar,
 	theme: ThemeNames.ShadesOfPurple,
+	font: DefaultFontName,
 	aiProvider: "ollama",
 	aiApiKey: "",
 	aiModel: "",

--- a/app/lib/constants/cookies.ts
+++ b/app/lib/constants/cookies.ts
@@ -1,4 +1,5 @@
 export const themeCookieName = "snippets-theme";
+export const fontCookieName = "snippets-font";
 export const defaultMaxAge = 31536000; // 1 year in seconds
 export const defaultPath = "/";
 export const defaultSameSite = "Lax";

--- a/app/lib/constants/markdown.constants.ts
+++ b/app/lib/constants/markdown.constants.ts
@@ -27,3 +27,5 @@ export const boldShortcutKey = "Mod-b";
 export const duplicateLineShortcutKey = "Mod-d";
 export const inlineCodeShortcutKey = "Mod-e";
 export const italicShortcutKey = "Mod-i";
+
+export const ReadingWordsPerMinute = 200;

--- a/app/lib/constants/shortcuts.ts
+++ b/app/lib/constants/shortcuts.ts
@@ -28,6 +28,18 @@ const shortcutGroups: ShortcutGroup[] = [
 				keys: ["["],
 				description: "Type [[ in any snippet to link to another snippet",
 			},
+			{
+				keys: ["↑", "↓"],
+				description: "Navigate tag or wiki-link suggestions",
+			},
+			{
+				keys: ["↵"],
+				description: "Accept highlighted tag or wiki-link suggestion",
+			},
+			{
+				keys: ["Esc"],
+				description: "Dismiss tag or wiki-link suggestions",
+			},
 		],
 	},
 	{
@@ -37,6 +49,14 @@ const shortcutGroups: ShortcutGroup[] = [
 			{ keys: ["Mod", "I"], description: "Italic selected text" },
 			{ keys: ["Mod", "E"], description: "Wrap selection in inline code" },
 			{ keys: ["Mod", "D"], description: "Duplicate current line below" },
+			{
+				keys: ["Mod", "Shift", "F"],
+				description: "Toggle distraction-free writing",
+			},
+			{
+				keys: ["Esc"],
+				description: "Exit distraction-free writing",
+			},
 		],
 	},
 	{

--- a/app/lib/store/user.store.tsx
+++ b/app/lib/store/user.store.tsx
@@ -3,12 +3,14 @@ import { create } from "zustand";
 /* Constants */
 import { defaultAvatar } from "../constants/account";
 import { ThemeNames } from "../config/themes";
+import { DefaultFontName } from "../config/fonts";
 
 type UserState = {
 	userName: string | null;
 	userAvatar: string;
 	email: string | null;
 	theme: string;
+	font: string;
 	aiApiKey: string;
 	autoSave: boolean;
 	isAdmin: boolean;
@@ -17,6 +19,7 @@ type UserState = {
 	setUserAvatar: (avatar: string) => void;
 	setEmail: (email: string | null) => void;
 	setTheme: (theme: string) => void;
+	setFont: (font: string) => void;
 	setAiApiKey: (aiApiKey: string) => void;
 	setAutoSave: (autoSave: boolean) => void;
 	setIsAdmin: (isAdmin: boolean) => void;
@@ -25,6 +28,7 @@ type UserState = {
 		userAvatar?: string;
 		email?: string | null;
 		theme?: string;
+		font?: string;
 		aiApiKey?: string;
 		autoSave?: boolean;
 		isAdmin?: boolean;
@@ -38,6 +42,7 @@ const useUserStore = create<UserState>((set) => ({
 	userAvatar: defaultAvatar,
 	email: null,
 	theme: ThemeNames.ShadesOfPurple,
+	font: DefaultFontName,
 	aiApiKey: "",
 	autoSave: false,
 	isAdmin: false,
@@ -46,6 +51,7 @@ const useUserStore = create<UserState>((set) => ({
 	setUserAvatar: (userAvatar) => set({ userAvatar }),
 	setEmail: (email) => set({ email }),
 	setTheme: (theme) => set({ theme }),
+	setFont: (font) => set({ font }),
 	setAiApiKey: (aiApiKey) => set({ aiApiKey }),
 	setAutoSave: (autoSave) => set({ autoSave }),
 	setIsAdmin: (isAdmin) => set({ isAdmin }),
@@ -61,6 +67,7 @@ const useUserStore = create<UserState>((set) => ({
 			userAvatar: defaultAvatar,
 			email: null,
 			theme: ThemeNames.ShadesOfPurple,
+			font: DefaultFontName,
 			aiApiKey: "",
 			autoSave: false,
 			isAdmin: false,

--- a/app/lib/store/viewPort.store.tsx
+++ b/app/lib/store/viewPort.store.tsx
@@ -1,15 +1,19 @@
 import { create } from "zustand";
 
 type State = {
+	isFocusMode: boolean;
 	isMobile: boolean;
 };
 
 type Actions = {
+	setFocusMode: (value: boolean) => void;
 	setIsMobile: (value: boolean) => void;
 };
 
 const useViewPortStore = create<State & Actions>((set) => ({
+	isFocusMode: false,
 	isMobile: false,
+	setFocusMode: (value) => set({ isFocusMode: value }),
 	setIsMobile: (value) => set({ isMobile: value }),
 }));
 

--- a/app/utils/markdown.utils.ts
+++ b/app/utils/markdown.utils.ts
@@ -1,0 +1,22 @@
+/* Lib */
+import { ReadingWordsPerMinute } from "@/lib/constants/markdown.constants";
+
+export const countCharacters = (content: string): number => content.length;
+
+export const countWords = (content: string): number => {
+	const trimmedContent = content.trim();
+
+	if (trimmedContent.length === 0) {
+		return 0;
+	}
+
+	return trimmedContent.split(/\s+/).length;
+};
+
+export const estimateReadingMinutes = (wordCount: number): number => {
+	if (wordCount === 0) {
+		return 0;
+	}
+
+	return Math.max(1, Math.ceil(wordCount / ReadingWordsPerMinute));
+};

--- a/types/fonts.d.ts
+++ b/types/fonts.d.ts
@@ -1,0 +1,13 @@
+import { FontNames } from "@/lib/config/fonts";
+
+declare global {
+	type FontName = (typeof FontNames)[keyof typeof FontNames];
+
+	type FontConfig = {
+		cssVariable: string;
+		label: string;
+		name: FontName;
+	};
+}
+
+export {};

--- a/types/supabase.d.ts
+++ b/types/supabase.d.ts
@@ -6,6 +6,7 @@ interface InitialAccountStateData {
 	confirmPassword?: string;
 	avatar?: string;
 	theme?: string;
+	font?: string;
 	aiProvider?: AiProvider;
 	aiApiKey?: string;
 	aiModel?: string;
@@ -19,6 +20,7 @@ interface User {
 		username?: string;
 		avatar?: string;
 		theme?: string;
+		font?: string;
 		ai_provider?: AiProvider;
 		ai_api_key?: string;
 		ai_model?: string;


### PR DESCRIPTION
#### Github Issue

relates to https://github.com/vianch/snippets/issues/

#### Why are you creating this PR? What value is added?

Adds focus mode for distraction-free editing, font preview in account settings, and a markdown toolbar with quick-insert buttons for formatting. Includes focus mode shortcut hook, font configuration, markdown utilities, and CSS modules for the new components.

#### Include screenshots below (if appropriate)