### PR TITLE
feat: reduce query payload sizes and race conditions in snippet storage

### DIFF
--- a/app/api/storage/export/route.ts
+++ b/app/api/storage/export/route.ts
@@ -4,6 +4,7 @@ import { SnippetState } from "@/lib/constants/core";
 import {
 	ExportFormat,
 	ServerSideBackends,
+	SnippetColumns,
 	SnippetTableName,
 } from "@/lib/constants/storage.constants";
 import { HttpStatusCode } from "@/lib/constants/ui.constants";
@@ -24,7 +25,7 @@ const fetchSnippets = async (
 	const supabase = createSupabaseAdminClient();
 	const { data } = await supabase
 		.from(SnippetTableName)
-		.select()
+		.select(SnippetColumns)
 		.match({ user_id: userId })
 		.neq("state", SnippetState.Inactive);
 

--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -6,7 +6,6 @@ import CodeMirror from "@uiw/react-codemirror";
 
 /* Lib */
 import SupportedLanguages from "@/lib/config/languages";
-import languageExtensions from "@/lib/codeEditor";
 import inlineCompletion from "@/lib/inlineCompletion";
 import markdownKeymap from "@/lib/markdown/markdownKeymap";
 import wikiLinkAutocomplete from "@/lib/wikiLinkAutocomplete";
@@ -129,6 +128,7 @@ const CodeEditor = ({
 		removeTagHandler,
 		togglePublicHandler,
 		refreshVersionCount,
+		restoreVersionHandler,
 		saveHandler,
 	} = useCurrentSnippet({
 		snippet,
@@ -311,26 +311,7 @@ const CodeEditor = ({
 										setShowHistory(false);
 										setPreRestoreSnapshot(null);
 									}}
-									onRestore={(version) => {
-										const restoredLanguage =
-											version.language as SupportedLanguages;
-
-										if (!preRestoreSnapshot) {
-											setPreRestoreSnapshot({ ...currentSnippet });
-										}
-
-										setCurrentSnippet({
-											...currentSnippet,
-											snippet: version.content,
-											language: restoredLanguage,
-											name: version.name,
-											tags: version.tags,
-											extension: languageExtensions[restoredLanguage],
-										});
-										onTouched(true);
-										setShowDetails(false);
-										refreshVersionCount(currentSnippet.snippet_id);
-									}}
+									onRestore={restoreVersionHandler}
 									undoSnapshot={preRestoreSnapshot}
 									onUndo={() => {
 										if (!preRestoreSnapshot) return;

--- a/app/components/CodeEditor/hooks/useCurrentSnippet.ts
+++ b/app/components/CodeEditor/hooks/useCurrentSnippet.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/constants/core";
 import { ToastType } from "@/lib/constants/toast";
 import {
+	getSnippetVersion,
 	getSnippetVersions,
 	toggleSnippetPublic,
 } from "@/lib/storage/snippets";
@@ -54,6 +55,7 @@ type UseCurrentSnippetReturn = {
 	removeTagHandler: (tagRemoved: string) => void;
 	togglePublicHandler: () => Promise<void>;
 	refreshVersionCount: (snippetId: UUID) => void;
+	restoreVersionHandler: (version: SnippetVersionSummary) => Promise<void>;
 	saveHandler: () => void;
 };
 
@@ -257,6 +259,42 @@ const useCurrentSnippet = ({
 			.catch(() => setVersionCount(0));
 	};
 
+	// The history list carries metadata only, so the body of the version the user
+	// picked is fetched here instead of shipping five snippet bodies with the list.
+	const restoreVersionHandler = async (
+		version: SnippetVersionSummary
+	): Promise<void> => {
+		const fullVersion = await getSnippetVersion(version.version_id);
+
+		if (!fullVersion) {
+			addToast({
+				type: ToastType.Error,
+				message: "Could not load that version",
+			});
+
+			return;
+		}
+
+		// `language` is a free-text column; the editor only knows SupportedLanguages.
+		const restoredLanguage = fullVersion.language as SupportedLanguages;
+
+		if (!preRestoreSnapshot) {
+			setPreRestoreSnapshot({ ...currentSnippet });
+		}
+
+		setCurrentSnippet({
+			...currentSnippet,
+			snippet: fullVersion.content,
+			language: restoredLanguage,
+			name: fullVersion.name,
+			tags: fullVersion.tags,
+			extension: languageExtensions[restoredLanguage],
+		});
+		onTouched(true);
+		setShowDetails(false);
+		refreshVersionCount(currentSnippet.snippet_id);
+	};
+
 	const saveHandler = (): void => {
 		onSave(currentSnippet, true);
 	};
@@ -349,6 +387,7 @@ const useCurrentSnippet = ({
 		removeTagHandler,
 		togglePublicHandler,
 		refreshVersionCount,
+		restoreVersionHandler,
 		saveHandler,
 	};
 };

--- a/app/components/History/History.tsx
+++ b/app/components/History/History.tsx
@@ -16,7 +16,7 @@ import styles from "./history.module.css";
 type HistoryProps = {
 	snippetId: UUID;
 	isOpen: boolean;
-	onRestore: (version: SnippetVersion) => void;
+	onRestore: (version: SnippetVersionSummary) => void;
 	onClose: () => void;
 	undoSnapshot: CurrentSnippet | null;
 	onUndo: () => void;
@@ -31,7 +31,7 @@ const History = ({
 	onUndo,
 }: HistoryProps): ReactElement | null => {
 	const isMobile = useViewPortStore((state) => state.isMobile);
-	const [versions, setVersions] = useState<SnippetVersion[]>([]);
+	const [versions, setVersions] = useState<SnippetVersionSummary[]>([]);
 	const [isLoading, setIsLoading] = useState(false);
 
 	useEffect(() => {

--- a/app/components/SnippetItem/SnippetItem.tsx
+++ b/app/components/SnippetItem/SnippetItem.tsx
@@ -49,6 +49,13 @@ const SnippetItem: FC<SnippetItemPropsComponent> = ({
 			onToggleFavorite(snippet);
 		};
 
+		// The row itself selects a snippet, so a delete/restore click must not reach
+		// it: the row would then make the snippet that was just removed the active
+		// one, leaving the editor on a fallback snippet and no row highlighted.
+		const stopRowSelection = (event: MouseEvent<HTMLSpanElement>): void => {
+			event.stopPropagation();
+		};
+
 		const isSnippetActive = activeSnippetId === snippet.snippet_id;
 
 		return (
@@ -72,25 +79,35 @@ const SnippetItem: FC<SnippetItemPropsComponent> = ({
 								/>
 							</span>
 						) : (
-							<Trash
-								className={styles.trashIcon}
-								width="18"
-								height="18"
-								onClick={() =>
-									onDeleteSnippet(snippet?.snippet_id, SnippetState.Inactive)
-								}
-							/>
+							<span
+								className={styles.actionIconWrapper}
+								onClick={stopRowSelection}
+							>
+								<Trash
+									className={styles.trashIcon}
+									width="18"
+									height="18"
+									onClick={() =>
+										onDeleteSnippet(snippet?.snippet_id, SnippetState.Inactive)
+									}
+								/>
+							</span>
 						))}
 
 					{snippet?.state === SnippetState.Inactive && (
-						<Restore
-							className={styles.restoreIcon}
-							width="18"
-							height="18"
-							onClick={() =>
-								onRestoreSnippet(snippet?.snippet_id, SnippetState.Active)
-							}
-						/>
+						<span
+							className={styles.actionIconWrapper}
+							onClick={stopRowSelection}
+						>
+							<Restore
+								className={styles.restoreIcon}
+								width="18"
+								height="18"
+								onClick={() =>
+									onRestoreSnippet(snippet?.snippet_id, SnippetState.Active)
+								}
+							/>
+						</span>
 					)}
 					<span className={styles.snippetName} title={snippet?.name ?? ""}>
 						{touched && isSnippetActive && "* "}

--- a/app/components/SnippetList/snippetlist.module.css
+++ b/app/components/SnippetList/snippetlist.module.css
@@ -389,7 +389,8 @@
 	transition: transform var(--duration-fast) var(--ease-spring);
 }
 
-.favoriteIconWrapper {
+.favoriteIconWrapper,
+.actionIconWrapper {
 	display: inline-flex;
 	flex-shrink: 0;
 	align-items: center;

--- a/app/lib/constants/storage.constants.ts
+++ b/app/lib/constants/storage.constants.ts
@@ -59,6 +59,22 @@ export const SnippetTableName = "snippet";
 
 export const SnippetVersionTableName = "snippet_version";
 
+// A bare `.select()` is `select *`, which on Supabase also ships the generated
+// `fts` tsvector — roughly as many bytes again as the snippet body itself, for a
+// column no client ever reads. Every snippet read names its columns instead.
+export const SnippetColumns =
+	"snippet_id, user_id, created_at, updated_at, name, url, notes, snippet, language, state, tags, is_public, public_slug, folder";
+
+// Version rows carry a full copy of the snippet body in `content`. The history
+// panel only renders metadata, so the list stays content-free and the body is
+// fetched for the one version the user actually restores.
+export const SnippetVersionSummaryColumns =
+	"version_id, snippet_id, user_id, version_number, name, language, tags, created_at";
+
+// Postgres function that allocates the next version_number and inserts in one
+// statement — see supabase/migrations/20260809200000_create_snippet_version_rpc.sql.
+export const CreateSnippetVersionFunction = "create_snippet_version";
+
 export const StorageConfigTableName = "storage_config";
 
 // Single global config row id — there is exactly one active backend per deploy.

--- a/app/lib/storage/adapters/supabase.adapter.ts
+++ b/app/lib/storage/adapters/supabase.adapter.ts
@@ -1,4 +1,7 @@
-import { SnippetTableName } from "@/lib/constants/storage.constants";
+import {
+	SnippetColumns,
+	SnippetTableName,
+} from "@/lib/constants/storage.constants";
 import {
 	emptyTrash,
 	getAllSnippets,
@@ -24,7 +27,7 @@ export const supabaseAdapter: SnippetStorage = {
 	getPublicBySlug: async (slug) => {
 		const { data } = await supabase
 			.from(SnippetTableName)
-			.select()
+			.select(SnippetColumns)
 			.match({ is_public: true, public_slug: slug })
 			.maybeSingle();
 

--- a/app/lib/storage/server/sqlStorage.ts
+++ b/app/lib/storage/server/sqlStorage.ts
@@ -1,6 +1,7 @@
 import { SnippetState } from "@/lib/constants/core";
 import {
 	SnippetTableName,
+	SnippetVersionSummaryColumns,
 	SqlDialect,
 } from "@/lib/constants/storage.constants";
 import { SnippetVersionTableName } from "@/lib/constants/storage.constants";
@@ -37,9 +38,10 @@ const rowToSnippet = (row: Record<string, unknown>): Snippet =>
 		user_id: row.user_id as UUID,
 	}) satisfies Snippet;
 
-const rowToVersion = (row: Record<string, unknown>): SnippetVersion =>
+const rowToVersionSummary = (
+	row: Record<string, unknown>
+): SnippetVersionSummary =>
 	({
-		content: String(row.content ?? ""),
 		created_at: String(row.created_at ?? ""),
 		language: String(row.language ?? ""),
 		name: String(row.name ?? ""),
@@ -48,6 +50,12 @@ const rowToVersion = (row: Record<string, unknown>): SnippetVersion =>
 		user_id: (row.user_id as UUID) ?? null,
 		version_id: row.version_id as UUID,
 		version_number: Number(row.version_number ?? 0),
+	}) satisfies SnippetVersionSummary;
+
+const rowToVersion = (row: Record<string, unknown>): SnippetVersion =>
+	({
+		...rowToVersionSummary(row),
+		content: String(row.content ?? ""),
 	}) satisfies SnippetVersion;
 
 export const createSqlSnippetStorage = (driver: SqlDriver): SnippetStorage => {
@@ -118,11 +126,11 @@ export const createSqlSnippetStorage = (driver: SqlDriver): SnippetStorage => {
 			await ensureSchema();
 
 			const { rows } = await driver.query(
-				`SELECT * FROM ${SnippetVersionTableName} WHERE snippet_id = ? ORDER BY version_number DESC LIMIT 5`,
+				`SELECT ${SnippetVersionSummaryColumns} FROM ${SnippetVersionTableName} WHERE snippet_id = ? ORDER BY version_number DESC LIMIT 5`,
 				[snippetId]
 			);
 
-			return rows.map(rowToVersion);
+			return rows.map(rowToVersionSummary);
 		},
 
 		list: (userId) =>

--- a/app/lib/storage/snippets.ts
+++ b/app/lib/storage/snippets.ts
@@ -14,30 +14,41 @@ import { getUserIdBySession } from "@/lib/supabase/queries";
 // import path. The active backend (set globally by an admin) decides whether an
 // op runs in the client (Supabase) or via the server.
 
-const backendCache: { value: StorageBackendType | null } = { value: null };
+// Memoizes the in-flight request, not just its result: a save fires several ops
+// at once on first load, and caching only the value let each of them start its
+// own /active fetch before the first one resolved.
+const backendCache: { request: Promise<StorageBackendType> | null } = {
+	request: null,
+};
 
-const getActiveBackend = async (): Promise<StorageBackendType> => {
-	if (backendCache.value) {
-		return backendCache.value;
-	}
-
+const fetchActiveBackend = async (): Promise<StorageBackendType> => {
 	const response = await fetch(`${StorageApiBasePath}/active`).catch(
 		() => null
 	);
 
-	if (response?.ok) {
-		const data = (await response.json()) as { backend: StorageBackendType };
+	if (!response?.ok) {
+		backendCache.request = null;
 
-		backendCache.value = data.backend;
+		return DefaultStorageBackend;
 	}
 
-	return backendCache.value ?? DefaultStorageBackend;
+	const data = (await response.json()) as { backend: StorageBackendType };
+
+	return data.backend;
+};
+
+const getActiveBackend = async (): Promise<StorageBackendType> => {
+	if (!backendCache.request) {
+		backendCache.request = fetchActiveBackend();
+	}
+
+	return backendCache.request;
 };
 
 // Clears the memoized backend so a just-saved config takes effect without a
 // reload (other sessions pick it up on their next load).
 export const resetActiveBackendCache = (): void => {
-	backendCache.value = null;
+	backendCache.request = null;
 };
 
 const getStorage = async (): Promise<SnippetStorage> => {
@@ -185,7 +196,8 @@ export const saveSnippetVersion = async (
 
 export const getSnippetVersions = async (
 	snippetId: UUID
-): Promise<SnippetVersion[]> => (await getStorage()).getVersions(snippetId);
+): Promise<SnippetVersionSummary[]> =>
+	(await getStorage()).getVersions(snippetId);
 
 export const getSnippetVersion = async (
 	versionId: UUID

--- a/app/lib/supabase/queries.ts
+++ b/app/lib/supabase/queries.ts
@@ -9,6 +9,11 @@ import {
 	MfaFriendlyName,
 } from "@/lib/constants/mfa";
 import { AppRole, RoleClaimKey, RolesTableName } from "@/lib/constants/roles";
+import {
+	CreateSnippetVersionFunction,
+	SnippetColumns,
+	SnippetVersionSummaryColumns,
+} from "@/lib/constants/storage.constants";
 import { HttpStatusCode } from "@/lib/constants/ui.constants";
 import { AuthError, UserAttributes, UserResponse } from "@supabase/supabase-js";
 
@@ -37,16 +42,29 @@ export const getUserDataFromSession = async (): Promise<Session> => {
 	return session as Session;
 };
 
-export const getUserIdBySession = async (): Promise<string | null> => {
-	const session = await getUserDataFromSession();
+// The storage facade resolves the user id, then every query it delegates to
+// resolved it again — up to three lookups per save, each of which can hit the
+// network when the local session is missing. Resolve once and let Supabase tell
+// us when the answer stops being valid.
+const sessionUserIdCache: { value: string | null } = { value: null };
 
-	if (session) {
-		return session?.user?.id;
+supabase.auth.onAuthStateChange(() => {
+	sessionUserIdCache.value = null;
+});
+
+export const getUserIdBySession = async (): Promise<string | null> => {
+	if (sessionUserIdCache.value) {
+		return sessionUserIdCache.value;
 	}
 
-	const userFromServer = await getUserDataFromServer();
+	const session = await getUserDataFromSession();
+	const userFromServer = session ? null : await getUserDataFromServer();
 
-	return userFromServer?.id ?? null;
+	sessionUserIdCache.value = session
+		? (session?.user?.id ?? null)
+		: (userFromServer?.id ?? null);
+
+	return sessionUserIdCache.value;
 };
 
 export const getUserEmailBySession = async (): Promise<
@@ -95,7 +113,7 @@ export const getAllSnippets = async (): Promise<Snippet[]> => {
 		if (userId) {
 			const { data } = await supabase
 				.from("snippet")
-				.select()
+				.select(SnippetColumns)
 				.order("updated_at", { ascending: false })
 				.match({ user_id: userId })
 				.neq("state", SnippetState.Inactive);
@@ -116,7 +134,7 @@ export const getSnippetsByState = async (
 		if (userId) {
 			const { data } = await supabase
 				.from("snippet")
-				.select()
+				.select(SnippetColumns)
 				.order("updated_at", { ascending: false })
 				.match({ user_id: userId, state });
 
@@ -134,7 +152,7 @@ export const getUncategorizedSnippets = async (): Promise<Snippet[]> => {
 		if (userId) {
 			const { data } = await supabase
 				.from("snippet")
-				.select()
+				.select(SnippetColumns)
 				.order("updated_at", { ascending: false })
 				.match({ user_id: userId })
 				.neq("state", SnippetState.Inactive)
@@ -156,7 +174,7 @@ export const getSnippetsByFolder = async (
 		if (userId) {
 			const { data } = await supabase
 				.from("snippet")
-				.select()
+				.select(SnippetColumns)
 				.order("updated_at", { ascending: false })
 				.match({ user_id: userId, folder })
 				.neq("state", SnippetState.Inactive);
@@ -175,7 +193,7 @@ export const getSnippetsByTag = async (tag: string): Promise<Snippet[]> => {
 		if (userId) {
 			const { data } = await supabase
 				.from("snippet")
-				.select()
+				.select(SnippetColumns)
 				.order("updated_at", { ascending: false })
 				.match({ user_id: userId })
 				.neq("state", SnippetState.Inactive)
@@ -203,7 +221,7 @@ export const searchSnippets = async (query: string): Promise<Snippet[]> => {
 
 			const { data } = await supabase
 				.from("snippet")
-				.select()
+				.select(SnippetColumns)
 				.order("updated_at", { ascending: false })
 				.match({ user_id: userId })
 				.neq("state", SnippetState.Inactive)
@@ -338,44 +356,20 @@ export const setNewSnippet = async (): Promise<Snippet | null> => {
 
 /* ─── Snippet Versioning ─── */
 
+// One statement: the database picks the next version_number, checks ownership of
+// the parent snippet, and inserts. Replaces a parent lookup, a max() lookup and
+// an insert — and closes the race where two saves read the same max.
 export const saveSnippetVersion = async (
 	snippetId: UUID,
 	currentSnippet: CurrentSnippet
 ): Promise<void> => {
 	if (supabase) {
-		const userId = await getUserIdBySession();
-
-		if (!userId) {
-			failQuery("Not authenticated");
-		}
-
-		const { data: parent } = await supabase
-			.from("snippet")
-			.select("snippet_id")
-			.match({ snippet_id: snippetId, user_id: userId })
-			.maybeSingle();
-
-		if (!parent) {
-			failQuery("Snippet not found");
-		}
-
-		const { data: latestVersion } = await supabase
-			.from("snippet_version")
-			.select("version_number")
-			.eq("snippet_id", snippetId)
-			.order("version_number", { ascending: false })
-			.limit(1)
-			.single();
-
-		const nextVersion = (latestVersion?.version_number ?? 0) + 1;
-
-		const { error } = await supabase.from("snippet_version").insert({
-			snippet_id: snippetId,
-			content: currentSnippet.snippet,
-			language: currentSnippet.language,
-			name: currentSnippet.name,
-			tags: currentSnippet.tags ?? null,
-			version_number: nextVersion,
+		const { error } = await supabase.rpc(CreateSnippetVersionFunction, {
+			p_content: currentSnippet.snippet,
+			p_language: currentSnippet.language,
+			p_name: currentSnippet.name,
+			p_snippet_id: snippetId,
+			p_tags: currentSnippet.tags ?? null,
 		});
 
 		if (error) {
@@ -386,16 +380,16 @@ export const saveSnippetVersion = async (
 
 export const getSnippetVersions = async (
 	snippetId: UUID
-): Promise<SnippetVersion[]> => {
+): Promise<SnippetVersionSummary[]> => {
 	if (supabase) {
 		const { data } = await supabase
 			.from("snippet_version")
-			.select()
+			.select(SnippetVersionSummaryColumns)
 			.eq("snippet_id", snippetId)
 			.order("version_number", { ascending: false })
 			.limit(5);
 
-		return (data ?? []) as SnippetVersion[];
+		return (data ?? []) as SnippetVersionSummary[];
 	}
 
 	return [];
@@ -407,7 +401,7 @@ export const getSnippetVersion = async (
 	if (supabase) {
 		const { data } = await supabase
 			.from("snippet_version")
-			.select()
+			.select(`${SnippetVersionSummaryColumns}, content`)
 			.eq("version_id", versionId)
 			.single();
 

--- a/docs/snippets-performance.md
+++ b/docs/snippets-performance.md
@@ -213,7 +213,9 @@ export const getUserSnippets = async () => {
 
 	const { data } = await supabase
 		.from("snippet")
-		.select("snippet_id, name, updated_at, state, tags, folder, is_public, public_slug, language")
+		.select(
+			"snippet_id, name, updated_at, state, tags, folder, is_public, public_slug, language"
+		)
 		.eq("user_id", userId)
 		.neq("state", SnippetState.Inactive)
 		.order("updated_at", { ascending: false });

--- a/supabase/migrations/20260809200000_create_snippet_version_rpc.sql
+++ b/supabase/migrations/20260809200000_create_snippet_version_rpc.sql
@@ -1,0 +1,72 @@
+-- Make snippet version creation atomic.
+--
+-- The client used to do: verify parent snippet -> select max(version_number) ->
+-- insert max+1. Three round trips, and two concurrent saves could both read the
+-- same max and collide on idx_snippet_version_unique. This does it in one
+-- statement inside the database.
+
+-- Already created by migration 001; restated so this file is self-sufficient
+-- when applied to a fresh database. It is the final guard against a duplicate
+-- version_number even with the function in place.
+create unique index if not exists idx_snippet_version_unique
+on public.snippet_version (snippet_id, version_number);
+
+create or replace function public.create_snippet_version(
+	p_snippet_id uuid,
+	p_content text,
+	p_language varchar,
+	p_name varchar,
+	p_tags text
+)
+returns public.snippet_version
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+	caller_id uuid := auth.uid();
+	created_version public.snippet_version;
+begin
+	if caller_id is null then
+		raise exception 'Not authenticated';
+	end if;
+
+	-- The foreign key only proves the snippet exists, not that the caller owns
+	-- it. Keep the ownership check the client used to make.
+	if not exists (
+		select 1
+		from public.snippet
+		where snippet_id = p_snippet_id
+			and user_id = caller_id
+	) then
+		raise exception 'Snippet not found';
+	end if;
+
+	insert into public.snippet_version (
+		snippet_id,
+		user_id,
+		content,
+		language,
+		name,
+		tags,
+		version_number
+	)
+	select
+		p_snippet_id,
+		caller_id,
+		p_content,
+		p_language,
+		p_name,
+		p_tags,
+		coalesce(max(version_number), 0) + 1
+	from public.snippet_version
+	where snippet_id = p_snippet_id
+	returning * into created_version;
+
+	return created_version;
+end;
+$$;
+
+grant execute on function public.create_snippet_version(
+	uuid, text, varchar, varchar, text
+) to authenticated;

--- a/types/snippets.d.ts
+++ b/types/snippets.d.ts
@@ -50,6 +50,10 @@ declare global {
 		created_at: string;
 	}
 
+	// A version row without its `content` body. Version lists render metadata
+	// only, so the body is fetched for the one version the user restores.
+	type SnippetVersionSummary = Omit<SnippetVersion, "content">;
+
 	interface CurrentSnippet extends Snippet {
 		extension: LanguageSupport;
 	}

--- a/types/storage.d.ts
+++ b/types/storage.d.ts
@@ -47,7 +47,7 @@ declare global {
 		emptyTrash(userId: UUID): Promise<void>;
 		getPublicBySlug(slug: string): Promise<Snippet | null>;
 		getVersion(versionId: UUID): Promise<SnippetVersion | null>;
-		getVersions(snippetId: UUID): Promise<SnippetVersion[]>;
+		getVersions(snippetId: UUID): Promise<SnippetVersionSummary[]>;
 		list(userId: UUID): Promise<Snippet[]>;
 		listByFolder(userId: UUID, folder: string): Promise<Snippet[]>;
 		listByState(userId: UUID, state: SnippetStateEnum): Promise<Snippet[]>;


### PR DESCRIPTION
#### Why are you creating this PR? What value is added?

Performance improvements to the snippet storage layer:

- **Explicit column selection**: replaces `select *` with named columns across all snippet queries, skipping the `fts` tsvector column which roughly doubles payload size and is never read by the client.
- **Lightweight version lists**: version history now fetches metadata only (`SnippetVersionSummary`); the full body is fetched on demand when the user restores a version.
- **Session user ID caching**: avoids redundant auth lookups per save operation (up to 3 per save).
- **Backend fetch deduplication**: memoizes the in-flight `/active` fetch request so concurrent saves share one call instead of each starting its own.
- **Atomic version creation**: moves version insert into a Postgres RPC function, eliminating the parent lookup + max() lookup + insert race condition.