### PR TITLE
feat(markdown): add rich formatting and link previews

### DIFF
--- a/app/api/link-preview/route.ts
+++ b/app/api/link-preview/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import fetchLinkPreview from "@/lib/linkPreview/fetchLinkPreview.server";
+import createSupabaseServerClient from "@/lib/supabase/server";
+
+// Authenticated proxy for link-preview metadata. Never forwards upstream
+// error text to the client — every failure collapses to the same generic
+// message so this cannot be used to probe internal network responses.
+export const GET = async (
+	request: NextRequest
+): Promise<NextResponse<LinkPreviewData | LinkPreviewErrorResponse>> => {
+	const { supabase } = await createSupabaseServerClient(request);
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		return NextResponse.json(
+			{ error: "Unauthorized" },
+			{ status: HttpStatusCode.Unauthorized }
+		);
+	}
+
+	const requestedUrl = request.nextUrl.searchParams.get("url");
+
+	if (!requestedUrl) {
+		return NextResponse.json(
+			{ error: "Missing url query parameter" },
+			{ status: HttpStatusCode.BadRequest }
+		);
+	}
+
+	const preview = await fetchLinkPreview(requestedUrl);
+
+	if (!preview) {
+		return NextResponse.json(
+			{ error: "Unable to generate a preview for this URL" },
+			{ status: HttpStatusCode.BadRequest }
+		);
+	}
+
+	return NextResponse.json(preview, {
+		headers: { "Cache-Control": "private, max-age=300" },
+	});
+};

--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -219,9 +219,10 @@ const CodeEditor = ({
 		onToggle: toggleFocusModeHandler,
 	});
 
