### PR TITLE
feat(editor): mobile viewport fixes and preview toggle

### DIFF
--- a/app/components/Aside/aside.module.css
+++ b/app/components/Aside/aside.module.css
@@ -501,6 +501,8 @@
 }
 
 @media (width < 1140px) {
+	/* Bottom bar clears the home indicator / gesture area so its own buttons are
+	   not the ones sitting under the phone chrome. */
 	.mobileMenuContainer {
 		width: 100%;
 		position: fixed;
@@ -508,6 +510,7 @@
 		bottom: 0;
 		z-index: 9;
 		height: 50px;
+		padding-bottom: env(safe-area-inset-bottom, 0);
 		max-width: 100%;
 		left: 0;
 		background: var(--bg-color-dark);
@@ -524,13 +527,15 @@
 		animation: backdrop-fade-in 0.2s ease;
 	}
 
-	/* Sidebar becomes a left slide-in drawer. */
+	/* Sidebar becomes a left slide-in drawer. dvh, not vh: vh is the *large*
+	   viewport on mobile, so the bottom of the drawer — the user card and its
+	   settings menu — ends up behind the browser's own URL/toolbar. */
 	.container {
 		position: fixed;
 		left: 0;
 		top: 0;
 		z-index: 8;
-		height: calc(100vh - 50px);
+		height: calc(100dvh - 50px - env(safe-area-inset-bottom, 0px));
 		width: min(82vw, 17rem);
 		max-width: none;
 		box-shadow: var(--card-shadow);

--- a/app/components/CodeEditor/CodeEditor.tsx
+++ b/app/components/CodeEditor/CodeEditor.tsx
@@ -97,10 +97,14 @@ const CodeEditor = ({
 	const isFocusMode = useViewPortStore((state) => state.isFocusMode);
 	const setFocusMode = useViewPortStore((state) => state.setFocusMode);
 	const theme = useUserStore((state) => state.theme) as ThemeName;
-	const { menuType } = codeEditorStates ?? {};
+	const { menuType, touched } = codeEditorStates ?? {};
 	const isTrashActive = menuType === "trash";
 	const [mobileChatTab, setMobileChatTab] = useState<AiPaneTab>(AiPaneTab.Chat);
-	const [isPreviewVisible, setIsPreviewVisible] = useState(true);
+	// null means "follow the viewport": on mobile and tablet the editor owns the
+	// full height and the preview is opt-in, on desktop the split is the default.
+	// A toggle pins an explicit choice for the session.
+	const [previewOverride, setPreviewOverride] = useState<boolean | null>(null);
+	const isPreviewVisible = previewOverride ?? !isMobile;
 	const editorContentRef = useRef<HTMLDivElement>(null);
 	const detailsAnchorRef = useRef<HTMLButtonElement>(null);
 	const editorViewRef = useRef<EditorView | null>(null);
@@ -140,7 +144,7 @@ const CodeEditor = ({
 		onTouched,
 	});
 
-	useKeyboardSave(saveHandler, isTrashActive);
+	useKeyboardSave(saveHandler, isTrashActive || !touched);
 
 	const inlineCompletionExtension = useMemo(
 		() =>
@@ -187,6 +191,10 @@ const CodeEditor = ({
 	const hasRightPane = showPreview || showChatPane;
 	const showPreviewToggle = hasPreviewPanel && !isChatMode;
 	const canToggleFocusMode = isMarkdownLanguage && !isTrashActive;
+
+	const togglePreviewHandler = (): void => {
+		setPreviewOverride(!isPreviewVisible);
+	};
 
 	// Long-form prose fixes: wrap instead of horizontal-scrolling, and let the
 	// browser spellcheck markdown content the way it would a text field.
@@ -294,10 +302,13 @@ const CodeEditor = ({
 								<div className={styles.mobileActions}>
 									<CodeEditorActions
 										currentSnippet={currentSnippet}
+										isPreviewVisible={isPreviewVisible}
 										isPublic={currentSnippet.is_public ?? false}
+										onTogglePreview={togglePreviewHandler}
 										onTogglePublic={togglePublicHandler}
 										onToggleHistory={() => setShowHistory(!showHistory)}
 										showHistory={showHistory}
+										showPreviewToggle={showPreviewToggle}
 										hasVersions={versionCount > 0}
 									/>
 								</div>
@@ -351,7 +362,7 @@ const CodeEditor = ({
 							showPreviewToggle={showPreviewToggle}
 							snippetName={currentSnippet.name ?? ""}
 							onExit={() => setFocusMode(false)}
-							onTogglePreview={() => setIsPreviewVisible(!isPreviewVisible)}
+							onTogglePreview={togglePreviewHandler}
 						/>
 					)}
 
@@ -404,7 +415,7 @@ const CodeEditor = ({
 									isFocusMode={isFocusMode}
 									isPreviewVisible={isPreviewVisible}
 									onToggleFocusMode={toggleFocusModeHandler}
-									onTogglePreview={() => setIsPreviewVisible(!isPreviewVisible)}
+									onTogglePreview={togglePreviewHandler}
 									onUploadMarkdown={onUploadMarkdown}
 									showFormattingActions={isMarkdownLanguage}
 									showPreviewToggle={showPreviewToggle}

--- a/app/components/CodeEditor/CodeEditorActions.tsx
+++ b/app/components/CodeEditor/CodeEditorActions.tsx
@@ -9,6 +9,8 @@ import useSnippetActions from "@/components/CodeEditor/hooks/useSnippetActions";
 import Camera from "@/components/ui/icons/Camera";
 import Clock from "@/components/ui/icons/Clock";
 import Copy from "@/components/ui/icons/Copy";
+import EyeClosed from "@/components/ui/icons/EyeClosed";
+import EyeOpen from "@/components/ui/icons/EyeOpen";
 import Globe from "@/components/ui/icons/Globe";
 import Share from "@/components/ui/icons/Share";
 import ScreenshotModal from "@/components/ScreenshotModal/ScreenshotModal";
@@ -18,10 +20,13 @@ import styles from "./codeEditorActions.module.css";
 
 type CodeEditorActionsProps = {
 	currentSnippet: CurrentSnippet;
+	isPreviewVisible?: boolean;
 	isPublic: boolean;
+	onTogglePreview?: () => void;
 	onTogglePublic: () => void;
 	onToggleHistory?: () => void;
 	showHistory?: boolean;
+	showPreviewToggle?: boolean;
 	hasVersions?: boolean;
 };
 
@@ -30,10 +35,13 @@ type CodeEditorActionsProps = {
 // equivalent is CodeEditorActionsMenu.
 const CodeEditorActions = ({
 	currentSnippet,
+	isPreviewVisible = false,
 	isPublic,
+	onTogglePreview,
 	onTogglePublic,
 	onToggleHistory,
 	showHistory = false,
+	showPreviewToggle = false,
 	hasVersions = false,
 }: CodeEditorActionsProps): ReactElement => {
 	const {
@@ -96,6 +104,24 @@ const CodeEditorActions = ({
 						{isPublic ? "Make private" : "Make public"}
 					</span>
 				</button>
+				{showPreviewToggle && (
+					<button
+						className={`${styles.actionButton} ${isPreviewVisible ? styles.actionButtonActive : ""}`}
+						type="button"
+						aria-label={isPreviewVisible ? "Hide preview" : "Show preview"}
+						aria-pressed={isPreviewVisible}
+						onClick={onTogglePreview}
+					>
+						{isPreviewVisible ? (
+							<EyeOpen width={24} height={24} />
+						) : (
+							<EyeClosed width={24} height={24} />
+						)}
+						<span className={styles.tooltip}>
+							{isPreviewVisible ? "Hide preview" : "Show preview"}
+						</span>
+					</button>
+				)}
 			</div>
 
 			{screenshotModalOpen && (

--- a/app/components/CodeEditor/CodeEditorHeader.tsx
+++ b/app/components/CodeEditor/CodeEditorHeader.tsx
@@ -168,7 +168,7 @@ const CodeEditorHeader = ({
 					className={`${styles.saveButton} ${touched ? styles.touched : ""}`}
 					variant="secondary"
 					shape="pill"
-					disabled={isSaving}
+					disabled={isSaving || !touched}
 					aria-label="Save snippet"
 					onClick={onSave}
 				>

--- a/app/components/CodeEditor/codeEditor.module.css
+++ b/app/components/CodeEditor/codeEditor.module.css
@@ -239,7 +239,7 @@
 @media (width < 1140px) {
 	.mobileActions {
 		position: fixed;
-		bottom: 50px;
+		bottom: calc(50px + env(safe-area-inset-bottom, 0px));
 		left: 0;
 		width: 100%;
 		display: flex;
@@ -269,9 +269,10 @@
 		opacity 0.2s ease;
 }
 
+/* Disabled means either nothing to save or a save in flight. */
 .saveButton:disabled {
 	opacity: 0.6;
-	cursor: progress;
+	cursor: not-allowed;
 }
 
 .icon {
@@ -327,6 +328,11 @@
 	background: var(--green-color);
 	color: var(--bg-color-dark);
 	filter: brightness(1.05);
+}
+
+/* Only the in-flight save is a wait — untouched keeps not-allowed from above. */
+.saveButton.touched:disabled {
+	cursor: progress;
 }
 
 .splitView {
@@ -580,6 +586,7 @@
 @media (width < 1140px) {
 	.codeEditorContainer {
 		width: 100%;
+		height: calc(100dvh - 1.5625rem);
 	}
 }
 

--- a/app/components/CodeEditor/editorHeight.ts
+++ b/app/components/CodeEditor/editorHeight.ts
@@ -10,6 +10,11 @@ type EditorHeightParams = {
 // distraction-free writing is active.
 const focusModeBarHeight = "3rem";
 
+// Mobile and tablet measure against dvh, not vh: vh is the large viewport, so a
+// vh-sized pane runs underneath the browser's URL/toolbar. The inset also keeps
+// the pane clear of the home-indicator area the bottom bars pad for.
+const mobileSafeArea = "env(safe-area-inset-bottom, 0px)";
+
 export const calculateEditorHeight = ({
 	hasMarkdownToolbar,
 	hasRightPane,
@@ -18,11 +23,13 @@ export const calculateEditorHeight = ({
 	isTrashActive,
 }: EditorHeightParams): string => {
 	if (isFocusMode) {
-		return `calc(100vh - ${focusModeBarHeight})`;
+		return `calc(100dvh - ${focusModeBarHeight})`;
 	}
 
 	if (isMobile && !isTrashActive) {
-		return hasRightPane ? "calc(50vh - 3.4rem)" : "calc(100vh - 6.5rem)";
+		return hasRightPane
+			? `calc(50dvh - 3.4rem - (${mobileSafeArea} / 2))`
+			: `calc(100dvh - 6.5rem - ${mobileSafeArea})`;
 	}
 
 	if (isTrashActive && !isMobile) {
@@ -30,7 +37,7 @@ export const calculateEditorHeight = ({
 	}
 
 	if (isTrashActive && isMobile) {
-		return "calc(100vh - 3.2rem)";
+		return `calc(100dvh - 3.2rem - ${mobileSafeArea})`;
 	}
 
 	if (hasMarkdownToolbar) {
@@ -45,11 +52,11 @@ export const calculatePreviewHeight = (
 	isFocusMode: boolean = false
 ): string => {
 	if (isFocusMode) {
-		return `calc(100vh - ${focusModeBarHeight})`;
+		return `calc(100dvh - ${focusModeBarHeight})`;
 	}
 
 	if (isMobile) {
-		return "calc(50vh - 3.4rem)";
+		return `calc(50dvh - 3.4rem - (${mobileSafeArea} / 2))`;
 	}
 
 	return "calc(100vh - 3.25rem)";
@@ -58,4 +65,4 @@ export const calculatePreviewHeight = (
 // Full-height single pane used by the mobile AI Code|Chat tab switcher: total
 // viewport minus the merged header row + tab bar (top) and the editor action bar +
 // nav bar (bottom).
-export const chatTabPaneHeight = "calc(100vh - 12.3rem)";
+export const chatTabPaneHeight = `calc(100dvh - 12.3rem - ${mobileSafeArea})`;

--- a/app/components/SnippetList/snippetlist.module.css
+++ b/app/components/SnippetList/snippetlist.module.css
@@ -412,13 +412,14 @@
 }
 
 @media (width < 1140px) {
-	/* Snippet list becomes a left slide-in drawer over the editor. */
+	/* Snippet list becomes a left slide-in drawer over the editor. dvh keeps its
+	   bottom above the mobile browser bar, same as the Aside drawer. */
 	.snippetsListContainer {
 		position: fixed;
 		top: 0;
 		left: 0;
 		z-index: 8;
-		height: calc(100vh - 50px);
+		height: calc(100dvh - 50px - env(safe-area-inset-bottom, 0px));
 		width: min(88vw, 22rem);
 		max-width: none;
 		box-shadow: var(--card-shadow);
@@ -430,7 +431,7 @@
 	}
 
 	.snippetsList {
-		height: calc(100vh - 50px - 3.2rem);
+		height: calc(100dvh - 50px - 3.2rem - env(safe-area-inset-bottom, 0px));
 	}
 
 	.mobileListOpen {


### PR DESCRIPTION
#### Github Issue

relates to https://github.com/vianch/snippets/issues/

#### Why are you creating this PR? What value is added?

Fixes mobile layout issues where editor panes rendered behind browser chrome by switching from `vh` to `dvh` units and adding `safe-area-inset-bottom` padding. Adds a preview toggle button on desktop and defaults to code-only view on mobile/tablet. Disables the save button when the snippet is untouched.

#### Include screenshots below (if appropriate)