### PR TITLE
fix: centralize tag-pill height in Badge component

### DIFF
--- a/app/components/CodeEditor/codeEditor.module.css
+++ b/app/components/CodeEditor/codeEditor.module.css
@@ -75,11 +75,9 @@
 	overflow: hidden;
 }
 
-/* Overrides Badge's own height, which is content-box and so renders taller
-   than its declared value once padding and border are added. */
+/* Badge already carries --row-control-height; only the row's width cap is
+   local. */
 .headerTagBadge {
-	box-sizing: border-box;
-	height: var(--row-control-height);
 	max-width: 7rem;
 }
 
@@ -538,12 +536,8 @@
 }
 
 /* Badge carries its own left margin for the inline row layout; the wrapped
-   chip grid supplies spacing through gap instead. Height is pinned to the same
-   token as the row's chips so the two surfaces agree — Badge's own height is
-   content-box and renders taller than declared. */
+   chip grid supplies spacing through gap instead. */
 .detailsChip {
-	box-sizing: border-box;
-	height: var(--row-control-height);
 	margin-left: 0;
 }
 

--- a/app/components/ui/Badge/badge.module.css
+++ b/app/components/ui/Badge/badge.module.css
@@ -1,5 +1,8 @@
+/* Pinned to the shared editor-row control height so tag pills line up with the
+   language Select and Save button. border-box makes it the real height. */
 .badgeWrapper {
-	height: 1.563rem;
+	box-sizing: border-box;
+	height: var(--row-control-height);
 	display: inline-flex;
 	flex-flow: row nowrap;
 	justify-content: center;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Moved `box-sizing: border-box` and `--row-control-height` into Badge so CodeEditor no longer overrides it. Tag pills now align with the language Select and Save button.