-	// Focus mode is only meaningful for markdown, outside trash. If either
-	// condition stops holding while it's on (language switch, trash open),
-	// drop back to the normal layout instead of leaving a broken overlay.
+	// Focus mode is only meaningful for prose languages, outside trash. If
+	// either condition stops holding while it's on (language switch, trash
+	// open), drop back to the normal layout instead of leaving a broken
+	// overlay.
 	useEffect(() => {
 		if (isFocusMode && !canToggleFocusMode) {
 			setFocusMode(false);

--- a/app/components/CodeEditor/MarkdownToolbar.tsx
+++ b/app/components/CodeEditor/MarkdownToolbar.tsx
@@ -79,9 +79,7 @@ const MarkdownToolbar = ({
 
 	return (
 		<div
-			aria-label={
-				showFormattingActions ? "Markdown formatting" : "Editor toolbar"
-			}
+			aria-label={showFormattingActions ? "Text formatting" : "Editor toolbar"}
 			className={styles.toolbar}
 			role="toolbar"
 		>

--- a/app/components/MarkdownPreview/MarkdownPreview.tsx
+++ b/app/components/MarkdownPreview/MarkdownPreview.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { MouseEvent, ReactElement, useEffect, useState } from "react";
+import { MouseEvent, ReactElement, useEffect, useRef, useState } from "react";
 
 /* Lib */
 import { renderMarkdownToHtml } from "@/lib/markdownRenderer";
 import useUserStore from "@/lib/store/user.store";
+
+/* Components */
+import useLinkPreviews from "@/components/MarkdownPreview/useLinkPreviews";
 
 /* Types */
 import type { ThemeName } from "@/lib/config/themes";
@@ -26,6 +29,9 @@ const MarkdownPreview = ({
 	// Store theme is a plain string; narrow it to the ThemeName shiki expects
 	const theme = useUserStore((state) => state.theme) as ThemeName;
 	const [htmlContent, setHtmlContent] = useState<string>("");
+	const previewContentRef = useRef<HTMLDivElement>(null);
+
+	useLinkPreviews(previewContentRef, htmlContent);
 
 	useEffect(() => {
 		if (!content) {
@@ -80,6 +86,7 @@ const MarkdownPreview = ({
 				<span className={styles.previewTitle}>Preview</span>
 			</div>
 			<div
+				ref={previewContentRef}
 				className={styles.previewContent}
 				onClick={handleClick}
 				dangerouslySetInnerHTML={{ __html: htmlContent }}

--- a/app/components/MarkdownPreview/markdownPreview.module.css
+++ b/app/components/MarkdownPreview/markdownPreview.module.css
@@ -208,6 +208,70 @@
 	border-bottom-color: var(--cyan-color);
 }
 
+.previewContent :global(.md-highlight) {
+	background: color-mix(in srgb, var(--yellow-color) 35%, transparent);
+	color: var(--foreground-color);
+	border-radius: 2px;
+	padding: 0 0.15em;
+}
+
+/* Link-preview card. Rendered first as a plain fallback link (server HTML,
+   through DOMPurify) then hydrated in place by useLinkPreviews — same
+   :global escape hatch as .wiki-link since the class is injected outside
+   JSX. */
+.previewContent :global(.link-card) {
+	display: block;
+	margin: 0.75rem 0;
+}
+
+.previewContent :global(.link-card-link) {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	border: 1px solid var(--border-color);
+	border-radius: 6px;
+	color: inherit;
+	text-decoration: none;
+	background: var(--bg-color);
+}
+
+.previewContent :global(.link-card-link:hover) {
+	border-color: var(--cyan-color);
+}
+
+.previewContent :global(.link-card-image) {
+	max-height: 220px;
+	object-fit: cover;
+	width: 100%;
+}
+
+.previewContent :global(.link-card-body) {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	padding: 0.625rem 0.75rem;
+}
+
+.previewContent :global(.link-card-title) {
+	color: var(--foreground-color);
+	font-weight: 600;
+}
+
+.previewContent :global(.link-card-description) {
+	overflow: hidden;
+	color: var(--gray-color);
+	font-size: var(--smaller-font-size);
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.previewContent :global(.link-card-site) {
+	color: var(--gray-color);
+	font-size: var(--smaller-font-size);
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
 /* Scrollbar styles matching code editor */
 .previewContent::-webkit-scrollbar {
 	width: 10px;

--- a/app/components/MarkdownPreview/useLinkPreviews.ts
+++ b/app/components/MarkdownPreview/useLinkPreviews.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { RefObject, useEffect } from "react";
+
+/* Utils */
+import { buildLinkCardMarkup } from "@/utils/linkPreview.utils";
+
+// Hydrates `.link-card` placeholders left by the markdown renderer: fetches
+// a preview for each unique URL and swaps the plain-link fallback for the
+// rendered card in place. Runs after every content/theme re-render (the
+// `htmlContent` dependency), dedupes fetches per URL, and silently leaves
+// the fallback link untouched on any failure.
+const useLinkPreviews = (
+	containerRef: RefObject<HTMLDivElement | null>,
+	htmlContent: string
+): void => {
+	useEffect(() => {
+		const container = containerRef.current;
+
+		if (!container) {
+			return;
+		}
+
+		const cardElements = Array.from(
+			container.querySelectorAll<HTMLElement>(".link-card")
+		);
+
+		if (cardElements.length === 0) {
+			return;
+		}
+
+		const elementsByUrl = new Map<string, HTMLElement[]>();
+
+		cardElements.forEach((element) => {
+			const url = element.getAttribute("data-link-card-url");
+
+			if (!url) {
+				return;
+			}
+
+			const existingElements = elementsByUrl.get(url) ?? [];
+
+			existingElements.push(element);
+			elementsByUrl.set(url, existingElements);
+		});
+
+		const abortController = new AbortController();
+
+		Array.from(elementsByUrl.entries()).forEach(([url, elements]) => {
+			fetch(`/api/link-preview?url=${encodeURIComponent(url)}`, {
+				signal: abortController.signal,
+			})
+				.then((response) => {
+					if (!response.ok) {
+						return null;
+					}
+
+					return response.json() as Promise<LinkPreviewData>;
+				})
+				.then((preview) => {
+					if (!preview) {
+						return;
+					}
+
+					const markup = buildLinkCardMarkup(preview);
+
+					elements.forEach((element) => {
+						element.innerHTML = markup;
+					});
+				})
+				.catch(() => undefined);
+		});
+
+		return () => {
+			abortController.abort();
+		};
+	}, [containerRef, htmlContent]);
+};
+
+export default useLinkPreviews;

--- a/app/components/ui/icons/Highlight.tsx
+++ b/app/components/ui/icons/Highlight.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from "react";
+
+import IconContainer from "@/components/ui/icons/Icon";
+
+const Highlight = (props: Icon): ReactElement => {
+	return (
+		<IconContainer viewBox="0 0 256 256" {...props}>
+			<path d="M231.4,44.5l-20-12a16.1,16.1,0,0,0-19.4,2.6l-93.3,93.4L88,120a8,8,0,0,0-10.9.4l-32,32a8,8,0,0,0,0,11.3l39.2,39.2v24.6a8,8,0,0,0,13.7,5.6l32-32A8,8,0,0,0,132,190.9l-8.5-10.7,93.4-93.3a16.1,16.1,0,0,0,2.6-19.4ZM88,207l-16-16v-13.4l16,16Zm-25.4-46.7L88.7,134.2l25.1,25.1L87.7,185.4ZM211.4,66,118,159.4,96.6,138,190,44.6Z"></path>
+		</IconContainer>
+	);
+};
+
+export default Highlight;

--- a/app/components/ui/icons/Strikethrough.tsx
+++ b/app/components/ui/icons/Strikethrough.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from "react";
+
+import IconContainer from "@/components/ui/icons/Icon";
+
+const Strikethrough = (props: Icon): ReactElement => {
+	return (
+		<IconContainer viewBox="0 0 256 256" {...props}>
+			<path d="M224,128a8,8,0,0,1-8,8H164.65a44,44,0,0,1-9.09,66.24C147,207.6,135.4,210,123.29,210c-19.55,0-40.36-6.24-56.13-16.71a8,8,0,1,1,8.84-13.34c19.5,12.95,44.19,17.99,60.09,12.26a28,28,0,0,0,7.87-49.19V143H40a8,8,0,0,1,0-16H216A8,8,0,0,1,224,128ZM72,88a8,8,0,0,0,8-8,20,20,0,0,1,20-20h24a20,20,0,0,1,20,20v4a8,8,0,0,0,16,0V80a36,36,0,0,0-36-36H100A36,36,0,0,0,64,80,8,8,0,0,0,72,88Z"></path>
+		</IconContainer>
+	);
+};
+
+export default Strikethrough;

--- a/app/components/ui/icons/Table.tsx
+++ b/app/components/ui/icons/Table.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from "react";
+
+import IconContainer from "@/components/ui/icons/Icon";
+
+const Table = (props: Icon): ReactElement => {
+	return (
+		<IconContainer viewBox="0 0 256 256" {...props}>
+			<path d="M40 56h176v8h-176ZM40 192h176v8h-176ZM40 56h8v144h-8ZM208 56h8v144h-8ZM95 56h8v144h-8ZM153 56h8v144h-8ZM40 100h176v8h-176ZM40 148h176v8h-176Z"></path>
+		</IconContainer>
+	);
+};
+
+export default Table;

--- a/app/lib/constants/linkPreview.constants.ts
+++ b/app/lib/constants/linkPreview.constants.ts
@@ -1,0 +1,54 @@
+export const LinkPreviewAllowedProtocol = "https:";
+
+export const LinkPreviewMaxRedirects = 3;
+
+export const LinkPreviewFetchTimeoutMs = 3_000;
+
+// Enough to cover a realistic <head> (og tags, title, description) without
+// ever buffering an attacker-controlled arbitrary-size body.
+export const LinkPreviewMaxBodyBytes = 512 * 1024;
+
+export const LinkPreviewCacheTtlMs = 10 * 60 * 1000;
+
+// Oldest-eviction bound on the in-memory cache so a flood of distinct URLs
+// cannot grow the Map without limit.
+export const LinkPreviewCacheMaxEntries = 500;
+
+export const LinkPreviewAllowedContentTypePattern = /^text\/html\b/i;
+
+// `[vianch](www.vianch.com)` has no scheme; assume https rather than
+// discarding the link, since https is the only scheme previews allow.
+export const LinkPreviewSchemePattern = /^[a-z][a-z\d+\-.]*:/i;
+
+export const LinkPreviewHostnameSeparator = ".";
+
+// GFM autolinks a bare URL into the same `link` token an explicit
+// `[label](url)` produces; only the token's raw text tells them apart.
+export const LinkPreviewMarkdownLinkPrefix = "[";
+
+export const LinkPreviewImageExtensionPattern =
+	/\.(?:apng|avif|bmp|gif|jpe?g|png|svg|webp)$/i;
+
+export const LinkPreviewOgImagePattern =
+	/<meta[^>]+(?:property|name)=["']og:image["'][^>]*content=["']([^"']+)["'][^>]*>/i;
+
+export const LinkPreviewOgTitlePattern =
+	/<meta[^>]+(?:property|name)=["']og:title["'][^>]*content=["']([^"']+)["'][^>]*>/i;
+
+export const LinkPreviewOgDescriptionPattern =
+	/<meta[^>]+(?:property|name)=["']og:description["'][^>]*content=["']([^"']+)["'][^>]*>/i;
+
+export const LinkPreviewOgSiteNamePattern =
+	/<meta[^>]+(?:property|name)=["']og:site_name["'][^>]*content=["']([^"']+)["'][^>]*>/i;
+
+export const LinkPreviewTitleTagPattern = /<title[^>]*>([^<]*)<\/title>/i;
+
+export const LinkPreviewMetaDescriptionPattern =
+	/<meta[^>]+name=["']description["'][^>]*content=["']([^"']+)["'][^>]*>/i;
+
+export const LinkPreviewHeadClosingPattern = /<\/head>/i;
+
+// IPv4-mapped IPv6 forms (::ffff:10.0.0.1, ::ffff:a00:1) resolve to private
+// space but do not match the plain IPv6 patterns in network.ts; catch them
+// separately before falling back to the shared IPv4/IPv6 checks.
+export const LinkPreviewIpv4MappedPattern = /^::ffff:/i;

--- a/app/lib/constants/markdown.constants.ts
+++ b/app/lib/constants/markdown.constants.ts
@@ -1,5 +1,7 @@
 export const boldMarker = "**";
 export const italicMarker = "*";
+export const strikethroughMarker = "~~";
+export const highlightMarker = "==";
 export const inlineCodeMarker = "`";
 export const codeFenceMarker = "```";
 export const blockquotePrefix = "> ";
@@ -11,6 +13,8 @@ export const maximumHeadingLevel = 3;
 
 export const boldPlaceholder = "bold text";
 export const italicPlaceholder = "italic text";
+export const strikethroughPlaceholder = "strikethrough text";
+export const highlightPlaceholder = "highlighted text";
 export const inlineCodePlaceholder = "code";
 export const codeBlockPlaceholder = "code";
 export const linkTextPlaceholder = "text";
@@ -27,5 +31,9 @@ export const boldShortcutKey = "Mod-b";
 export const duplicateLineShortcutKey = "Mod-d";
 export const inlineCodeShortcutKey = "Mod-e";
 export const italicShortcutKey = "Mod-i";
+export const strikethroughShortcutKey = "Mod-Shift-x";
+
+export const tableEnterKey = "Enter";
+export const tableTabKey = "Tab";
 
 export const ReadingWordsPerMinute = 200;

--- a/app/lib/constants/table.constants.ts
+++ b/app/lib/constants/table.constants.ts
@@ -1,0 +1,22 @@
+export const enum TableAlignment {
+	Center = "center",
+	Left = "left",
+	None = "none",
+	Right = "right",
+}
+
+export const enum TableInsertPosition {
+	After = "after",
+	Before = "before",
+}
+
+export const TableAlignmentColonCharacter = ":";
+export const TableCellPaddingSpace = " ";
+export const TableDefaultColumnCount = 3;
+export const TableDefaultRowCount = 3;
+export const TableDelimiterCellPattern = /^:?-+:?$/;
+export const TableDelimiterCharacter = "-";
+export const TableEmptyCellText = "";
+export const TableMinimumColumnWidth = 3;
+export const TablePipeCharacter = "|";
+export const TableRowLineBreak = "\n";

--- a/app/lib/constants/ui.constants.ts
+++ b/app/lib/constants/ui.constants.ts
@@ -3,6 +3,7 @@ export const enum HttpStatusCode {
 	BadRequest = 400,
 	Forbidden = 403,
 	InternalServerError = 500,
+	MultipleChoices = 300,
 	NotFound = 404,
 	Ok = 200,
 	PayloadTooLarge = 413,

--- a/app/lib/linkPreview/fetchLinkPreview.server.ts
+++ b/app/lib/linkPreview/fetchLinkPreview.server.ts
@@ -1,0 +1,221 @@
+import { lookup } from "node:dns/promises";
+
+import {
+	LinkPreviewAllowedContentTypePattern,
+	LinkPreviewAllowedProtocol,
+	LinkPreviewCacheMaxEntries,
+	LinkPreviewCacheTtlMs,
+	LinkPreviewFetchTimeoutMs,
+	LinkPreviewMaxBodyBytes,
+	LinkPreviewMaxRedirects,
+} from "@/lib/constants/linkPreview.constants";
+import { HttpStatusCode } from "@/lib/constants/ui.constants";
+import {
+	extractLinkPreviewFromHead,
+	isBlockedHostname,
+	isPrivateIpAddress,
+} from "@/utils/linkPreview.utils";
+
+// Bounded, oldest-eviction cache — insertion order is Map's natural order, so
+// evicting `.keys().next().value` always removes the longest-lived entry.
+const previewCache = new Map<string, LinkPreviewCacheEntry>();
+
+const readCache = (url: string): LinkPreviewData | null => {
+	const entry = previewCache.get(url);
+
+	if (!entry) {
+		return null;
+	}
+
+	if (entry.expiresAt < Date.now()) {
+		previewCache.delete(url);
+
+		return null;
+	}
+
+	return entry.preview;
+};
+
+const writeCache = (url: string, preview: LinkPreviewData): void => {
+	if (previewCache.size >= LinkPreviewCacheMaxEntries) {
+		const oldestKey = previewCache.keys().next().value;
+
+		if (oldestKey !== undefined) {
+			previewCache.delete(oldestKey);
+		}
+	}
+
+	previewCache.set(url, {
+		expiresAt: Date.now() + LinkPreviewCacheTtlMs,
+		preview,
+	});
+};
+
+// Every hop (the initial URL and every redirect target) must independently
+// pass scheme + hostname + resolved-IP checks — a redirect is exactly how an
+// attacker turns an allowed public URL into a request against an internal
+// service.
+const assertSafeDestination = async (candidateUrl: URL): Promise<void> => {
+	if (candidateUrl.protocol !== LinkPreviewAllowedProtocol) {
+		throw new Error("Blocked destination: disallowed protocol");
+	}
+
+	const hostname = candidateUrl.hostname.toLowerCase();
+
+	if (isBlockedHostname(hostname)) {
+		throw new Error("Blocked destination: disallowed hostname");
+	}
+
+	const resolvedAddresses = await lookup(hostname, { all: true }).catch(
+		() => []
+	);
+
+	if (resolvedAddresses.length === 0) {
+		throw new Error("Blocked destination: hostname did not resolve");
+	}
+
+	const hasPrivateAddress = resolvedAddresses.some((resolved) =>
+		isPrivateIpAddress(resolved.address)
+	);
+
+	if (hasPrivateAddress) {
+		throw new Error("Blocked destination: resolved address is private");
+	}
+};
+
+// Reads the response body up to the byte cap and aborts (rather than
+// buffering an unbounded upstream response) past it.
+const readBodyWithCap = async (response: Response): Promise<string> => {
+	const reader = response.body?.getReader();
+
+	if (!reader) {
+		return "";
+	}
+
+	const decoder = new TextDecoder();
+	const chunks: string[] = [];
+	let totalBytes = 0;
+	let isFinished = false;
+
+	try {
+		while (!isFinished) {
+			const { done, value } = await reader.read();
+
+			if (done) {
+				isFinished = true;
+
+				continue;
+			}
+
+			totalBytes += value.byteLength;
+
+			if (totalBytes > LinkPreviewMaxBodyBytes) {
+				chunks.push(decoder.decode(value.slice(0, LinkPreviewMaxBodyBytes)));
+				isFinished = true;
+
+				continue;
+			}
+
+			chunks.push(decoder.decode(value, { stream: true }));
+		}
+	} finally {
+		await reader.cancel().catch(() => undefined);
+	}
+
+	return chunks.join("");
+};
+
+const fetchWithManualRedirects = async (
+	initialUrl: URL,
+	abortSignal: AbortSignal
+): Promise<{ finalUrl: URL; html: string } | null> => {
+	let currentUrl = initialUrl;
+
+	for (let hop = 0; hop <= LinkPreviewMaxRedirects; hop += 1) {
+		await assertSafeDestination(currentUrl);
+
+		const response = await fetch(currentUrl, {
+			headers: { Accept: "text/html" },
+			redirect: "manual",
+			signal: abortSignal,
+		});
+
+		const isRedirect =
+			response.status >= HttpStatusCode.MultipleChoices &&
+			response.status < HttpStatusCode.BadRequest;
+		const location = response.headers.get("location");
+
+		if (isRedirect && location) {
+			currentUrl = new URL(location, currentUrl);
+
+			continue;
+		}
+
+		const contentType = response.headers.get("content-type") ?? "";
+
+		if (!LinkPreviewAllowedContentTypePattern.test(contentType)) {
+			return null;
+		}
+
+		const html = await readBodyWithCap(response);
+
+		return { finalUrl: currentUrl, html };
+	}
+
+	return null;
+};
+
+// Server-side entry point for the API route: resolves + validates the
+// destination on every hop, fetches under a hard timeout and body cap, and
+// caches the parsed result. Returns null on any rejection or upstream
+// failure — the route turns that into a generic error, never the upstream
+// error text.
+const fetchLinkPreview = async (
+	rawUrl: string
+): Promise<LinkPreviewData | null> => {
+	const cached = readCache(rawUrl);
+
+	if (cached) {
+		return cached;
+	}
+
+	let initialUrl: URL;
+
+	try {
+		initialUrl = new URL(rawUrl);
+	} catch {
+		return null;
+	}
+
+	const abortController = new AbortController();
+	const timeoutHandle = setTimeout(
+		() => abortController.abort(),
+		LinkPreviewFetchTimeoutMs
+	);
+
+	try {
+		const result = await fetchWithManualRedirects(
+			initialUrl,
+			abortController.signal
+		);
+
+		if (!result) {
+			return null;
+		}
+
+		const preview = extractLinkPreviewFromHead(
+			result.html,
+			result.finalUrl.toString()
+		);
+
+		writeCache(rawUrl, preview);
+
+		return preview;
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timeoutHandle);
+	}
+};
+
+export default fetchLinkPreview;

--- a/app/lib/markdown/highlightMarked.ts
+++ b/app/lib/markdown/highlightMarked.ts
@@ -1,0 +1,49 @@
+import type { MarkedExtension, Tokens } from "marked";
+
+type HighlightToken = Tokens.Generic & {
+	type: "highlight";
+	raw: string;
+	text: string;
+};
+
+const escapeHtml = (text: string): string =>
+	text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+
+const highlightMarked: MarkedExtension = {
+	extensions: [
+		{
+			name: "highlight",
+			level: "inline",
+			start(src: string): number | undefined {
+				const index = src.indexOf("==");
+
+				return index === -1 ? undefined : index;
+			},
+			tokenizer(src: string): HighlightToken | undefined {
+				const match = /^==([^=\n]+)==/.exec(src);
+
+				if (match) {
+					return {
+						type: "highlight",
+						raw: match[0],
+						text: match[1],
+					};
+				}
+
+				return undefined;
+			},
+			renderer(token: Tokens.Generic): string {
+				const highlightedText = (token as HighlightToken).text;
+				const escaped = escapeHtml(highlightedText);
+
+				return `<mark class="md-highlight">${escaped}</mark>`;
+			},
+		},
+	],
+};
+
+export default highlightMarked;

--- a/app/lib/markdown/linkCardMarked.ts
+++ b/app/lib/markdown/linkCardMarked.ts
@@ -1,0 +1,72 @@
+import type { MarkedExtension, Tokens } from "marked";
+
+/* Lib */
+import { LinkPreviewMarkdownLinkPrefix } from "@/lib/constants/linkPreview.constants";
+
+/* Utils */
+import {
+	hasImageExtension,
+	normalizeLinkPreviewUrl,
+} from "@/utils/linkPreview.utils";
+
+const escapeHtml = (text: string): string =>
+	text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;");
+
+// Turns a paragraph whose entire content is one markdown link —
+// `[label](url)` — into an inline image (when the target is an image file) or
+// a hydration placeholder for a link-preview card.
+//
+// This hooks the paragraph renderer rather than tokenizing raw text, because
+// by this point marked has already decided that `[a](b)` is a link and
+// `![a](b)` is an image: a text-level tokenizer cannot tell them apart, since
+// marked re-scans for block starts from one character in and the leading `!`
+// is no longer visible.
+//
+// Anything else — a bare URL, an inline link inside prose, a non-https
+// target, `![alt](url)` images, raw <img> elements — returns false and falls
+// through to marked's default rendering.
+const linkCardMarked: MarkedExtension = {
+	renderer: {
+		paragraph(token: Tokens.Paragraph): string | false {
+			const [child] = token.tokens ?? [];
+
+			if (token.tokens?.length !== 1 || child?.type !== "link") {
+				return false;
+			}
+
+			// Narrowed by the type check above.
+			const link = child as Tokens.Link;
+
+			// A bare URL is autolinked into the same token shape; only an
+			// explicit `[label](url)` gets a card.
+			if (!link.raw.startsWith(LinkPreviewMarkdownLinkPrefix)) {
+				return false;
+			}
+
+			const url = normalizeLinkPreviewUrl(link.href);
+
+			if (!url) {
+				return false;
+			}
+
+			const escapedUrl = escapeHtml(url);
+			const linkText = escapeHtml(link.text || url);
+
+			if (hasImageExtension(url)) {
+				return `<img src="${escapedUrl}" alt="${linkText}" loading="lazy" referrerpolicy="no-referrer" />`;
+			}
+
+			return (
+				`<div class="link-card" data-link-card-url="${escapedUrl}">` +
+				`<a href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${linkText}</a>` +
+				"</div>"
+			);
+		},
+	},
+};
+
+export default linkCardMarked;

--- a/app/lib/markdown/markdownKeymap.ts
+++ b/app/lib/markdown/markdownKeymap.ts
@@ -2,7 +2,7 @@ import { Prec } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
 
 import type { Extension } from "@codemirror/state";
-import type { Command, KeyBinding } from "@codemirror/view";
+import type { Command, EditorView, KeyBinding } from "@codemirror/view";
 
 /* Lib */
 import {
@@ -10,12 +10,30 @@ import {
 	duplicateLineShortcutKey,
 	inlineCodeShortcutKey,
 	italicShortcutKey,
+	strikethroughShortcutKey,
+	tableEnterKey,
+	tableTabKey,
 } from "@/lib/constants/markdown.constants";
+import { TableInsertPosition } from "@/lib/constants/table.constants";
 import {
 	wrapSelectionWithBold,
 	wrapSelectionWithInlineCode,
 	wrapSelectionWithItalic,
+	wrapSelectionWithStrikethrough,
 } from "@/lib/markdown/markdownToolbarActions";
+import {
+	getCurrentTableRange,
+	getCursorCellPosition,
+	getDocumentLines,
+	replaceTableRange,
+} from "@/lib/markdown/tableEditor";
+import {
+	getNextCellPosition,
+	getPreviousCellPosition,
+	insertRow,
+	isLastTableRow,
+	parseTable,
+} from "@/utils/table.utils";
 
 const toggleBold: Command = (view) => {
 	wrapSelectionWithBold(view);
@@ -31,6 +49,106 @@ const toggleItalic: Command = (view) => {
 
 const toggleInlineCode: Command = (view) => {
 	wrapSelectionWithInlineCode(view);
+
+	return true;
+};
+
+const toggleStrikethrough: Command = (view) => {
+	wrapSelectionWithStrikethrough(view);
+
+	return true;
+};
+
+type TableContext = {
+	position: TableCellPosition;
+	range: TableLineRange;
+	table: ParsedTable;
+};
+
+const getTableContext = (view: EditorView): TableContext | null => {
+	const range = getCurrentTableRange(view);
+
+	if (!range) {
+		return null;
+	}
+
+	const table = parseTable(getDocumentLines(view), range);
+	const position = getCursorCellPosition(view, range);
+
+	return { position, range, table };
+};
+
+const appendRowAndMoveTo = (
+	view: EditorView,
+	{ position, range, table }: TableContext
+): boolean => {
+	const nextTable = insertRow(table, position.row, TableInsertPosition.After);
+
+	replaceTableRange(view, range, nextTable, {
+		column: 0,
+		row: position.row + 1,
+	});
+
+	return true;
+};
+
+const tableTab: Command = (view) => {
+	const context = getTableContext(view);
+
+	if (!context) {
+		return false;
+	}
+
+	const nextPosition = getNextCellPosition(context.table, context.position);
+
+	if (!nextPosition) {
+		return appendRowAndMoveTo(view, context);
+	}
+
+	replaceTableRange(view, context.range, context.table, nextPosition);
+
+	return true;
+};
+
+const tableShiftTab: Command = (view) => {
+	const context = getTableContext(view);
+
+	if (!context) {
+		return false;
+	}
+
+	const previousPosition = getPreviousCellPosition(
+		context.table,
+		context.position
+	);
+
+	replaceTableRange(
+		view,
+		context.range,
+		context.table,
+		previousPosition ?? context.position
+	);
+
+	return true;
+};
+
+const tableEnter: Command = (view) => {
+	const context = getTableContext(view);
+
+	if (!context) {
+		return false;
+	}
+
+	if (isLastTableRow(context.table, context.position)) {
+		return appendRowAndMoveTo(view, context);
+	}
+
+	const nextPosition: TableCellPosition = {
+		column: context.position.column,
+		row: context.position.row + 1,
+	};
+
+	replaceTableRange(view, context.range, context.table, nextPosition);
 
 	return true;
 };
@@ -62,10 +180,17 @@ const markdownKeyBindings: KeyBinding[] = [
 	{ key: italicShortcutKey, preventDefault: true, run: toggleItalic },
 	{ key: inlineCodeShortcutKey, preventDefault: true, run: toggleInlineCode },
 	{
+		key: strikethroughShortcutKey,
+		preventDefault: true,
+		run: toggleStrikethrough,
+	},
+	{
 		key: duplicateLineShortcutKey,
 		preventDefault: true,
 		run: duplicateLineBelow,
 	},
+	{ key: tableTabKey, run: tableTab, shift: tableShiftTab },
+	{ key: tableEnterKey, run: tableEnter },
 ];
 
 const markdownKeymap: Extension = Prec.high(keymap.of(markdownKeyBindings));

--- a/app/lib/markdown/markdownToolbarActions.ts
+++ b/app/lib/markdown/markdownToolbarActions.ts
@@ -6,12 +6,14 @@ import Bold from "@/components/ui/icons/Bold";
 import Code from "@/components/ui/icons/Code";
 import CodeBlock from "@/components/ui/icons/CodeBlock";
 import Heading from "@/components/ui/icons/Heading";
+import Highlight from "@/components/ui/icons/Highlight";
 import Italic from "@/components/ui/icons/Italic";
 import Link from "@/components/ui/icons/Link";
 import List from "@/components/ui/icons/List";
 import ListChecks from "@/components/ui/icons/ListChecks";
 import ListNumbers from "@/components/ui/icons/ListNumbers";
 import Quote from "@/components/ui/icons/Quote";
+import Strikethrough from "@/components/ui/icons/Strikethrough";
 
 /* Lib */
 import {
@@ -25,6 +27,8 @@ import {
 	headingMarker,
 	headingPattern,
 	headingSeparator,
+	highlightMarker,
+	highlightPlaceholder,
 	inlineCodeMarker,
 	inlineCodePlaceholder,
 	italicMarker,
@@ -34,7 +38,10 @@ import {
 	linkUrlPlaceholder,
 	maximumHeadingLevel,
 	numberedListPattern,
+	strikethroughMarker,
+	strikethroughPlaceholder,
 } from "@/lib/constants/markdown.constants";
+import { insertTableAction } from "@/lib/markdown/tableActions";
 
 const getSelectedLines = (view: EditorView): Line[] => {
 	const { from, to } = view.state.selection.main;
@@ -176,6 +183,12 @@ export const wrapSelectionWithBold = (view: EditorView): void =>
 export const wrapSelectionWithItalic = (view: EditorView): void =>
 	applyInlineWrap(view, italicMarker, italicPlaceholder);
 
+export const wrapSelectionWithStrikethrough = (view: EditorView): void =>
+	applyInlineWrap(view, strikethroughMarker, strikethroughPlaceholder);
+
+export const wrapSelectionWithHighlight = (view: EditorView): void =>
+	applyInlineWrap(view, highlightMarker, highlightPlaceholder);
+
 export const wrapSelectionWithInlineCode = (view: EditorView): void =>
 	applyInlineWrap(view, inlineCodeMarker, inlineCodePlaceholder);
 
@@ -289,7 +302,13 @@ const markdownToolbarActions: MarkdownToolbarAction[] = [
 	{ apply: cycleHeadingOnLines, icon: Heading, label: "Heading" },
 	{ apply: wrapSelectionWithBold, icon: Bold, label: "Bold" },
 	{ apply: wrapSelectionWithItalic, icon: Italic, label: "Italic" },
+	{
+		apply: wrapSelectionWithStrikethrough,
+		icon: Strikethrough,
+		label: "Strikethrough",
+	},
 	{ apply: wrapSelectionWithInlineCode, icon: Code, label: "Inline code" },
+	{ apply: wrapSelectionWithHighlight, icon: Highlight, label: "Highlight" },
 	{ apply: wrapSelectionWithCodeBlock, icon: CodeBlock, label: "Code block" },
 	{ apply: wrapSelectionWithLink, icon: Link, label: "Link" },
 	{
@@ -305,6 +324,7 @@ const markdownToolbarActions: MarkdownToolbarAction[] = [
 		label: "Numbered list",
 	},
 	{ apply: prefixLinesWithChecklist, icon: ListChecks, label: "Checklist" },
+	insertTableAction,
 ];
 
 export default markdownToolbarActions;

--- a/app/lib/markdown/tableActions.ts
+++ b/app/lib/markdown/tableActions.ts
@@ -1,0 +1,46 @@
+import type { EditorView } from "@codemirror/view";
+
+/* Components */
+import TableIcon from "@/components/ui/icons/Table";
+
+/* Lib */
+import { TableRowLineBreak } from "@/lib/constants/table.constants";
+import {
+	computeSerializedCellSelection,
+	getCurrentTableRange,
+} from "@/lib/markdown/tableEditor";
+import { buildEmptyTable, serializeTable } from "@/utils/table.utils";
+
+const insertTable = (view: EditorView): void => {
+	// Only a fresh insert is exposed in the toolbar: inside an existing table
+	// rows are added through Tab/Enter navigation instead.
+	if (getCurrentTableRange(view) !== null) {
+		return;
+	}
+
+	const cursorLine = view.state.doc.lineAt(view.state.selection.main.head);
+	const insertionPrefix = cursorLine.text.length > 0 ? TableRowLineBreak : "";
+	const serializedText = serializeTable(buildEmptyTable());
+	const insertFrom = cursorLine.to;
+	const textOffset = insertFrom + insertionPrefix.length;
+	const { anchor, head } = computeSerializedCellSelection(serializedText, {
+		column: 0,
+		row: 0,
+	});
+
+	view.dispatch({
+		changes: {
+			from: insertFrom,
+			insert: `${insertionPrefix}${serializedText}`,
+		},
+		selection: { anchor: textOffset + anchor, head: textOffset + head },
+	});
+	view.focus();
+};
+
+export const insertTableAction: MarkdownToolbarAction = {
+	apply: insertTable,
+	hasDividerBefore: true,
+	icon: TableIcon,
+	label: "Insert table",
+};

--- a/app/lib/markdown/tableEditor.ts
+++ b/app/lib/markdown/tableEditor.ts
@@ -1,0 +1,107 @@
+import type { EditorView } from "@codemirror/view";
+
+/* Lib */
+import { TableRowLineBreak } from "@/lib/constants/table.constants";
+import {
+	findTableRange,
+	getCellColumnBounds,
+	serializeTable,
+	splitTableRow,
+} from "@/utils/table.utils";
+
+// Shared CodeMirror <-> ParsedTable glue used by both the toolbar's insert
+// action (tableActions.ts) and the cell-navigation keymap
+// (markdownKeymap.ts), so the two never drift on how a cursor position maps
+// to a table cell or how a serialized table maps back to a selection.
+
+export const getDocumentLines = (view: EditorView): string[] =>
+	view.state.doc.toString().split(TableRowLineBreak);
+
+export const getCursorLineNumber = (view: EditorView): number =>
+	view.state.doc.lineAt(view.state.selection.main.head).number;
+
+export const getCurrentTableRange = (view: EditorView): TableLineRange | null =>
+	findTableRange(getDocumentLines(view), getCursorLineNumber(view));
+
+const getColumnIndexAtOffset = (
+	lineText: string,
+	offsetInLine: number,
+	columnCount: number
+): number => {
+	const columnIndices = Array.from(
+		{ length: columnCount },
+		(_unused, index) => index
+	);
+	const matchingIndex = columnIndices.find((columnIndex) => {
+		const bounds = getCellColumnBounds(lineText, columnIndex);
+
+		return (
+			bounds !== null &&
+			offsetInLine >= bounds.start &&
+			offsetInLine <= bounds.end
+		);
+	});
+
+	return matchingIndex ?? Math.max(0, columnCount - 1);
+};
+
+export const getCursorCellPosition = (
+	view: EditorView,
+	range: TableLineRange
+): TableCellPosition => {
+	const cursorLine = view.state.doc.lineAt(view.state.selection.main.head);
+	const offsetFromHeader = cursorLine.number - range.startLine;
+	const logicalRow = offsetFromHeader <= 0 ? 0 : offsetFromHeader - 1;
+	const columnCount = splitTableRow(cursorLine.text).length;
+	const offsetInLine = view.state.selection.main.head - cursorLine.from;
+	const column = getColumnIndexAtOffset(
+		cursorLine.text,
+		offsetInLine,
+		columnCount
+	);
+
+	return { column, row: logicalRow };
+};
+
+export const computeSerializedCellSelection = (
+	serializedText: string,
+	position: TableCellPosition
+): { anchor: number; head: number } => {
+	const lines = serializedText.split(TableRowLineBreak);
+	const lineIndex = position.row === 0 ? 0 : position.row + 1;
+	const precedingLength = lines
+		.slice(0, lineIndex)
+		.reduce((total, line) => total + line.length + TableRowLineBreak.length, 0);
+	const line = lines[lineIndex] ?? "";
+	const bounds = getCellColumnBounds(line, position.column);
+
+	if (!bounds) {
+		return { anchor: precedingLength, head: precedingLength };
+	}
+
+	return {
+		anchor: precedingLength + bounds.start,
+		head: precedingLength + bounds.end,
+	};
+};
+
+export const replaceTableRange = (
+	view: EditorView,
+	range: TableLineRange,
+	table: ParsedTable,
+	cursorPosition: TableCellPosition
+): void => {
+	const startLine = view.state.doc.line(range.startLine);
+	const endLine = view.state.doc.line(range.endLine);
+	const serializedText = serializeTable(table);
+	const { anchor, head } = computeSerializedCellSelection(
+		serializedText,
+		cursorPosition
+	);
+
+	view.dispatch({
+		changes: { from: startLine.from, insert: serializedText, to: endLine.to },
+		selection: { anchor: startLine.from + anchor, head: startLine.from + head },
+	});
+	view.focus();
+};

--- a/app/lib/markdownRenderer.ts
+++ b/app/lib/markdownRenderer.ts
@@ -3,6 +3,8 @@ import { Marked } from "marked";
 
 /* Lib */
 import { getHighlightedFenceCode } from "@/lib/config/shiki";
+import highlightMarked from "@/lib/markdown/highlightMarked";
+import linkCardMarked from "@/lib/markdown/linkCardMarked";
 import wikiLinkMarked from "@/lib/wikiLinkMarked";
 
 /* Utils */
@@ -27,6 +29,8 @@ export const renderMarkdownToHtml = async (
 	const markedInstance = new Marked();
 
 	markedInstance.use(wikiLinkMarked);
+	markedInstance.use(highlightMarked);
+	markedInstance.use(linkCardMarked);
 
 	markedInstance.use({
 		async: true,
@@ -77,7 +81,12 @@ export const renderMarkdownToHtml = async (
 	// leak out). Forbid it — styled full documents belong in the HTML preview,
 	// which renders inside a sandboxed iframe.
 	return DOMPurify.sanitize(rawHtml, {
-		ADD_ATTR: ["data-wiki-target"],
+		ADD_ATTR: [
+			"data-link-card-url",
+			"data-wiki-target",
+			"loading",
+			"referrerpolicy",
+		],
 		FORBID_TAGS: ["style"],
 	});
 };

--- a/app/utils/linkPreview.utils.ts
+++ b/app/utils/linkPreview.utils.ts
@@ -1,0 +1,212 @@
+import {
+	LinkPreviewAllowedProtocol,
+	LinkPreviewHeadClosingPattern,
+	LinkPreviewHostnameSeparator,
+	LinkPreviewImageExtensionPattern,
+	LinkPreviewIpv4MappedPattern,
+	LinkPreviewMetaDescriptionPattern,
+	LinkPreviewOgDescriptionPattern,
+	LinkPreviewOgImagePattern,
+	LinkPreviewOgSiteNamePattern,
+	LinkPreviewOgTitlePattern,
+	LinkPreviewSchemePattern,
+	LinkPreviewTitleTagPattern,
+} from "@/lib/constants/linkPreview.constants";
+import {
+	BlockedHostnames,
+	BlockedHostnameSuffixes,
+	PrivateIpv4Pattern,
+	PrivateIpv6Pattern,
+} from "@/lib/constants/network";
+
+import { escapeHtml } from "@/utils/string.utils";
+
+// Normalizes the href of a markdown link into the https URL a preview can be
+// fetched for, or null when it is not previewable. A missing scheme is
+// assumed to be https (`[vianch](www.vianch.com)`); any other scheme, or an
+// href without a real hostname (`/page`, `#anchor`, `mailto:…`), is rejected
+// so it keeps rendering as an ordinary link.
+const normalizeLinkPreviewUrl = (href: string): string | null => {
+	const trimmed = href.trim();
+
+	if (!trimmed) {
+		return null;
+	}
+
+	const candidate = LinkPreviewSchemePattern.test(trimmed)
+		? trimmed
+		: `${LinkPreviewAllowedProtocol}//${trimmed}`;
+
+	try {
+		const parsed = new URL(candidate);
+
+		if (parsed.protocol !== LinkPreviewAllowedProtocol) {
+			return null;
+		}
+
+		if (!parsed.hostname.includes(LinkPreviewHostnameSeparator)) {
+			return null;
+		}
+
+		return parsed.toString();
+	} catch {
+		return null;
+	}
+};
+
+const hasImageExtension = (url: string): boolean => {
+	try {
+		const parsed = new URL(url);
+
+		return LinkPreviewImageExtensionPattern.test(parsed.pathname);
+	} catch {
+		return false;
+	}
+};
+
+const decodeHtmlEntities = (text: string): string =>
+	text
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&amp;/g, "&")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">");
+
+// Resolves a possibly-relative image URL against the page's final (post
+// redirect) URL and rejects anything that does not resolve to https.
+const resolveHttpsImageUrl = (
+	candidate: string,
+	baseUrl: string
+): string | null => {
+	try {
+		const resolved = new URL(candidate, baseUrl);
+
+		if (resolved.protocol !== LinkPreviewAllowedProtocol) {
+			return null;
+		}
+
+		return resolved.toString();
+	} catch {
+		return null;
+	}
+};
+
+// Textual private/loopback/link-local checks. Callers resolving a hostname
+// via DNS must run this against every resolved address, not the hostname.
+const isPrivateIpAddress = (address: string): boolean => {
+	const normalized = address.toLowerCase();
+	const mappedMatch = LinkPreviewIpv4MappedPattern.exec(normalized);
+
+	if (mappedMatch) {
+		const mappedSuffix = normalized.slice(mappedMatch[0].length);
+
+		// Only the dotted-decimal mapped form can be checked against the IPv4
+		// pattern; an unrecognised (e.g. hex) suffix is blocked conservatively.
+		return (
+			PrivateIpv4Pattern.test(`${mappedSuffix}.`) || !/^\d/.test(mappedSuffix)
+		);
+	}
+
+	return (
+		PrivateIpv4Pattern.test(`${normalized}.`) ||
+		PrivateIpv6Pattern.test(normalized)
+	);
+};
+
+const isBlockedHostname = (hostname: string): boolean => {
+	const normalized = hostname.toLowerCase();
+
+	if (BlockedHostnames.includes(normalized)) {
+		return true;
+	}
+
+	return BlockedHostnameSuffixes.some((suffix) => normalized.endsWith(suffix));
+};
+
+const extractHeadHtml = (html: string): string => {
+	const closingMatch = LinkPreviewHeadClosingPattern.exec(html);
+
+	return closingMatch ? html.slice(0, closingMatch.index) : html;
+};
+
+const extractLinkPreviewFromHead = (
+	html: string,
+	finalUrl: string
+): LinkPreviewData => {
+	const headHtml = extractHeadHtml(html);
+	const ogImage = LinkPreviewOgImagePattern.exec(headHtml)?.[1] ?? null;
+	const ogTitle = LinkPreviewOgTitlePattern.exec(headHtml)?.[1] ?? null;
+	const ogDescription =
+		LinkPreviewOgDescriptionPattern.exec(headHtml)?.[1] ?? null;
+	const ogSiteName = LinkPreviewOgSiteNamePattern.exec(headHtml)?.[1] ?? null;
+	const titleTag = LinkPreviewTitleTagPattern.exec(headHtml)?.[1] ?? null;
+	const metaDescription =
+		LinkPreviewMetaDescriptionPattern.exec(headHtml)?.[1] ?? null;
+	const image = ogImage ? resolveHttpsImageUrl(ogImage, finalUrl) : null;
+
+	return {
+		description: ogDescription
+			? decodeHtmlEntities(ogDescription)
+			: metaDescription
+				? decodeHtmlEntities(metaDescription)
+				: null,
+		image,
+		siteName: ogSiteName ? decodeHtmlEntities(ogSiteName) : null,
+		title: ogTitle
+			? decodeHtmlEntities(ogTitle)
+			: titleTag
+				? decodeHtmlEntities(titleTag)
+				: null,
+		url: finalUrl,
+	};
+};
+
+// escapeHtml only neutralizes &, <, > — safe for text content but not for
+// unquoted-breakout inside a double-quoted attribute value.
+const escapeAttribute = (value: string): string =>
+	escapeHtml(value).replace(/"/g, "&quot;");
+
+const getUrlHostname = (url: string): string => {
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return url;
+	}
+};
+
+// Builds the sanitized hydration markup for one `.link-card` placeholder.
+// Every dynamic field is attacker-influenced (it comes from the remote
+// page's <head>) and must be escaped before interpolation — this never
+// passes through the DOMPurify pipeline since it replaces DOM content
+// directly.
+const buildLinkCardMarkup = (preview: LinkPreviewData): string => {
+	const escapedUrl = escapeAttribute(preview.url);
+	const displayTitle = preview.title || preview.url;
+	const displaySite = preview.siteName || getUrlHostname(preview.url);
+	const imageMarkup = preview.image
+		? `<img class="link-card-image" src="${escapeAttribute(preview.image)}" alt="" loading="lazy" referrerpolicy="no-referrer" />`
+		: "";
+	const descriptionMarkup = preview.description
+		? `<span class="link-card-description">${escapeHtml(preview.description)}</span>`
+		: "";
+
+	return (
+		`<a class="link-card-link" href="${escapedUrl}" target="_blank" rel="noopener noreferrer">` +
+		imageMarkup +
+		'<span class="link-card-body">' +
+		`<span class="link-card-title">${escapeHtml(displayTitle)}</span>` +
+		descriptionMarkup +
+		`<span class="link-card-site">${escapeHtml(displaySite)}</span>` +
+		"</span>" +
+		"</a>"
+	);
+};
+
+export {
+	buildLinkCardMarkup,
+	extractLinkPreviewFromHead,
+	hasImageExtension,
+	isBlockedHostname,
+	isPrivateIpAddress,
+	normalizeLinkPreviewUrl,
+};

--- a/app/utils/table.utils.ts
+++ b/app/utils/table.utils.ts
@@ -1,0 +1,525 @@
+import {
+	TableAlignment,
+	TableAlignmentColonCharacter,
+	TableCellPaddingSpace,
+	TableDefaultColumnCount,
+	TableDefaultRowCount,
+	TableDelimiterCellPattern,
+	TableDelimiterCharacter,
+	TableEmptyCellText,
+	TableInsertPosition,
+	TableMinimumColumnWidth,
+	TablePipeCharacter,
+	TableRowLineBreak,
+} from "@/lib/constants/table.constants";
+
+// Escaped pipes (`\|`) inside cell content are intentionally unsupported in
+// this POC: every helper below treats every unescaped `|` as a cell
+// separator, which matches how the vast majority of hand-written tables and
+// the toolbar/keymap-generated ones look.
+
+const findPipeIndices = (lineText: string): number[] =>
+	Array.from(lineText).reduce<number[]>((pipeIndices, character, index) => {
+		if (character !== TablePipeCharacter) {
+			return pipeIndices;
+		}
+
+		return [...pipeIndices, index];
+	}, []);
+
+const getRowBoundaryIndices = (lineText: string): number[] => {
+	const pipeIndices = findPipeIndices(lineText);
+	const hasLeadingPipe = lineText.trimStart().startsWith(TablePipeCharacter);
+	const hasTrailingPipe = lineText.trimEnd().endsWith(TablePipeCharacter);
+	const leadingBoundary = hasLeadingPipe ? [] : [-1];
+	const trailingBoundary = hasTrailingPipe ? [] : [lineText.length];
+
+	return [...leadingBoundary, ...pipeIndices, ...trailingBoundary];
+};
+
+const trimBounds = (
+	lineText: string,
+	bounds: TableCellBounds
+): TableCellBounds => {
+	const rawText = lineText.slice(bounds.start, bounds.end);
+	const leadingWhitespaceLength = rawText.length - rawText.trimStart().length;
+	const trailingWhitespaceLength = rawText.length - rawText.trimEnd().length;
+	const start = bounds.start + leadingWhitespaceLength;
+	const end = Math.max(start, bounds.end - trailingWhitespaceLength);
+
+	return { end, start };
+};
+
+const getRowCellBounds = (lineText: string): TableCellBounds[] => {
+	const boundaries = getRowBoundaryIndices(lineText);
+	const starts = boundaries.slice(0, -1).map((boundary) => boundary + 1);
+	const ends = boundaries.slice(1);
+
+	return starts.map((start, index) =>
+		trimBounds(lineText, { end: ends[index] ?? start, start })
+	);
+};
+
+export const splitTableRow = (lineText: string): TableRow =>
+	getRowCellBounds(lineText).map((bounds) =>
+		lineText.slice(bounds.start, bounds.end)
+	);
+
+export const getCellColumnBounds = (
+	lineText: string,
+	columnIndex: number
+): TableCellBounds | null => getRowCellBounds(lineText)[columnIndex] ?? null;
+
+export const isTableRowLine = (lineText: string): boolean =>
+	lineText.trim().length > 0 && lineText.includes(TablePipeCharacter);
+
+export const isTableDelimiterLine = (lineText: string): boolean => {
+	if (lineText.trim().length === 0) {
+		return false;
+	}
+
+	const cells = splitTableRow(lineText);
+
+	return (
+		cells.length > 0 &&
+		cells.every((cell) => TableDelimiterCellPattern.test(cell))
+	);
+};
+
+const findLastContiguousRowLineIndex = (
+	documentLines: string[],
+	startIndex: number
+): number => {
+	const availableCount = Math.max(0, documentLines.length - startIndex);
+	const candidateIndices = Array.from(
+		{ length: availableCount },
+		(_unused, offset) => startIndex + offset
+	);
+	const firstNonRowOffset = candidateIndices.findIndex((lineIndex) => {
+		const line = documentLines[lineIndex];
+
+		return line === undefined || !isTableRowLine(line);
+	});
+	const contiguousRowCount =
+		firstNonRowOffset === -1 ? candidateIndices.length : firstNonRowOffset;
+
+	return startIndex + contiguousRowCount - 1;
+};
+
+export const findTableRange = (
+	documentLines: string[],
+	cursorLineNumber: number
+): TableLineRange | null => {
+	const cursorLineIndex = cursorLineNumber - 1;
+	const candidateHeaderIndices = Array.from(
+		{ length: cursorLineIndex + 1 },
+		(_unused, offset) => cursorLineIndex - offset
+	);
+
+	return candidateHeaderIndices.reduce<TableLineRange | null>(
+		(foundRange, headerLineIndex) => {
+			if (foundRange) {
+				return foundRange;
+			}
+
+			const headerLine = documentLines[headerLineIndex];
+			const delimiterLine = documentLines[headerLineIndex + 1];
+
+			if (headerLine === undefined || delimiterLine === undefined) {
+				return null;
+			}
+
+			if (!isTableRowLine(headerLine) || !isTableDelimiterLine(delimiterLine)) {
+				return null;
+			}
+
+			const columnCount = splitTableRow(headerLine).length;
+
+			if (splitTableRow(delimiterLine).length !== columnCount) {
+				return null;
+			}
+
+			const lastBodyLineIndex = findLastContiguousRowLineIndex(
+				documentLines,
+				headerLineIndex + 2
+			);
+
+			if (cursorLineIndex > lastBodyLineIndex) {
+				return null;
+			}
+
+			return { endLine: lastBodyLineIndex + 1, startLine: headerLineIndex + 1 };
+		},
+		null
+	);
+};
+
+export const isCursorInTable = (
+	documentLines: string[],
+	cursorLineNumber: number
+): boolean => findTableRange(documentLines, cursorLineNumber) !== null;
+
+const normalizeRowLength = (row: TableRow, columnCount: number): TableRow =>
+	Array.from(
+		{ length: columnCount },
+		(_unused, columnIndex) => row[columnIndex] ?? TableEmptyCellText
+	);
+
+const normalizeAlignmentsLength = (
+	alignments: TableAlignment[],
+	columnCount: number
+): TableAlignment[] =>
+	Array.from(
+		{ length: columnCount },
+		(_unused, columnIndex) => alignments[columnIndex] ?? TableAlignment.None
+	);
+
+const parseAlignmentFromDelimiterCell = (
+	delimiterCell: string
+): TableAlignment => {
+	const hasLeadingColon = delimiterCell.startsWith(
+		TableAlignmentColonCharacter
+	);
+	const hasTrailingColon = delimiterCell.endsWith(TableAlignmentColonCharacter);
+
+	if (hasLeadingColon && hasTrailingColon) {
+		return TableAlignment.Center;
+	}
+
+	if (hasTrailingColon) {
+		return TableAlignment.Right;
+	}
+
+	if (hasLeadingColon) {
+		return TableAlignment.Left;
+	}
+
+	return TableAlignment.None;
+};
+
+export const parseTable = (
+	documentLines: string[],
+	range: TableLineRange
+): ParsedTable => {
+	const headerLineIndex = range.startLine - 1;
+	const delimiterLineIndex = headerLineIndex + 1;
+	const bodyLineIndices = Array.from(
+		{ length: range.endLine - delimiterLineIndex - 1 },
+		(_unused, offset) => delimiterLineIndex + 1 + offset
+	);
+	const headerCells = splitTableRow(documentLines[headerLineIndex] ?? "");
+	const alignments = splitTableRow(documentLines[delimiterLineIndex] ?? "").map(
+		parseAlignmentFromDelimiterCell
+	);
+	const bodyRows = bodyLineIndices.map((lineIndex) =>
+		normalizeRowLength(
+			splitTableRow(documentLines[lineIndex] ?? ""),
+			headerCells.length
+		)
+	);
+
+	return {
+		alignments: normalizeAlignmentsLength(alignments, headerCells.length),
+		bodyRows,
+		headerCells,
+	};
+};
+
+const buildDelimiterCell = (
+	width: number,
+	alignment: TableAlignment
+): string => {
+	const usesLeadingColon =
+		alignment === TableAlignment.Left || alignment === TableAlignment.Center;
+	const usesTrailingColon =
+		alignment === TableAlignment.Right || alignment === TableAlignment.Center;
+	const colonCount = (usesLeadingColon ? 1 : 0) + (usesTrailingColon ? 1 : 0);
+	const dashCount = Math.max(1, width - colonCount);
+	const dashes = TableDelimiterCharacter.repeat(dashCount);
+
+	return `${usesLeadingColon ? TableAlignmentColonCharacter : ""}${dashes}${usesTrailingColon ? TableAlignmentColonCharacter : ""}`;
+};
+
+const justifyCellText = (
+	text: string,
+	width: number,
+	alignment: TableAlignment
+): string => {
+	const paddingLength = Math.max(0, width - text.length);
+
+	if (alignment === TableAlignment.Right) {
+		return `${TableCellPaddingSpace.repeat(paddingLength)}${text}`;
+	}
+
+	if (alignment === TableAlignment.Center) {
+		const leftPadding = Math.floor(paddingLength / 2);
+		const rightPadding = paddingLength - leftPadding;
+
+		return `${TableCellPaddingSpace.repeat(leftPadding)}${text}${TableCellPaddingSpace.repeat(rightPadding)}`;
+	}
+
+	return `${text}${TableCellPaddingSpace.repeat(paddingLength)}`;
+};
+
+const computeColumnWidths = (table: ParsedTable): number[] =>
+	table.headerCells.map((headerCell, columnIndex) => {
+		const bodyCellLengths = table.bodyRows.map(
+			(row) => (row[columnIndex] ?? TableEmptyCellText).length
+		);
+
+		return Math.max(
+			headerCell.length,
+			...bodyCellLengths,
+			TableMinimumColumnWidth
+		);
+	});
+
+const buildRowLine = (
+	cells: TableRow,
+	widths: number[],
+	alignments: TableAlignment[]
+): string => {
+	const cellSeparator = `${TableCellPaddingSpace}${TablePipeCharacter}${TableCellPaddingSpace}`;
+	const justifiedCells = widths.map((width, columnIndex) =>
+		justifyCellText(
+			cells[columnIndex] ?? TableEmptyCellText,
+			width,
+			alignments[columnIndex] ?? TableAlignment.None
+		)
+	);
+
+	return `${TablePipeCharacter}${TableCellPaddingSpace}${justifiedCells.join(cellSeparator)}${TableCellPaddingSpace}${TablePipeCharacter}`;
+};
+
+export const serializeTable = (table: ParsedTable): string => {
+	const columnWidths = computeColumnWidths(table);
+	const headerAlignments = table.headerCells.map(() => TableAlignment.None);
+	const headerLine = buildRowLine(
+		table.headerCells,
+		columnWidths,
+		headerAlignments
+	);
+	const delimiterCells = columnWidths.map((width, columnIndex) =>
+		buildDelimiterCell(
+			width,
+			table.alignments[columnIndex] ?? TableAlignment.None
+		)
+	);
+	const delimiterLine = buildRowLine(
+		delimiterCells,
+		columnWidths,
+		headerAlignments
+	);
+	const bodyLines = table.bodyRows.map((row) =>
+		buildRowLine(row, columnWidths, table.alignments)
+	);
+
+	return [headerLine, delimiterLine, ...bodyLines].join(TableRowLineBreak);
+};
+
+export const buildEmptyTable = (
+	rowCount: number = TableDefaultRowCount,
+	columnCount: number = TableDefaultColumnCount
+): ParsedTable => {
+	const bodyRowCount = Math.max(0, rowCount - 1);
+
+	return {
+		alignments: Array.from({ length: columnCount }, () => TableAlignment.None),
+		bodyRows: Array.from({ length: bodyRowCount }, () =>
+			Array.from({ length: columnCount }, () => TableEmptyCellText)
+		),
+		headerCells: Array.from({ length: columnCount }, () => TableEmptyCellText),
+	};
+};
+
+export const getRowCount = (table: ParsedTable): number =>
+	1 + table.bodyRows.length;
+
+export const getColumnCount = (table: ParsedTable): number =>
+	table.headerCells.length;
+
+export const getRowLineIndex = (
+	range: TableLineRange,
+	logicalRowIndex: number
+): number => {
+	const headerLineIndex = range.startLine - 1;
+
+	return logicalRowIndex === 0
+		? headerLineIndex
+		: headerLineIndex + logicalRowIndex + 1;
+};
+
+const resolveInsertIndex = (
+	referenceIndex: number,
+	position: TableInsertPosition
+): number =>
+	position === TableInsertPosition.Before ? referenceIndex : referenceIndex + 1;
+
+export const insertRow = (
+	table: ParsedTable,
+	logicalRowIndex: number,
+	position: TableInsertPosition
+): ParsedTable => {
+	const bodyReferenceIndex = logicalRowIndex - 1;
+	const insertIndex = Math.max(
+		0,
+		resolveInsertIndex(bodyReferenceIndex, position)
+	);
+	const newRow = table.headerCells.map(() => TableEmptyCellText);
+
+	return {
+		...table,
+		bodyRows: [
+			...table.bodyRows.slice(0, insertIndex),
+			newRow,
+			...table.bodyRows.slice(insertIndex),
+		],
+	};
+};
+
+export const deleteRow = (
+	table: ParsedTable,
+	logicalRowIndex: number
+): ParsedTable => {
+	if (logicalRowIndex === 0) {
+		const [firstBodyRow, ...remainingBodyRows] = table.bodyRows;
+
+		if (firstBodyRow === undefined) {
+			return table;
+		}
+
+		return { ...table, bodyRows: remainingBodyRows, headerCells: firstBodyRow };
+	}
+
+	const bodyIndex = logicalRowIndex - 1;
+
+	return {
+		...table,
+		bodyRows: table.bodyRows.filter((_unused, index) => index !== bodyIndex),
+	};
+};
+
+const insertAtIndex = <ElementType>(
+	items: ElementType[],
+	index: number,
+	value: ElementType
+): ElementType[] => [...items.slice(0, index), value, ...items.slice(index)];
+
+const removeAtIndex = <ElementType>(
+	items: ElementType[],
+	index: number
+): ElementType[] => items.filter((_unused, itemIndex) => itemIndex !== index);
+
+export const insertColumn = (
+	table: ParsedTable,
+	columnIndex: number,
+	position: TableInsertPosition
+): ParsedTable => {
+	const insertIndex = resolveInsertIndex(columnIndex, position);
+
+	return {
+		alignments: insertAtIndex(
+			table.alignments,
+			insertIndex,
+			TableAlignment.None
+		),
+		bodyRows: table.bodyRows.map((row) =>
+			insertAtIndex(row, insertIndex, TableEmptyCellText)
+		),
+		headerCells: insertAtIndex(
+			table.headerCells,
+			insertIndex,
+			TableEmptyCellText
+		),
+	};
+};
+
+export const deleteColumn = (
+	table: ParsedTable,
+	columnIndex: number
+): ParsedTable => {
+	if (getColumnCount(table) <= 1) {
+		return table;
+	}
+
+	return {
+		alignments: removeAtIndex(table.alignments, columnIndex),
+		bodyRows: table.bodyRows.map((row) => removeAtIndex(row, columnIndex)),
+		headerCells: removeAtIndex(table.headerCells, columnIndex),
+	};
+};
+
+// GFM pipe tables always require a header + delimiter line, so there is no
+// way to truly remove the header. "Toggling" it swaps the header content
+// with the first body row instead, which mirrors what most rich editors do
+// when the underlying format can't drop the header row entirely.
+export const toggleHeaderPresence = (table: ParsedTable): ParsedTable => {
+	const [firstBodyRow, ...remainingBodyRows] = table.bodyRows;
+
+	if (firstBodyRow === undefined) {
+		return {
+			...table,
+			bodyRows: [table.headerCells],
+			headerCells: table.headerCells.map(() => TableEmptyCellText),
+		};
+	}
+
+	return {
+		...table,
+		bodyRows: [table.headerCells, ...remainingBodyRows],
+		headerCells: firstBodyRow,
+	};
+};
+
+export const setColumnAlignment = (
+	table: ParsedTable,
+	columnIndex: number,
+	alignment: TableAlignment
+): ParsedTable => ({
+	...table,
+	alignments: table.alignments.map((currentAlignment, index) =>
+		index === columnIndex ? alignment : currentAlignment
+	),
+});
+
+export const getNextCellPosition = (
+	table: ParsedTable,
+	position: TableCellPosition
+): TableCellPosition | null => {
+	const columnCount = getColumnCount(table);
+	const rowCount = getRowCount(table);
+	const isLastColumn = position.column >= columnCount - 1;
+
+	if (!isLastColumn) {
+		return { column: position.column + 1, row: position.row };
+	}
+
+	if (position.row >= rowCount - 1) {
+		return null;
+	}
+
+	return { column: 0, row: position.row + 1 };
+};
+
+export const getPreviousCellPosition = (
+	table: ParsedTable,
+	position: TableCellPosition
+): TableCellPosition | null => {
+	const columnCount = getColumnCount(table);
+	const isFirstColumn = position.column <= 0;
+
+	if (!isFirstColumn) {
+		return { column: position.column - 1, row: position.row };
+	}
+
+	if (position.row <= 0) {
+		return null;
+	}
+
+	return { column: columnCount - 1, row: position.row - 1 };
+};
+
+export const isLastTableRow = (
+	table: ParsedTable,
+	position: TableCellPosition
+): boolean => position.row === getRowCount(table) - 1;

--- a/scripts/table.utils.check.ts
+++ b/scripts/table.utils.check.ts
@@ -1,0 +1,308 @@
+// Runnable self-check for app/utils/table.utils.ts (there is no test runner
+// in this repo). Run with: npx tsx scripts/table.utils.check.ts
+//
+// Location: deliberately NOT under app/utils/ (a `table.utils.check.ts` there
+// would still typecheck/lint fine, since neither tsc nor ESLint enforce the
+// "utils are pure functions only" rule mechanically — it's a convention, not
+// tooling) but it would violate that convention itself (assert calls +
+// process.stdout writes are not pure) and would sit oddly next to the real
+// util. Next.js only bundles what a page/route actually imports, so this
+// file is never pulled into the app bundle regardless of folder; putting it
+// under scripts/ just keeps app/utils/ honestly "pure functions only" on
+// disk. It is still picked up by the repo-wide tsconfig ("**/*.ts") and
+// ESLint globs ("**/*.{ts,tsx}"), and passes both.
+import assert from "node:assert/strict";
+
+import {
+	TableAlignment,
+	TableInsertPosition,
+} from "../app/lib/constants/table.constants";
+import {
+	buildEmptyTable,
+	deleteColumn,
+	deleteRow,
+	findTableRange,
+	getNextCellPosition,
+	getPreviousCellPosition,
+	insertColumn,
+	insertRow,
+	isLastTableRow,
+	parseTable,
+	serializeTable,
+	setColumnAlignment,
+	toggleHeaderPresence,
+} from "../app/utils/table.utils";
+
+const results: string[] = [];
+
+const check = (description: string, run: () => void): void => {
+	run();
+	results.push(`ok - ${description}`);
+};
+
+const sourceTableLines = [
+	"intro line",
+	"| Name | Age |",
+	"| :--- | ---: |",
+	"| Ada  | 30  |",
+	"| Grace | 40 |",
+	"outro line",
+];
+
+check("findTableRange locates the table from any cursor line inside it", () => {
+	assert.deepEqual(findTableRange(sourceTableLines, 2), {
+		endLine: 5,
+		startLine: 2,
+	});
+	assert.deepEqual(findTableRange(sourceTableLines, 4), {
+		endLine: 5,
+		startLine: 2,
+	});
+	assert.equal(findTableRange(sourceTableLines, 1), null);
+	assert.equal(findTableRange(sourceTableLines, 6), null);
+});
+
+check(
+	"parse -> serialize round trip preserves cell content and alignment",
+	() => {
+		const range = findTableRange(sourceTableLines, 3);
+
+		assert.ok(range);
+
+		if (!range) {
+			return;
+		}
+
+		const table = parseTable(sourceTableLines, range);
+
+		assert.deepEqual(table.headerCells, ["Name", "Age"]);
+		assert.deepEqual(table.alignments, [
+			TableAlignment.Left,
+			TableAlignment.Right,
+		]);
+		assert.deepEqual(table.bodyRows, [
+			["Ada", "30"],
+			["Grace", "40"],
+		]);
+
+		const serialized = serializeTable(table);
+		const reparsedRange = findTableRange(serialized.split("\n"), 1);
+
+		assert.ok(reparsedRange);
+
+		if (!reparsedRange) {
+			return;
+		}
+
+		const reparsedTable = parseTable(serialized.split("\n"), reparsedRange);
+
+		assert.deepEqual(reparsedTable, table);
+	}
+);
+
+check(
+	"serializeTable re-realigns columns: equal pipe positions after an uneven edit",
+	() => {
+		const range = findTableRange(sourceTableLines, 2);
+
+		assert.ok(range);
+
+		if (!range) {
+			return;
+		}
+
+		const table = parseTable(sourceTableLines, range);
+		// Simulate typing a much longer value into one cell, then re-serializing
+		// (the "auto-realign" behavior every mutation goes through).
+		const edited = {
+			...table,
+			bodyRows: [
+				["Ada", "30"],
+				["Grace-with-a-very-long-name", "40"],
+			],
+		};
+		const serialized = serializeTable(edited);
+		const lines = serialized.split("\n");
+		const pipeIndices = lines.map((line) => line.indexOf("|"));
+		const lastPipeIndices = lines.map((line) => line.lastIndexOf("|"));
+
+		assert.ok(pipeIndices.every((index) => index === pipeIndices[0]));
+		assert.ok(lastPipeIndices.every((index) => index === lastPipeIndices[0]));
+
+		const lineLengths = new Set(lines.map((line) => line.length));
+
+		assert.equal(lineLengths.size, 1);
+	}
+);
+
+check("insertRow: above inserts before the referenced row", () => {
+	const table = {
+		alignments: [TableAlignment.None],
+		bodyRows: [["row-1"], ["row-2"]],
+		headerCells: ["header"],
+	};
+	// logicalRowIndex 2 === bodyRows[1] ("row-2"); inserting "above" it must
+	// land the new blank row between "row-1" and "row-2".
+	const withRowAbove = insertRow(table, 2, TableInsertPosition.Before);
+
+	assert.deepEqual(withRowAbove.bodyRows, [["row-1"], [""], ["row-2"]]);
+});
+
+check("insertRow: below inserts after the referenced row", () => {
+	const table = {
+		alignments: [TableAlignment.None],
+		bodyRows: [["row-1"], ["row-2"]],
+		headerCells: ["header"],
+	};
+	const withRowBelow = insertRow(table, 1, TableInsertPosition.After);
+
+	assert.deepEqual(withRowBelow.bodyRows, [["row-1"], [""], ["row-2"]]);
+});
+
+check(
+	"deleteRow removes a body row and promotes the first body row when deleting the header",
+	() => {
+		const table = buildEmptyTable(3, 2);
+		const populated = {
+			...table,
+			bodyRows: [
+				["a1", "a2"],
+				["b1", "b2"],
+			],
+			headerCells: ["h1", "h2"],
+		};
+		const withoutBodyRow = deleteRow(populated, 1);
+
+		assert.deepEqual(withoutBodyRow.bodyRows, [["b1", "b2"]]);
+
+		const withoutHeader = deleteRow(populated, 0);
+
+		assert.deepEqual(withoutHeader.headerCells, ["a1", "a2"]);
+		assert.deepEqual(withoutHeader.bodyRows, [["b1", "b2"]]);
+	}
+);
+
+check("insertColumn: left inserts before the referenced column", () => {
+	const table = {
+		alignments: [TableAlignment.None, TableAlignment.None],
+		bodyRows: [["a1", "a2"]],
+		headerCells: ["h1", "h2"],
+	};
+	const withColumnLeft = insertColumn(table, 1, TableInsertPosition.Before);
+
+	assert.deepEqual(withColumnLeft.headerCells, ["h1", "", "h2"]);
+	assert.deepEqual(withColumnLeft.bodyRows, [["a1", "", "a2"]]);
+	assert.deepEqual(withColumnLeft.alignments, [
+		TableAlignment.None,
+		TableAlignment.None,
+		TableAlignment.None,
+	]);
+});
+
+check("insertColumn: right inserts after the referenced column", () => {
+	const table = {
+		alignments: [TableAlignment.None, TableAlignment.None],
+		bodyRows: [["a1", "a2"]],
+		headerCells: ["h1", "h2"],
+	};
+	const withColumnRight = insertColumn(table, 0, TableInsertPosition.After);
+
+	assert.deepEqual(withColumnRight.headerCells, ["h1", "", "h2"]);
+	assert.deepEqual(withColumnRight.bodyRows, [["a1", "", "a2"]]);
+});
+
+check(
+	"deleteColumn removes the targeted column and refuses to delete the last one",
+	() => {
+		const table = buildEmptyTable(2, 2);
+		const withColumn = insertColumn(table, 0, TableInsertPosition.After);
+		const withoutColumn = deleteColumn(withColumn, 1);
+
+		assert.equal(withoutColumn.headerCells.length, 2);
+
+		const cannotDeleteLastColumn = deleteColumn(buildEmptyTable(2, 1), 0);
+
+		assert.equal(cannotDeleteLastColumn.headerCells.length, 1);
+	}
+);
+
+check(
+	"toggleHeaderPresence swaps the header row with the first body row",
+	() => {
+		const table = {
+			alignments: [TableAlignment.None],
+			bodyRows: [["body-1"], ["body-2"]],
+			headerCells: ["header"],
+		};
+		const toggled = toggleHeaderPresence(table);
+
+		assert.deepEqual(toggled.headerCells, ["body-1"]);
+		assert.deepEqual(toggled.bodyRows, [["header"], ["body-2"]]);
+
+		// Toggling back moves the (now) header content back into the body.
+		const toggledAgain = toggleHeaderPresence(toggled);
+
+		assert.deepEqual(toggledAgain, table);
+	}
+);
+
+check("setColumnAlignment only changes the targeted column", () => {
+	const table = buildEmptyTable(2, 3);
+	const aligned = setColumnAlignment(table, 1, TableAlignment.Center);
+
+	assert.deepEqual(aligned.alignments, [
+		TableAlignment.None,
+		TableAlignment.Center,
+		TableAlignment.None,
+	]);
+});
+
+check(
+	"getNextCellPosition/getPreviousCellPosition wrap across rows and stop at the edges",
+	() => {
+		const table = buildEmptyTable(2, 2);
+
+		assert.deepEqual(getNextCellPosition(table, { column: 0, row: 0 }), {
+			column: 1,
+			row: 0,
+		});
+		assert.deepEqual(getNextCellPosition(table, { column: 1, row: 0 }), {
+			column: 0,
+			row: 1,
+		});
+		assert.equal(getNextCellPosition(table, { column: 1, row: 1 }), null);
+
+		assert.deepEqual(getPreviousCellPosition(table, { column: 1, row: 0 }), {
+			column: 0,
+			row: 0,
+		});
+		assert.deepEqual(getPreviousCellPosition(table, { column: 0, row: 1 }), {
+			column: 1,
+			row: 0,
+		});
+		assert.equal(getPreviousCellPosition(table, { column: 0, row: 0 }), null);
+	}
+);
+
+check(
+	"isLastTableRow + insertRow(After) is what Tab/Enter use to append a row from the last row",
+	() => {
+		const table = buildEmptyTable(2, 2);
+		const lastRowPosition = { column: 1, row: 1 };
+
+		assert.equal(isLastTableRow(table, lastRowPosition), true);
+		assert.equal(getNextCellPosition(table, lastRowPosition), null);
+
+		const withAppendedRow = insertRow(
+			table,
+			lastRowPosition.row,
+			TableInsertPosition.After
+		);
+
+		assert.equal(withAppendedRow.bodyRows.length, table.bodyRows.length + 1);
+		assert.equal(isLastTableRow(table, { column: 0, row: 0 }), false);
+	}
+);
+
+process.stdout.write(`${results.join("\n")}\n`);
+process.stdout.write(`\n${results.length} checks passed.\n`);

--- a/types/linkPreview.d.ts
+++ b/types/linkPreview.d.ts
@@ -1,0 +1,20 @@
+declare global {
+	type LinkPreviewData = {
+		description: string | null;
+		image: string | null;
+		siteName: string | null;
+		title: string | null;
+		url: string;
+	};
+
+	type LinkPreviewCacheEntry = {
+		expiresAt: number;
+		preview: LinkPreviewData;
+	};
+
+	type LinkPreviewErrorResponse = {
+		error: string;
+	};
+}
+
+export {};

--- a/types/table.d.ts
+++ b/types/table.d.ts
@@ -1,0 +1,26 @@
+import type { TableAlignment } from "@/lib/constants/table.constants";
+
+declare global {
+	type TableRow = string[];
+
+	type ParsedTable = {
+		alignments: TableAlignment[];
+		bodyRows: TableRow[];
+		headerCells: TableRow;
+	};
+
+	type TableLineRange = {
+		endLine: number;
+		startLine: number;
+	};
+
+	type TableCellPosition = {
+		column: number;
+		row: number;
+	};
+
+	type TableCellBounds = {
+		end: number;
+		start: number;
+	};
+}


### PR DESCRIPTION
## Summary

This change expands the snippet editor's Markdown authoring and preview experience. It adds toolbar and keyboard support for text highlighting, strikethrough, and editable tables, along with the supporting table utilities and rendering changes.

It also adds link preview cards to rendered Markdown. Link metadata is fetched through an authenticated API route with URL validation, DNS/IP checks, redirect limits, response-size limits, timeouts, and bounded caching.

## Validation

- `yarn lint` passed with three existing max-line warnings.
- `yarn build` could not complete in this environment because Turbopack was unable to bind a port (`Operation not permitted`).
- The pre-push audit reported 12 dependency vulnerabilities.