### PR TITLE
feat: close overlays on window resize

### DIFF
--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import {
 	aiActions,
 	AiProviderId,
+	aiStandaloneAskSystemPrompt,
 	AiStreamEventType,
 	aiSystemPrompts,
 	defaultAnthropicModel,
@@ -140,7 +141,15 @@ const emitDone = (
 	});
 };
 
-const buildAskSystemPrompt = (language: string, code: string): string => {
+const buildAskSystemPrompt = (
+	language: string,
+	code: string,
+	withSnippetContext: boolean
+): string => {
+	if (!withSnippetContext) {
+		return aiStandaloneAskSystemPrompt;
+	}
+
 	const base = aiSystemPrompts.ask(language || "unknown");
 
 	return `${base}\n\nHere is the ${language || "code"} snippet:\n\`\`\`${language || ""}\n${code}\n\`\`\``;
@@ -161,7 +170,8 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 		}
 
 		const body = (await request.json()) as AiRequest;
-		const { action, code, language, userPrompt, history } = body;
+		const { action, code, includeSnippet, language, userPrompt, history } =
+			body;
 
 		if (!action || !validActions.includes(action)) {
 			return NextResponse.json(
@@ -173,21 +183,23 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 			);
 		}
 
-		if (!code || code.trim().length === 0) {
+		const isAskAction = action === aiActions.ask;
+		// Only the ask action may opt out of snippet context; code actions operate on the snippet.
+		const withSnippetContext = isAskAction ? includeSnippet !== false : true;
+
+		if (withSnippetContext && (!code || code.trim().length === 0)) {
 			return NextResponse.json(
 				{ error: "Code is required" },
 				{ status: HttpStatusCode.BadRequest }
 			);
 		}
 
-		if (code.length > maxCodeLength) {
+		if (code && code.length > maxCodeLength) {
 			return NextResponse.json(
 				{ error: `Code exceeds ${maxCodeLength} character limit` },
 				{ status: HttpStatusCode.PayloadTooLarge }
 			);
 		}
-
-		const isAskAction = action === aiActions.ask;
 
 		if (isAskAction && (!userPrompt || userPrompt.trim().length === 0)) {
 			return NextResponse.json(
@@ -204,7 +216,7 @@ export const POST = async (request: NextRequest): Promise<Response> => {
 		}
 
 		const systemPrompt = isAskAction
-			? buildAskSystemPrompt(language || "unknown", code)
+			? buildAskSystemPrompt(language || "unknown", code, withSnippetContext)
 			: aiSystemPrompts[action](language || "unknown");
 		const prompt = isAskAction ? (userPrompt as string) : code;
 		const stripFences = !isAskAction;

--- a/app/components/AiAssistantPanel/AiAssistantPanel.tsx
+++ b/app/components/AiAssistantPanel/AiAssistantPanel.tsx
@@ -60,6 +60,7 @@ const AiAssistantPanel = ({
 		handleWikiSelect,
 		hasCurrentTurn,
 		history,
+		includeSnippetContext,
 		inputValue,
 		isAnswered,
 		isProcessing,
@@ -69,6 +70,7 @@ const AiAssistantPanel = ({
 		revealedAnswer,
 		selectedModel,
 		sendDisabled,
+		setIncludeSnippetContext,
 		showApplyButton,
 		showEmptyState,
 		showThinking,
@@ -112,11 +114,12 @@ const AiAssistantPanel = ({
 		addToast({ type: ToastType.Success, message: "AI result applied" });
 	};
 
-	const inputPlaceholder = currentSnippet
-		? history.length > 0 || currentUserMessage
+	const needsSnippet = !currentSnippet && includeSnippetContext;
+	const inputPlaceholder = needsSnippet
+		? "Select a snippet to start a chat"
+		: history.length > 0 || currentUserMessage
 			? "Ask a follow-up… ([[ to link a snippet)"
-			: "Ask something… ([[ to link a snippet)"
-		: "Select a snippet to start a chat";
+			: "Ask something… ([[ to link a snippet)";
 
 	return (
 		<section
@@ -181,10 +184,12 @@ const AiAssistantPanel = ({
 			</div>
 
 			<ChatComposer
-				inputDisabled={isProcessing || !currentSnippet}
+				includeSnippetContext={includeSnippetContext}
+				inputDisabled={isProcessing || needsSnippet}
 				inputValue={inputValue}
 				isProcessing={isProcessing}
 				lastUsage={lastUsage}
+				onIncludeSnippetContextChange={setIncludeSnippetContext}
 				onInputChange={handleInputChange}
 				onInputSelect={handleInputSelect}
 				onKeyDown={handleKeyDown}

--- a/app/components/Chat/ChatComposer/ChatComposer.tsx
+++ b/app/components/Chat/ChatComposer/ChatComposer.tsx
@@ -6,15 +6,19 @@ import { ChangeEvent, KeyboardEvent, ReactElement, RefObject } from "react";
 import WikiLinkPopover from "@/components/Chat/WikiLinkPopover/WikiLinkPopover";
 import ContextUsage from "@/components/ContextUsage/ContextUsage";
 import ModelSelector from "@/components/ModelSelector/ModelSelector";
+import Button from "@/components/ui/Button/Button";
+import Code from "@/components/ui/icons/Code";
 
 /* Styles */
 import styles from "./chatComposer.module.css";
 
 type ChatComposerProps = {
+	includeSnippetContext: boolean;
 	inputDisabled: boolean;
 	inputValue: string;
 	isProcessing: boolean;
 	lastUsage: AiUsage | null;
+	onIncludeSnippetContextChange: (includeSnippetContext: boolean) => void;
 	onInputChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
 	onInputSelect: () => void;
 	onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
@@ -32,10 +36,12 @@ type ChatComposerProps = {
 };
 
 const ChatComposer = ({
+	includeSnippetContext,
 	inputDisabled,
 	inputValue,
 	isProcessing,
 	lastUsage,
+	onIncludeSnippetContextChange,
 	onInputChange,
 	onInputSelect,
 	onKeyDown,
@@ -116,6 +122,28 @@ const ChatComposer = ({
 			<div className={styles.dockHint}>
 				<div className={styles.dockHintLeft}>
 					{showModelSelector && <ModelSelector compact />}
+					<Button
+						className={`${styles.contextToggle} ${
+							includeSnippetContext ? styles.contextToggleOn : ""
+						}`}
+						variant="secondary"
+						shape="pill"
+						aria-pressed={includeSnippetContext}
+						title={
+							includeSnippetContext
+								? "The snippet is sent with your question. Turn off to ask without it."
+								: "The snippet is not sent with your question. Turn on to include it."
+						}
+						onClick={() =>
+							onIncludeSnippetContextChange(!includeSnippetContext)
+						}
+					>
+						<Code width="12" height="12" />
+						Snippet context
+						<span className={styles.contextToggleState}>
+							{includeSnippetContext ? "on" : "off"}
+						</span>
+					</Button>
 					<ContextUsage usage={lastUsage} />
 				</div>
 				<span>

--- a/app/components/Chat/ChatComposer/chatComposer.module.css
+++ b/app/components/Chat/ChatComposer/chatComposer.module.css
@@ -146,6 +146,36 @@
 	flex: 1 1 auto;
 }
 
+.contextToggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	padding: 0.125rem 0.5rem;
+	font-size: 0.6875rem;
+	line-height: 1.4;
+	background: transparent;
+	color: var(--gray-color);
+}
+
+.contextToggle:hover:not(:disabled) {
+	background: var(--bg-color-dark);
+	transform: none;
+	box-shadow: none;
+}
+
+.contextToggleOn {
+	border-color: var(--purple-color);
+	color: var(--foreground-color);
+}
+
+.contextToggleState {
+	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	font-size: 0.625rem;
+	text-transform: uppercase;
+	letter-spacing: 0.03em;
+	opacity: 0.75;
+}
+
 .dockHint {
 	display: flex;
 	flex-wrap: wrap;

--- a/app/components/CodeEditor/AiChatModal/AiChatModal.tsx
+++ b/app/components/CodeEditor/AiChatModal/AiChatModal.tsx
@@ -28,6 +28,7 @@ import { getUserDataFromSession } from "@/lib/supabase/queries";
 
 /* Utils */
 import { extractCodeBlockBody } from "@/utils/chat.utils";
+import { useCloseOnResize } from "@/utils/ui.utils";
 
 /* Styles */
 import styles from "./aiChatModal.module.css";
@@ -53,6 +54,9 @@ const AiChatModal = ({
 }: AiChatModalProps): ReactElement | null => {
 	const { addToast } = useToastStore();
 	const isMobile = useViewPortStore((state) => state.isMobile);
+
+	// Conversation lives in chat.store, so reopening restores the thread.
+	useCloseOnResize(onClose, isOpen);
 
 	const {
 		abortInFlight,

--- a/app/components/CodeEditor/AiChatModal/AiChatModal.tsx
+++ b/app/components/CodeEditor/AiChatModal/AiChatModal.tsx
@@ -71,6 +71,7 @@ const AiChatModal = ({
 		handleWikiSelect,
 		hasCurrentTurn,
 		history,
+		includeSnippetContext,
 		inputValue,
 		isAnswered,
 		isProcessing,
@@ -81,6 +82,7 @@ const AiChatModal = ({
 		revealedAnswer,
 		selectedModel,
 		sendDisabled,
+		setIncludeSnippetContext,
 		setSelectedModel,
 		showApplyButton,
 		showEmptyState,
@@ -357,10 +359,12 @@ const AiChatModal = ({
 			</div>
 
 			<ChatComposer
+				includeSnippetContext={includeSnippetContext}
 				inputDisabled={isProcessing}
 				inputValue={inputValue}
 				isProcessing={isProcessing}
 				lastUsage={lastUsage}
+				onIncludeSnippetContextChange={setIncludeSnippetContext}
 				onInputChange={handleInputChange}
 				onInputSelect={handleInputSelect}
 				onKeyDown={handleKeyDown}

--- a/app/components/CodeEditor/SnippetDetails/FolderField.tsx
+++ b/app/components/CodeEditor/SnippetDetails/FolderField.tsx
@@ -3,6 +3,7 @@
 import { ChangeEvent, ReactElement, useMemo, useState } from "react";
 
 /* Components */
+import Folder from "@/components/ui/icons/Folder";
 import Input from "@/components/ui/Input/Input";
 import TagSuggestions from "@/components/CodeEditor/TagSuggestions";
 
@@ -40,7 +41,10 @@ const FolderField = ({
 
 	return (
 		<div className={styles.detailsField}>
-			<label className={styles.detailsLabel}>Folder</label>
+			<label className={styles.detailsLabel}>
+				<Folder width={14} height={14} />
+				Folder
+			</label>
 			<div className={styles.detailsAutocomplete}>
 				<Input
 					placeholder="e.g. Recipes, Work, Snippets-2026"

--- a/app/components/CodeEditor/SnippetDetails/SnippetDetails.tsx
+++ b/app/components/CodeEditor/SnippetDetails/SnippetDetails.tsx
@@ -13,6 +13,9 @@ import FolderField from "@/components/CodeEditor/SnippetDetails/FolderField";
 import Input from "@/components/ui/Input/Input";
 import TagsField from "@/components/CodeEditor/SnippetDetails/TagsField";
 
+/* Utils */
+import { useCloseOnResize } from "@/utils/ui.utils";
+
 /* Styles */
 import styles from "../codeEditor.module.css";
 
@@ -54,8 +57,9 @@ const SnippetDetails = ({
 
 	// The panel hangs off the ⓘ button, whose x position moves with the title
 	// input's width, so it cannot be expressed in CSS. Measured on open only —
-	// ponytail: a resize while the panel is open leaves it offset; recompute on
-	// resize if that shows up in practice.
+	// the panel closes on resize rather than tracking the anchor.
+	useCloseOnResize(onClose);
+
 	useLayoutEffect(() => {
 		const anchor = anchorRef.current;
 

--- a/app/components/CodeEditor/SnippetDetails/TagsField.tsx
+++ b/app/components/CodeEditor/SnippetDetails/TagsField.tsx
@@ -8,6 +8,7 @@ import { MaxSnippetTags } from "@/lib/constants/core";
 /* Components */
 import Badge from "@/components/ui/Badge/Badge";
 import Input from "@/components/ui/Input/Input";
+import Tag from "@/components/ui/icons/Tag";
 import TagSuggestions from "@/components/CodeEditor/TagSuggestions";
 
 /* Utils */
@@ -45,7 +46,10 @@ const TagsField = ({
 
 	return (
 		<div className={styles.detailsField}>
-			<label className={styles.detailsLabel}>Tags</label>
+			<label className={styles.detailsLabel}>
+				<Tag width={14} height={14} />
+				Tags
+			</label>
 
 			{tagList.length > 0 && (
 				<div className={styles.detailsChips}>

--- a/app/components/CodeEditor/codeEditor.module.css
+++ b/app/components/CodeEditor/codeEditor.module.css
@@ -508,6 +508,9 @@
 }
 
 .detailsLabel {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
 	font-size: var(--tiny-font-size);
 	color: var(--comment-color);
 	font-weight: 600;

--- a/app/components/CommandPalette/CommandPalette.tsx
+++ b/app/components/CommandPalette/CommandPalette.tsx
@@ -17,6 +17,9 @@ import Settings from "@/components/ui/icons/Settings";
 import NewFile from "@/components/ui/icons/NewFile";
 import LanguageBadge from "@/components/ui/LanguageBadge/LanguageBadge";
 
+/* Utils */
+import { useCloseOnResize } from "@/utils/ui.utils";
+
 /* Styles */
 import styles from "./commandPalette.module.css";
 
@@ -59,6 +62,8 @@ const CommandPalette = ({
 		(store) => store.toggleCommandPalette
 	);
 	const [isMac, setIsMac] = useState<boolean>(true);
+
+	useCloseOnResize(() => setCommandPaletteOpen(false), open);
 
 	useEffect(() => {
 		setIsMac(window.navigator.userAgent.includes("Mac"));

--- a/app/components/ui/Menu/Menu.tsx
+++ b/app/components/ui/Menu/Menu.tsx
@@ -6,6 +6,9 @@ import { createPortal } from "react-dom";
 /* Components */
 import DotsThreeVertical from "@/components/ui/icons/DotsThreeVertical";
 
+/* Utils */
+import { useCloseOnResize } from "@/utils/ui.utils";
+
 /* Styles */
 import styles from "./menu.module.css";
 
@@ -27,6 +30,10 @@ const Menu = ({
 	});
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
 	const menuRef = useRef<HTMLDivElement | null>(null);
+
+	// The dropdown is portaled at coordinates measured when it opened, and its
+	// trigger is hidden below 1140px — a resize would otherwise strand it.
+	useCloseOnResize(() => setIsOpen(false), isOpen);
 
 	useEffect(() => {
 		if (!isOpen) {

--- a/app/components/ui/Modal/Modal.tsx
+++ b/app/components/ui/Modal/Modal.tsx
@@ -4,6 +4,9 @@ import { createPortal } from "react-dom";
 /* Icons */
 import CloseSquare from "@/components/ui/icons/CloseSquare";
 
+/* Utils */
+import { useCloseOnResize } from "@/utils/ui.utils";
+
 /* Styles */
 import styles from "./modal.module.css";
 
@@ -30,6 +33,8 @@ const Modal = ({
 }: ModalProps): ReactElement | null => {
 	const modalRef = useRef<HTMLDivElement>(null);
 	const [isRendered, setIsRendered] = useState<boolean>(isOpen);
+
+	useCloseOnResize(onClose, isOpen);
 
 	useEffect(() => {
 		if (isOpen) {

--- a/app/components/ui/Skeleton/SkeletonCodeEditor.tsx
+++ b/app/components/ui/Skeleton/SkeletonCodeEditor.tsx
@@ -9,20 +9,53 @@ import styles from "./skeleton.module.css";
 const SkeletonCodeEditor = (): ReactElement => {
 	return (
 		<div className={styles.editorContainer}>
-			{/* One row, matching the merged editor chrome: identity on the left,
-			    tag chips and the actions cluster on the right. */}
+			{/* Mirrors CodeEditorHeader group for group: ★ / title / ⓘ on the left,
+			    the tag chip in the middle, and Select / Save / ⋯ pinned right. Sizes
+			    track --row-control-height so the row does not shift on hydration. */}
 			<div className={styles.editorHeader}>
-				<div className={styles.editorHeaderLeft}>
-					<Skeleton width="1.25rem" height="1.25rem" borderRadius="50%" />
-					<Skeleton width="12rem" height="1.25rem" />
-					<Skeleton width="1.25rem" height="1.25rem" borderRadius="50%" />
+				<div className={styles.editorHeaderIdentity}>
+					<Skeleton
+						width="var(--row-control-height)"
+						height="var(--row-control-height)"
+						borderRadius="var(--border-radius)"
+					/>
+					<Skeleton
+						width="12rem"
+						height="2rem"
+						borderRadius="var(--border-radius)"
+					/>
+					<Skeleton
+						width="var(--row-control-height)"
+						height="var(--row-control-height)"
+						borderRadius="var(--border-radius)"
+					/>
 				</div>
-				<div className={styles.editorHeaderRight}>
-					<Skeleton width="4rem" height="1.5rem" borderRadius="12px" />
-					<Skeleton width="4rem" height="1.5rem" borderRadius="12px" />
-					<Skeleton width="1.25rem" height="1.25rem" borderRadius="4px" />
-					<Skeleton width="5rem" height="1.5rem" borderRadius="4px" />
-					<Skeleton width="4rem" height="1.5rem" borderRadius="4px" />
+
+				<div className={styles.editorHeaderTags}>
+					<Skeleton
+						width="5.5rem"
+						height="var(--row-control-height)"
+						borderRadius="999px"
+					/>
+				</div>
+
+				<div className={styles.editorHeaderActions}>
+					<Skeleton
+						width="6rem"
+						height="var(--row-control-height)"
+						borderRadius="999px"
+					/>
+					<Skeleton
+						width="5.5rem"
+						height="var(--row-control-height)"
+						borderRadius="999px"
+					/>
+					<Skeleton
+						className={styles.editorHeaderMenu}
+						width="var(--row-control-height)"
+						height="var(--row-control-height)"
+						borderRadius="var(--border-radius-md)"
+					/>
 				</div>
 			</div>
 

--- a/app/components/ui/Skeleton/skeleton.module.css
+++ b/app/components/ui/Skeleton/skeleton.module.css
@@ -57,29 +57,55 @@
 	height: 100%;
 }
 
+/* Geometry copied from .header in codeEditor.module.css — the loader and the
+   hydrated row must land on the same pixels. */
 .editorHeader {
 	display: flex;
-	flex-direction: row;
+	flex-flow: row nowrap;
 	align-items: center;
 	justify-content: space-between;
+	gap: 0.5rem;
 	height: 3.2rem;
 	background: var(--bg-color-dark);
-	padding: 0 0.625rem;
+	padding: 0 0.5rem;
 	border-bottom: 1px solid var(--border-color);
 }
 
-.editorHeaderLeft {
+.editorHeaderIdentity {
 	display: flex;
-	flex-direction: row;
+	flex: 1 1 auto;
+	flex-flow: row nowrap;
 	align-items: center;
-	gap: 0.625rem;
+	gap: 0.375rem;
+	min-width: 11rem;
 }
 
-.editorHeaderRight {
+.editorHeaderTags {
 	display: flex;
-	flex-direction: row;
+	flex: 0 1 auto;
+	flex-flow: row nowrap;
 	align-items: center;
+	min-width: 0;
+	overflow: hidden;
+}
+
+.editorHeaderActions {
+	display: flex;
+	flex: 0 0 auto;
+	flex-flow: row nowrap;
+	align-items: center;
+	justify-content: flex-end;
 	gap: 0.625rem;
+	margin-left: auto;
+}
+
+/* Same breakpoint as .headerTags / .headerActionsMenu, which collapse into the
+   mobile bottom bar below 1140px. */
+@media (width < 1140px) {
+	.editorHeaderTags,
+	.editorHeaderMenu {
+		display: none;
+	}
 }
 
 /* Action-icon row loader — mirrors CodeEditorActions; hidden < 1140px to match

--- a/app/lib/constants/ai.ts
+++ b/app/lib/constants/ai.ts
@@ -48,6 +48,9 @@ export const aiSystemPrompts: Record<AiAction, (language: string) => string> = {
 		`You are an inline ${language} code completion assistant. The user's message is a partial code prefix; return ONLY the next 1 to 3 lines that should follow the cursor. Output raw text, no explanation, no markdown, no code fences. Preserve the existing indentation and style. If the prefix already looks complete, return an empty response.`,
 };
 
+export const aiStandaloneAskSystemPrompt =
+	"You are a coding assistant. Answer the user's question clearly and concisely. No code snippet has been shared as context, so answer from general knowledge and ask for the code if you need it. If you include code, wrap it in fenced code blocks with the language tag.";
+
 export const codeActions: AiAction[] = [
 	"comments",
 	"format",

--- a/app/lib/hooks/useAiChat.ts
+++ b/app/lib/hooks/useAiChat.ts
@@ -32,6 +32,12 @@ const useAiChat = ({
 	const selectedModel = useChatStore((state) => state.selectedModel);
 	const setSelectedModel = useChatStore((state) => state.setSelectedModel);
 	const history = useChatStore((state) => state.history);
+	const includeSnippetContext = useChatStore(
+		(state) => state.includeSnippetContext
+	);
+	const setIncludeSnippetContext = useChatStore(
+		(state) => state.setIncludeSnippetContext
+	);
 	const lastUsage = useChatStore((state) => state.lastUsage);
 	const appendMessage = useChatStore((state) => state.appendMessage);
 	const clearHistory = useChatStore((state) => state.clearHistory);
@@ -187,11 +193,14 @@ const useAiChat = ({
 		) {
 			appendMessage({ role: UserRole.User, content: currentUserMessage });
 
-			const isReplaceCandidate = detectReplaceCandidate(
-				currentUserPrompt,
-				revealedAnswer,
-				snippetLanguage
-			);
+			// Replacing the snippet with an answer that never saw it would destroy content.
+			const isReplaceCandidate =
+				includeSnippetContext &&
+				detectReplaceCandidate(
+					currentUserPrompt,
+					revealedAnswer,
+					snippetLanguage
+				);
 
 			appendMessage({
 				role: UserRole.Assistant,
@@ -209,7 +218,12 @@ const useAiChat = ({
 		displayMessage: string,
 		userPrompt?: string
 	): Promise<void> => {
-		if (!currentSnippet?.snippet?.trim()) {
+		// Chip actions transform the snippet, so they always need it; a plain question
+		// only needs it while the user keeps snippet context switched on.
+		const withSnippetContext =
+			action !== aiActions.ask || includeSnippetContext;
+
+		if (withSnippetContext && !currentSnippet?.snippet?.trim()) {
 			addToast({
 				type: ToastType.Error,
 				message: missingSnippetMessage,
@@ -316,9 +330,10 @@ const useAiChat = ({
 		try {
 			const response = await requestAiAction(
 				action,
-				currentSnippet.snippet,
-				currentSnippet.language,
+				withSnippetContext ? (currentSnippet?.snippet ?? "") : "",
+				withSnippetContext ? (currentSnippet?.language ?? "") : "",
 				{
+					includeSnippet: withSnippetContext,
 					userPrompt: effectivePrompt,
 					signal: controller.signal,
 					history: historyForRequest,
@@ -418,6 +433,7 @@ const useAiChat = ({
 	const showTurnActions = isAnswered && lastAction === aiActions.ask;
 	const currentTurnReplaceCandidate =
 		isAnswered &&
+		includeSnippetContext &&
 		detectReplaceCandidate(currentUserPrompt, revealedAnswer, snippetLanguage);
 
 	return {
@@ -437,6 +453,7 @@ const useAiChat = ({
 		handleWikiSelect,
 		hasCurrentTurn,
 		history,
+		includeSnippetContext,
 		inputValue,
 		isAnswered,
 		isProcessing,
@@ -447,6 +464,7 @@ const useAiChat = ({
 		revealedAnswer,
 		selectedModel,
 		sendDisabled,
+		setIncludeSnippetContext,
 		setSelectedModel,
 		showApplyButton,
 		showEmptyState,

--- a/app/lib/store/chat.store.tsx
+++ b/app/lib/store/chat.store.tsx
@@ -3,8 +3,10 @@ import { create } from "zustand";
 type ChatState = {
 	selectedModel: string;
 	history: ChatEntry[];
+	includeSnippetContext: boolean;
 	lastUsage: AiUsage | null;
 	setSelectedModel: (model: string) => void;
+	setIncludeSnippetContext: (includeSnippetContext: boolean) => void;
 	appendMessage: (entry: ChatEntry) => void;
 	clearHistory: () => void;
 	setLastUsage: (usage: AiUsage | null) => void;
@@ -13,8 +15,11 @@ type ChatState = {
 const useChatStore = create<ChatState>((set) => ({
 	selectedModel: "",
 	history: [],
+	includeSnippetContext: true,
 	lastUsage: null,
 	setSelectedModel: (selectedModel) => set({ selectedModel }),
+	setIncludeSnippetContext: (includeSnippetContext) =>
+		set({ includeSnippetContext }),
 	appendMessage: (entry) =>
 		set((state) => ({ history: [...state.history, entry] })),
 	clearHistory: () => set({ history: [], lastUsage: null }),

--- a/app/utils/ai.utils.ts
+++ b/app/utils/ai.utils.ts
@@ -83,14 +83,28 @@ export const requestAiAction = async (
 	language: string,
 	options: RequestAiActionOptions = {}
 ): Promise<AiResponse> => {
-	const { userPrompt, signal, history, onThinkingDelta, onTextDelta } = options;
+	const {
+		includeSnippet,
+		userPrompt,
+		signal,
+		history,
+		onThinkingDelta,
+		onTextDelta,
+	} = options;
 
 	const response = await fetch("/api/ai", {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
 		},
-		body: JSON.stringify({ action, code, language, userPrompt, history }),
+		body: JSON.stringify({
+			action,
+			code,
+			language,
+			includeSnippet,
+			userPrompt,
+			history,
+		}),
 		signal,
 	});
 

--- a/app/utils/ui.utils.ts
+++ b/app/utils/ui.utils.ts
@@ -1,4 +1,10 @@
-import { MouseEvent, MutableRefObject, RefObject, useEffect } from "react";
+import {
+	MouseEvent,
+	MutableRefObject,
+	RefObject,
+	useEffect,
+	useRef,
+} from "react";
 import useViewPortStore from "@/lib/store/viewPort.store";
 import useMenuStore from "@/lib/store/menu.store";
 
@@ -46,6 +52,51 @@ export const useClickOutside = (
 			document.removeEventListener("mousedown", handleClickOutside);
 		};
 	}, [reference, onClickOutside, enabled]);
+};
+
+// Overlays either measure their anchor once (Menu, SnippetDetails) or assume a
+// layout that a resize invalidates, so a resize while one is open leaves it
+// detached from whatever opened it. Closing is the honest outcome.
+export const useCloseOnResize = (
+	onClose: () => void,
+	enabled: boolean = true
+): void => {
+	const widthRef = useRef<number>(0);
+
+	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
+
+		widthRef.current = window.innerWidth;
+
+		const handleResize = (): void => {
+			const isWidthUnchanged = widthRef.current === window.innerWidth;
+			const activeElement = document.activeElement;
+			const isEditing =
+				activeElement instanceof HTMLElement &&
+				(activeElement.isContentEditable ||
+					activeElement instanceof HTMLInputElement ||
+					activeElement instanceof HTMLTextAreaElement);
+
+			widthRef.current = window.innerWidth;
+
+			// The mobile on-screen keyboard resizes height only. Ignoring that one
+			// case keeps the overlay from closing itself the moment a field is
+			// focused — every other resize still closes it.
+			if (isWidthUnchanged && isEditing) {
+				return;
+			}
+
+			onClose();
+		};
+
+		window.addEventListener("resize", handleResize);
+
+		return () => {
+			window.removeEventListener("resize", handleResize);
+		};
+	}, [enabled, onClose]);
 };
 
 export const useCloseOutsideCodeEditor = (

--- a/types/ai.d.ts
+++ b/types/ai.d.ts
@@ -11,6 +11,7 @@ declare global {
 	};
 
 	type RequestAiActionOptions = {
+		includeSnippet?: boolean;
 		userPrompt?: string;
 		signal?: AbortSignal;
 		history?: AiHistoryMessage[];

--- a/types/snippets.d.ts
+++ b/types/snippets.d.ts
@@ -101,6 +101,7 @@ declare global {
 		action: AiAction;
 		code: string;
 		language: string;
+		includeSnippet?: boolean;
 		userPrompt?: string;
 		history?: AiHistoryMessage[];
 	};


### PR DESCRIPTION
#### Github Issue

relates to https://github.com/vianch/snippets/issues/{issue number}

#### Why are you creating this PR? What value is added?

Adds a `useCloseOnResize` hook that closes overlays (modals, menus, command palette, snippet details) when the window is resized. Overlays measured their anchor once on open, so a resize would strand them detached from their trigger. Closing is the honest outcome — the mobile keyboard resize is the only exception (height-only, no width change).

#### Include screenshots below (if appropriate)