### PR TITLE
feat(snip-pet): overhaul sprite animation and fix account modal save flow

### DIFF
--- a/app/components/AccountModal/AccountModal.tsx
+++ b/app/components/AccountModal/AccountModal.tsx
@@ -1,5 +1,6 @@
 import {
 	ReactElement,
+	useRef,
 	useState,
 	useEffect,
 	FormEvent,
@@ -106,6 +107,7 @@ const AccountModal = (): ReactElement | null => {
 	const [aiModels, setAiModels] = useState<string[]>([]);
 	const [originalAiUrl, setOriginalAiUrl] = useState<string>("");
 	const [modelsLoading, setModelsLoading] = useState(false);
+	const closeTimeoutRef = useRef<number>(0);
 
 	const handleInputChange = (
 		event: ChangeEvent<HTMLInputElement>,
@@ -353,38 +355,58 @@ const AccountModal = (): ReactElement | null => {
 			const updatePasswordError = await updatePassword();
 			const updateMetadataError = await updateUserMetadata();
 
-			if (!updatePasswordError && !updateMetadataError) {
-				setMessage({
-					text: "Profile updated successfully!",
-					type: FormMessageTypes.Success,
-				});
+			resetStateData();
 
+			// The metadata write already happened above, so the store has to be
+			// synced even when the password step failed — otherwise a password
+			// error leaves the app showing stale values that are saved server-side.
+			if (!updateMetadataError) {
 				updateUserStore();
-
-				if (
-					userData.aiProvider === AiProviderId.Ollama &&
-					userData.aiUrl !== originalAiUrl
-				) {
-					await refreshModels(AiProviderId.Ollama);
-					setOriginalAiUrl(userData.aiUrl ?? "");
-				}
-
-				setTimeout(() => {
-					close();
-				}, modalCloseDelay);
 			}
+
+			if (updatePasswordError || updateMetadataError) {
+				setLoading(false);
+
+				return;
+			}
+
+			setMessage({
+				text: "Profile updated successfully!",
+				type: FormMessageTypes.Success,
+			});
+
+			if (
+				userData.aiProvider === AiProviderId.Ollama &&
+				userData.aiUrl !== originalAiUrl
+			) {
+				await refreshModels(AiProviderId.Ollama);
+				setOriginalAiUrl(userData.aiUrl ?? "");
+			}
+
+			// Stay in the loading state through the success message: the modal is
+			// still on screen for modalCloseDelay, and re-enabling the CTA in that
+			// window lets a second click fire a duplicate update.
+			closeTimeoutRef.current = window.setTimeout(() => {
+				closeTimeoutRef.current = 0;
+				setLoading(false);
+				close();
+			}, modalCloseDelay);
 		} catch (_catchError) {
 			setMessage({
 				text: "An error occurred while updating profile",
 				type: FormMessageTypes.Error,
 			});
+			resetStateData();
+			setLoading(false);
 		}
-
-		resetStateData();
-		setLoading(false);
 	};
 
 	const handleClose = (): void => {
+		// Escape or the backdrop can beat the auto-close timer. Drop it, or it
+		// fires later and slams a freshly reopened modal shut.
+		window.clearTimeout(closeTimeoutRef.current);
+		closeTimeoutRef.current = 0;
+		setLoading(false);
 		resetMessages();
 		resetStateData();
 
@@ -710,6 +732,10 @@ const AccountModal = (): ReactElement | null => {
 					<Input
 						type="password"
 						name="newPassword"
+						// Without this the browser autofills the saved account password
+						// here on open, and the next save attempts a real password
+						// change the user never asked for.
+						autoComplete="new-password"
 						placeholder="New Password"
 						fat
 						value={userData.newPassword}
@@ -730,6 +756,7 @@ const AccountModal = (): ReactElement | null => {
 						className={styles.input}
 						type="password"
 						name="confirmPassword"
+						autoComplete="new-password"
 						placeholder="Confirm New Password"
 						fat
 						value={userData.confirmPassword}
@@ -883,6 +910,9 @@ const AccountModal = (): ReactElement | null => {
 					<Input
 						type="password"
 						name="aiApiKey"
+						// A type=password field is an autofill magnet even when it holds
+						// an API key rather than a credential.
+						autoComplete="off"
 						placeholder={
 							userData.aiProvider === AiProviderId.Claude
 								? "sk-ant-..."

--- a/app/components/SnipPet/SnipPet.tsx
+++ b/app/components/SnipPet/SnipPet.tsx
@@ -11,6 +11,7 @@ import {
 
 /* Constants */
 import {
+	PetActivityEvents,
 	PetAfraidFrame,
 	PetAfraidLiftThresholdPx,
 	PetClickMovementThresholdPx,
@@ -30,14 +31,14 @@ import {
 	PetHappyFrame,
 	PetHardImpactRatio,
 	PetIdleFrame,
-	PetIdlePauseMs,
+	PetIntroWalkMs,
 	PetLandingDurationMs,
 	PetLandingMessages,
 	PetLegFrameIntervalMs,
+	PetMaxIdleBeforeWalkMs,
 	PetMaxImpactSpeedPxPerSecond,
-	PetMaxWalkBeforeIdleMs,
 	PetMessages,
-	PetMinWalkBeforeIdleMs,
+	PetMinIdleBeforeWalkMs,
 	PetModes,
 	PetPixelSizePx,
 	PetReactionDurationMs,
@@ -56,9 +57,11 @@ import {
 	PetEvent,
 	PetIdleChatterMaxMs,
 	PetIdleChatterMinMs,
+	PetIdleHoldMaxMs,
+	PetIdleHoldMinMs,
 	PetSpriteFrameHeightPx,
-	PetSpriteFrameIntervalMs,
 	PetSpriteFrameWidthPx,
+	PetSpriteRow,
 } from "@/lib/constants/pets.constants";
 import {
 	petDesignCookieName,
@@ -80,6 +83,7 @@ import {
 	isValidPetDesign,
 	randomIntBetween,
 	spriteFrameCountForRow,
+	spriteFrameIntervalForRow,
 	spriteRowForMode,
 } from "@/utils/pet.utils";
 
@@ -94,6 +98,7 @@ const SnipPet = (): ReactElement => {
 	const [mode, setMode] = useState<PetMode>(PetModes.Walking);
 	const [legFrameIndex, setLegFrameIndex] = useState<number>(0);
 	const [message, setMessage] = useState<string | null>(null);
+	const [startPositionPx, setStartPositionPx] = useState<number>(0);
 
 	const petEnabled = useUserStore((store) => store.petEnabled);
 	const petDesignId = useUserStore((store) => store.petDesign);
@@ -109,8 +114,10 @@ const SnipPet = (): ReactElement => {
 	const legAccumulatorRef = useRef<number>(0);
 	const spriteAccumulatorRef = useRef<number>(0);
 	const spriteFrameRef = useRef<number>(0);
-	const walkUntilRef = useRef<number>(0);
-	const idleUntilRef = useRef<number>(0);
+	const spriteRowRef = useRef<PetSpriteRow>(PetSpriteRow.Idle);
+	const idleHoldRef = useRef<number>(PetIdleHoldMinMs);
+	const walkAtRef = useRef<number>(0);
+	const introUntilRef = useRef<number>(0);
 	const lastTimestampRef = useRef<number | null>(null);
 	const animationFrameRef = useRef<number>(0);
 	const isAnimatingRef = useRef<boolean>(false);
@@ -193,6 +200,20 @@ const SnipPet = (): ReactElement => {
 		setMode(nextMode);
 	};
 
+	// Stand still and start the boredom countdown over. Every path that ends a
+	// mood — a reaction finishing, a drop landing, a drag being released — comes
+	// through here, so the pet always returns to being motionless and only walks
+	// again once the app has been left alone for the whole stretch.
+	const settleAndArmWalk = (): void => {
+		// Clearing the intro here is what stops a cut-short arrival walk from
+		// expiring again under the next boredom walk.
+		introUntilRef.current = 0;
+		walkAtRef.current =
+			performance.now() +
+			randomIntBetween(PetMinIdleBeforeWalkMs, PetMaxIdleBeforeWalkMs);
+		updateMode(PetModes.Idle);
+	};
+
 	const renderPetTransform = (): void => {
 		const container = containerRef.current;
 
@@ -211,9 +232,11 @@ const SnipPet = (): ReactElement => {
 		// the sheets' own run-left row can't be trusted to face left.
 		container.style.setProperty("--pet-facing", String(facingRef.current));
 		container.style.setProperty("--pet-impact", String(impactRef.current));
-		container.style.transform = `translate3d(${Math.round(
-			positionRef.current
-		)}px, ${-Math.round(liftRef.current)}px, 0)`;
+		// Deliberately sub-pixel: rounding to whole pixels made the pet hold still
+		// for a frame and then jump a pixel, which is what read as chunky walking.
+		container.style.transform = `translate3d(${positionRef.current.toFixed(
+			2
+		)}px, ${(-liftRef.current).toFixed(2)}px, 0)`;
 	};
 
 	// Shared entry point for every scripted mood change: a click, an app event,
@@ -245,8 +268,7 @@ const SnipPet = (): ReactElement => {
 			setMessage(null);
 
 			if (!isPhysicsOwned) {
-				walkUntilRef.current = 0;
-				updateMode(PetModes.Walking);
+				settleAndArmWalk();
 			}
 		}, durationMs);
 	};
@@ -341,7 +363,7 @@ const SnipPet = (): ReactElement => {
 
 			if (wasClick) {
 				// playReaction refuses to interrupt a grab, so drop out of it first.
-				modeRef.current = PetModes.Walking;
+				modeRef.current = PetModes.Idle;
 				triggerClickReaction();
 
 				return;
@@ -357,8 +379,7 @@ const SnipPet = (): ReactElement => {
 			}
 
 			liftRef.current = 0;
-			walkUntilRef.current = 0;
-			updateMode(PetModes.Walking);
+			settleAndArmWalk();
 
 			if (!isAnimatingRef.current) {
 				renderPetTransform();
@@ -367,21 +388,6 @@ const SnipPet = (): ReactElement => {
 
 		window.addEventListener("pointermove", handleMove);
 		window.addEventListener("pointerup", handleUp);
-	};
-
-	const handlePointerEnter = (): void => {
-		if (modeRef.current === PetModes.Walking) {
-			idleUntilRef.current = 0;
-			walkUntilRef.current = 0;
-			updateMode(PetModes.Idle);
-		}
-	};
-
-	const handlePointerLeave = (): void => {
-		if (modeRef.current === PetModes.Idle && idleUntilRef.current === 0) {
-			walkUntilRef.current = 0;
-			updateMode(PetModes.Walking);
-		}
 	};
 
 	// Seed the store from the cookies the settings modal writes, so the pet the
@@ -405,13 +411,26 @@ const SnipPet = (): ReactElement => {
 			`(min-width: ${PetDesktopMinWidthPx}px) and (pointer: fine)`
 		);
 
-		const sync = (): void => setIsDesktop(query.matches);
+		// Seeded here rather than in the animation effect so the position is
+		// already right on the render that first mounts the pet — otherwise it
+		// paints one frame in the bottom-left before the loop moves it over.
+		const sync = (): void => {
+			const startX = Math.max(
+				PetEdgePaddingPx,
+				window.innerWidth - petWidthPx - PetEdgePaddingPx
+			);
+
+			positionRef.current = startX;
+			facingRef.current = PetFacings.Left;
+			setStartPositionPx(startX);
+			setIsDesktop(query.matches);
+		};
 
 		sync();
 		query.addEventListener("change", sync);
 
 		return () => query.removeEventListener("change", sync);
-	}, []);
+	}, [petWidthPx]);
 
 	// Tell the rest of the app the pet is really on screen, so the toast store
 	// knows to hand its messages over instead of rendering them itself.
@@ -453,6 +472,42 @@ const SnipPet = (): ReactElement => {
 		return () => window.clearTimeout(chatterTimeoutRef.current);
 	}, [isDesktop, petEnabled]);
 
+	// The pet is a boredom indicator: any sign of life in the page parks it and
+	// restarts the countdown, so it is only ever walking while the user isn't
+	// doing anything. Capture phase because scroll doesn't bubble, and passive
+	// because none of this ever calls preventDefault.
+	useEffect(() => {
+		if (!isDesktop || !petEnabled) {
+			return;
+		}
+
+		const handleActivity = (): void => {
+			if (modeRef.current === PetModes.Walking) {
+				settleAndArmWalk();
+
+				return;
+			}
+
+			walkAtRef.current =
+				performance.now() +
+				randomIntBetween(PetMinIdleBeforeWalkMs, PetMaxIdleBeforeWalkMs);
+		};
+
+		PetActivityEvents.forEach((eventName: string): void =>
+			document.addEventListener(eventName, handleActivity, {
+				capture: true,
+				passive: true,
+			})
+		);
+
+		return () =>
+			PetActivityEvents.forEach((eventName: string): void =>
+				document.removeEventListener(eventName, handleActivity, {
+					capture: true,
+				})
+			);
+	}, [isDesktop, petEnabled]);
+
 	useEffect(() => {
 		if (!isDesktop || !petEnabled) {
 			return;
@@ -472,6 +527,12 @@ const SnipPet = (): ReactElement => {
 
 		isAnimatingRef.current = true;
 
+		// The arrival stroll. Only armed if the pet is actually walking, so a
+		// design swap while it is standing still doesn't kick off a second one.
+		if (modeRef.current === PetModes.Walking) {
+			introUntilRef.current = performance.now() + PetIntroWalkMs;
+		}
+
 		const step = (timestamp: number): void => {
 			const previous = lastTimestampRef.current ?? timestamp;
 			const deltaMs = Math.min(timestamp - previous, 48);
@@ -481,11 +542,42 @@ const SnipPet = (): ReactElement => {
 
 			// Sprite rows animate in every mood, not just while walking, so the
 			// frame counter advances independently of the pixel pet's leg cycle.
+			const spriteRow = spriteRowForMode(modeRef.current);
+			const spriteFrameCount = spriteFrameCountForRow(design, spriteRow);
+
+			// A new mood is a new animation: start it on its own first frame at its
+			// own pace instead of inheriting the previous row's position mid-cycle.
+			if (spriteRow !== spriteRowRef.current) {
+				spriteRowRef.current = spriteRow;
+				spriteAccumulatorRef.current = 0;
+				spriteFrameRef.current = 0;
+			}
+
+			// Sitting on frame 0 of the idle row means eyes open: hold it for a few
+			// seconds so the pet blinks now and then instead of continuously.
+			const isHoldingIdleFrame =
+				spriteRow === PetSpriteRow.Idle &&
+				spriteFrameRef.current % spriteFrameCount === 0;
+			const spriteIntervalMs = isHoldingIdleFrame
+				? idleHoldRef.current
+				: spriteFrameIntervalForRow(spriteRow);
+
 			spriteAccumulatorRef.current += deltaMs;
 
-			if (spriteAccumulatorRef.current >= PetSpriteFrameIntervalMs) {
-				spriteAccumulatorRef.current = 0;
+			// Carry the remainder instead of zeroing it: dropping it stretched every
+			// frame out to the next whole rAF tick and let the cadence drift, which
+			// is the stutter in the walk cycle. Every interval is well above the
+			// 48ms delta cap, so one step per tick is always enough to catch up.
+			if (spriteAccumulatorRef.current >= spriteIntervalMs) {
+				spriteAccumulatorRef.current -= spriteIntervalMs;
 				spriteFrameRef.current += 1;
+
+				if (spriteFrameRef.current % spriteFrameCount === 0) {
+					idleHoldRef.current = randomIntBetween(
+						PetIdleHoldMinMs,
+						PetIdleHoldMaxMs
+					);
+				}
 			}
 
 			if (shakeEnergyRef.current > 0) {
@@ -496,15 +588,6 @@ const SnipPet = (): ReactElement => {
 			}
 
 			if (modeRef.current === PetModes.Walking) {
-				if (walkUntilRef.current === 0) {
-					const walkSpan = PetMaxWalkBeforeIdleMs - PetMinWalkBeforeIdleMs;
-
-					walkUntilRef.current =
-						timestamp +
-						PetMinWalkBeforeIdleMs +
-						(Math.floor(timestamp) % walkSpan);
-				}
-
 				positionRef.current +=
 					(PetWalkSpeedPxPerSecond * facingRef.current * deltaMs) / 1000;
 
@@ -516,22 +599,26 @@ const SnipPet = (): ReactElement => {
 					facingRef.current = PetFacings.Left;
 				}
 
-				legAccumulatorRef.current += deltaMs;
+				// Only the pixel pet swaps leg frames through React state; for a sprite
+				// design the row already animates, so re-rendering here would just
+				// stall the loop mid-frame for nothing.
+				if (!isSprite) {
+					legAccumulatorRef.current += deltaMs;
 
-				if (legAccumulatorRef.current >= PetLegFrameIntervalMs) {
-					legAccumulatorRef.current = 0;
-					setLegFrameIndex((previousIndex) => (previousIndex === 0 ? 1 : 0));
+					if (legAccumulatorRef.current >= PetLegFrameIntervalMs) {
+						legAccumulatorRef.current -= PetLegFrameIntervalMs;
+						setLegFrameIndex((previousIndex) => (previousIndex === 0 ? 1 : 0));
+					}
 				}
 
-				if (timestamp >= walkUntilRef.current) {
-					walkUntilRef.current = 0;
-					idleUntilRef.current = timestamp + PetIdlePauseMs;
-					updateMode(PetModes.Idle);
+				// The arrival stroll is the only walk on a timer; a boredom walk runs
+				// until the activity listener parks it.
+				if (introUntilRef.current !== 0 && timestamp >= introUntilRef.current) {
+					settleAndArmWalk();
 				}
 			} else if (modeRef.current === PetModes.Idle) {
-				if (idleUntilRef.current !== 0 && timestamp >= idleUntilRef.current) {
-					idleUntilRef.current = 0;
-					walkUntilRef.current = 0;
+				if (walkAtRef.current !== 0 && timestamp >= walkAtRef.current) {
+					walkAtRef.current = 0;
 					updateMode(PetModes.Walking);
 				}
 			} else if (modeRef.current === PetModes.Falling) {
@@ -564,9 +651,8 @@ const SnipPet = (): ReactElement => {
 				if (timestamp >= landingUntilRef.current) {
 					landingUntilRef.current = 0;
 					impactRef.current = 0;
-					walkUntilRef.current = 0;
 					setMessage(null);
-					updateMode(PetModes.Walking);
+					settleAndArmWalk();
 				}
 			} else if (
 				modeRef.current === PetModes.Grabbed ||
@@ -636,12 +722,11 @@ const SnipPet = (): ReactElement => {
 			aria-hidden="true"
 			className={styles.pet}
 			data-mode={mode}
+			data-sprite={String(isSprite)}
 			onPointerDown={handlePointerDown}
-			onPointerEnter={handlePointerEnter}
-			onPointerLeave={handlePointerLeave}
 			style={{
 				height: `${petHeightPx}px`,
-				transform: `translate3d(${PetEdgePaddingPx}px, 0, 0)`,
+				transform: `translate3d(${startPositionPx}px, 0, 0)`,
 				width: `${petWidthPx}px`,
 			}}
 		>

--- a/app/components/SnipPet/snipPet.module.css
+++ b/app/components/SnipPet/snipPet.module.css
@@ -2,7 +2,11 @@
 	position: fixed;
 	left: 0;
 	bottom: var(--pet-ground-offset, 10px);
-	z-index: 40;
+
+	/* Above every overlay in the app — modals and drawers (1000), menus (1100)
+	   and the toast strip (9999) — so the pet is never buried under the AI chat
+	   panel. It is a small sprite on the floor, so it covers nothing. */
+	z-index: 10000;
 	display: block;
 	color: var(--bg-color-dark);
 	cursor: grab;
@@ -92,19 +96,12 @@
 }
 
 @media (prefers-reduced-motion: no-preference) {
-	.pet[data-mode="walking"] .motion,
-	.pet[data-mode="idle"] .motion,
-	.pet[data-mode="reviewing"] .motion,
-	.pet[data-mode="working"] .motion {
-		animation: pet-bob 0.34s steps(2, end) infinite;
-	}
-
 	.pet[data-mode="celebrating"] .motion {
 		animation: pet-hop 0.42s ease-out 0s 3;
 	}
 
 	.pet[data-mode="excited"] .motion {
-		animation: pet-hop-excited 0.28s ease-out infinite;
+		animation: pet-hop-excited 0.42s ease-out infinite;
 	}
 
 	.pet[data-mode="afraid"] .motion {
@@ -123,8 +120,47 @@
 		animation: pet-land 0.44s cubic-bezier(0.18, 0.7, 0.3, 1);
 	}
 
+	/*
+	 * The bob belongs to the hand-drawn pixel pet only: it has two leg frames
+	 * and no vertical motion of its own. Sprite sheets already animate a full
+	 * cycle, and a second bounce on a 340ms period that doesn't divide into the
+	 * sheet's 800ms run cycle is what made the sprite pets judder.
+	 */
+	.pet[data-sprite="false"][data-mode="walking"] .motion,
+	.pet[data-sprite="false"][data-mode="idle"] .motion,
+	.pet[data-sprite="false"][data-mode="reviewing"] .motion,
+	.pet[data-sprite="false"][data-mode="working"] .motion {
+		animation: pet-bob 0.5s steps(2, end) infinite;
+	}
+
+	/*
+	 * Sprite pets hold frame 0 of the idle row for seconds at a time between
+	 * blinks (see PetIdleHoldMinMs), which left them looking frozen rather than
+	 * standing. This is the breathing underneath that hold — slow and sub-pixel,
+	 * so it never competes with the blink itself.
+	 */
+	.pet[data-sprite="true"][data-mode="idle"] .motion {
+		animation: pet-breathe 2.8s ease-in-out infinite;
+	}
+
 	.bubble {
 		animation: pet-bubble-pop 0.18s ease-out;
+	}
+}
+
+/* Idle breathing. transform-origin is bottom center, so the pet swells upward
+ * off its feet instead of growing in both directions. */
+@keyframes pet-breathe {
+	0% {
+		transform: translateY(0) scaleY(1);
+	}
+
+	50% {
+		transform: translateY(-1px) scaleY(1.025);
+	}
+
+	100% {
+		transform: translateY(0) scaleY(1);
 	}
 }
 

--- a/app/components/ui/Input/Input.tsx
+++ b/app/components/ui/Input/Input.tsx
@@ -11,6 +11,7 @@ import {
 import styles from "./input.module.css";
 
 const Input = ({
+	autoComplete,
 	className = "",
 	cleanOnBlur = false,
 	fat = false,
@@ -18,6 +19,7 @@ const Input = ({
 	dark = true,
 	disabled = false,
 	disableMargin = false,
+	name,
 	type = "text",
 	placeholder = "",
 	required = false,
@@ -79,6 +81,10 @@ const Input = ({
 			<input
 				className={`${styles.input} ${ghost ? styles.inputGhost : dark ? styles.inputDark : styles.inputLight} ${className}`}
 				type={type}
+				// Both were accepted as props but never reached the DOM, so callers
+				// had no way to tell a browser not to autofill a field.
+				autoComplete={autoComplete}
+				name={name}
 				onBlur={handlerOnBlur}
 				value={updatedValue}
 				contentEditable

--- a/app/lib/constants/pets.constants.ts
+++ b/app/lib/constants/pets.constants.ts
@@ -120,8 +120,42 @@ export const PetWorkingDurationMs = 25000;
 export const PetIdleChatterMinMs = 30000;
 export const PetIdleChatterMaxMs = 300000;
 
-/* Sprite playback rate, in milliseconds per frame. */
-export const PetSpriteFrameIntervalMs = 110;
+/*
+ * Fallback sprite playback rate, in milliseconds per frame, for any row without
+ * an entry in PetSpriteRowFrameIntervalsMs.
+ */
+export const PetSpriteFrameIntervalMs = 200;
+
+/*
+ * Milliseconds per frame, indexed by PetSpriteRow — same layout as
+ * PetDefaultRowFrames.
+ *
+ * Only the run rows are tied to PetWalkSpeedPxPerSecond: the feet have to keep
+ * up with the ground, so those two and the walk speed get retuned together.
+ * Every other row is a loop in place, and playing those at run pace is what
+ * made the pets twitch — an idle blink especially has to hold still between
+ * frames or it reads as a stutter rather than a blink.
+ */
+export const PetSpriteRowFrameIntervalsMs = [
+	110, // Idle — the blink itself is quick; see PetIdleHoldMinMs for the pause
+	100, // RunRight — paired with PetWalkSpeedPxPerSecond
+	100, // RunLeft — unused, mirrored from RunRight (see spriteRowForMode)
+	190, // Wave
+	170, // Jump
+	180, // Failure
+	280, // Waiting — held pose, barely moves
+	220, // ActiveWork
+	240, // Review
+] as const;
+
+/*
+ * The idle row is a single blink, not a loop of blinking. Frame 0 is the pet
+ * with its eyes open, so it is held for this long — re-rolled each time, or
+ * every pet on screen blinks in unison — and only then does the blink play out
+ * at the row's normal interval.
+ */
+export const PetIdleHoldMinMs = 2600;
+export const PetIdleHoldMaxMs = 6500;
 
 /*
  * Pointer exits through the top edge of the viewport (clientY <= this) read as

--- a/app/lib/constants/snipPet.ts
+++ b/app/lib/constants/snipPet.ts
@@ -8,14 +8,48 @@ export const PetGridHeight = 12;
 /* Rendered size of a single sprite pixel, in CSS pixels. */
 export const PetPixelSizePx = 5;
 
-/* Motion tuning. */
-export const PetWalkSpeedPxPerSecond = 44;
-export const PetLegFrameIntervalMs = 160;
+/*
+ * Motion tuning.
+ *
+ * Walk speed is paired with the sprite run cycle: the run row is 8 frames at
+ * PetSpriteFrameIntervalMs (800ms), so at this speed the pet covers ~62px per
+ * cycle — roughly a stride per step instead of skating along the floor. Retune
+ * the two together, or the feet start sliding again.
+ *
+ * ponytail: eyeballed against the shipped sheets, not measured per design.
+ */
+export const PetWalkSpeedPxPerSecond = 78;
+export const PetLegFrameIntervalMs = 120;
 export const PetEdgePaddingPx = 18;
 export const PetGroundOffsetPx = 10;
-export const PetIdlePauseMs = 1600;
-export const PetMinWalkBeforeIdleMs = 2600;
-export const PetMaxWalkBeforeIdleMs = 6000;
+
+/*
+ * The pet stands still while the app is being used. It only wanders off once
+ * the page has gone this long without a pointer, key, wheel or scroll event —
+ * re-rolled every time so it doesn't set off like a metronome — and it stops
+ * again the moment the user touches anything.
+ */
+export const PetMinIdleBeforeWalkMs = 10000;
+export const PetMaxIdleBeforeWalkMs = 30000;
+
+/*
+ * The one walk that isn't triggered by boredom: on arrival the pet strolls in
+ * from its corner so the user actually notices it, then settles and falls into
+ * the normal stand-still-until-idle cycle. Any interaction cuts it short.
+ */
+export const PetIntroWalkMs = 5000;
+
+/*
+ * What counts as "the app is being used". Listened for on document in the
+ * capture phase, because scroll doesn't bubble.
+ */
+export const PetActivityEvents = [
+	"keydown",
+	"pointerdown",
+	"pointermove",
+	"scroll",
+	"wheel",
+] as const;
 
 /* How long a click reaction (celebrating / excited) plays before walking again. */
 export const PetReactionDurationMs = 1400;

--- a/app/utils/pet.utils.ts
+++ b/app/utils/pet.utils.ts
@@ -2,7 +2,9 @@
 import {
 	DefaultPetDesignId,
 	PetDesigns,
+	PetSpriteFrameIntervalMs,
 	PetSpriteRow,
+	PetSpriteRowFrameIntervalsMs,
 } from "@/lib/constants/pets.constants";
 import { PetModes } from "@/lib/constants/snipPet";
 
@@ -79,3 +81,6 @@ export const spriteFrameCountForRow = (
 	design: PetDesign,
 	row: PetSpriteRow
 ): number => design.rowFrames[row] ?? 1;
+
+export const spriteFrameIntervalForRow = (row: PetSpriteRow): number =>
+	PetSpriteRowFrameIntervalsMs[row] ?? PetSpriteFrameIntervalMs;


### PR DESCRIPTION
#### Github Issue

relates to https://github.com/vianch/snippets/issues/135

#### Why are you creating this PR? What value is added?

- Pet now idles during user activity, walks only when idle 10-30s
- Per-row sprite frame intervals replace global interval
- Idle breathing animation for sprite pets
- Arrival walk intro on mount
- Input: pass autoComplete and name props to DOM
- AccountModal: fix stale store after password error, prevent duplicate saves
- Remove pointer enter/leave idle toggle (redundant with activity listener)

#### Include screenshots below (if appropriate)